### PR TITLE
feat(codegen): implement documentation support

### DIFF
--- a/smithy-kotlin/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/EnumGenerator.kt
+++ b/smithy-kotlin/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/EnumGenerator.kt
@@ -60,7 +60,7 @@ class EnumGenerator(val shape: StringShape, val symbol: Symbol, val writer: Kotl
     }
 
     fun render() {
-        // TODO - write docs for shape
+        writer.renderDocumentation(shape)
         // NOTE: The smithy spec only allows string shapes to apply to a string shape at the moment
         writer.withBlock("enum class ${symbol.name}(val value: String) {", "}") {
             enumTrait
@@ -87,7 +87,7 @@ class EnumGenerator(val shape: StringShape, val symbol: Symbol, val writer: Kotl
     }
 
     fun generateEnumConstant(definition: EnumDefinition) {
-        // TODO - write constant documentation (body.documentation)
+        writer.renderEnumDefinitionDocumentation(definition)
         val constName = definition.name.orElseGet {
                 CaseUtils.toSnakeCase(definition.value).replace(".", "_")
             }.toUpperCase()

--- a/smithy-kotlin/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/StructureGenerator.kt
+++ b/smithy-kotlin/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/StructureGenerator.kt
@@ -59,7 +59,7 @@ class StructureGenerator(
         // push context to be used throughout generation of the class
         writer.putContext("class.name", symbol.name)
 
-        // TODO write shape docs
+        writer.renderDocumentation(shape)
         // constructor
         writer.openBlock("class \$class.name:L private constructor(builder: BuilderImpl) {")
             .call { renderImmutableProperties() }
@@ -82,7 +82,7 @@ class StructureGenerator(
         // generate the immutable properties that are set from a builder
         sortedMembers.forEach {
             val (memberName, memberSymbol) = byMemberShape[it]!!
-            // TODO write member docs
+            writer.renderMemberDocumentation(model, it)
 
             // handle enums
             val targetShape = model.getShape(it.target).get()

--- a/smithy-kotlin/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/UnionGenerator.kt
+++ b/smithy-kotlin/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/UnionGenerator.kt
@@ -37,8 +37,10 @@ class UnionGenerator(
      */
     private fun renderUnion() {
         val symbol = symbolProvider.toSymbol(shape)
+        writer.renderDocumentation(shape)
         writer.openBlock("sealed class \$L {", symbol.name)
         shape.allMembers.values.forEach {
+            writer.renderMemberDocumentation(model, it)
             val memberName = symbolProvider.toMemberName(it)
             writer.write("data class \$L(val \$L: \$L) : \$L()", memberName.capitalize(), memberName, symbolProvider.toSymbol(it).name, symbol.name)
         }

--- a/smithy-kotlin/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/EnumGeneratorTest.kt
+++ b/smithy-kotlin/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/EnumGeneratorTest.kt
@@ -18,6 +18,7 @@ import io.kotest.matchers.string.shouldContain
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.model.traits.DocumentationTrait
 import software.amazon.smithy.model.traits.EnumDefinition
 import software.amazon.smithy.model.traits.EnumTrait
 
@@ -27,12 +28,13 @@ class EnumGeneratorTest {
     fun `generates unnamed enums`() {
         val trait = EnumTrait.builder()
             .addEnum(EnumDefinition.builder().value("FOO").build())
-            .addEnum(EnumDefinition.builder().value("BAR").build())
+            .addEnum(EnumDefinition.builder().value("BAR").documentation("Documentation for bar").build())
             .build()
 
         val shape = StringShape.builder()
             .id("com.test#Baz")
             .addTrait(trait)
+            .addTrait(DocumentationTrait("Documentation for this enum"))
             .build()
 
         val model = Model.assembler()
@@ -47,7 +49,13 @@ class EnumGeneratorTest {
         val contents = writer.toString()
 
         val expectedEnumDecl = """
+/**
+ * Documentation for this enum
+ */
 enum class Baz(val value: String) {
+    /**
+     * Documentation for bar
+     */
     BAR("BAR"),
     FOO("FOO"),
     SDK_UNKNOWN("SDK_UNKNOWN");
@@ -70,12 +78,17 @@ enum class Baz(val value: String) {
     fun `generates named enums`() {
         val trait = EnumTrait.builder()
             .addEnum(EnumDefinition.builder().value("t2.nano").name("T2_NANO").build())
-            .addEnum(EnumDefinition.builder().value("t2.micro").name("T2_MICRO").build())
+            .addEnum(EnumDefinition.builder().value("t2.micro").name("T2_MICRO").documentation("\"\"\"\n" +
+                    "T2 instances are Burstable Performance\n" +
+                    "Instances that provide a baseline level of CPU\n" +
+                    "performance with the ability to burst above the\n" +
+                    "baseline.\"\"\"").build())
             .build()
 
         val shape = StringShape.builder()
             .id("com.test#Baz")
             .addTrait(trait)
+            .addTrait(DocumentationTrait("Documentation for this enum"))
             .build()
 
         val model = Model.assembler()
@@ -90,7 +103,17 @@ enum class Baz(val value: String) {
         val contents = writer.toString()
 
         val expectedEnumDecl = """
+/**
+ * Documentation for this enum
+ */
 enum class Baz(val value: String) {
+    /**
+     * ${"\"\"\""}
+     * T2 instances are Burstable Performance
+     * Instances that provide a baseline level of CPU
+     * performance with the ability to burst above the
+     * baseline.${"\"\"\""}
+     */
     T2_MICRO("t2.micro"),
     T2_NANO("t2.nano"),
     SDK_UNKNOWN("SDK_UNKNOWN");

--- a/smithy-kotlin/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/KotlinWriterTest.kt
+++ b/smithy-kotlin/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/KotlinWriterTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.kotlin.codegen
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class KotlinWriterTest {
+
+    @Test fun `writes doc strings`() {
+        val writer = KotlinWriter("com.test")
+        writer.dokka("These are the docs.\nMore.")
+        val result = writer.toString()
+        Assertions.assertTrue(result.contains("/**\n * These are the docs.\n * More.\n */\n"))
+    }
+
+    @Test fun `escapes $ in doc strings`() {
+        val writer = KotlinWriter("com.test")
+        val docs = "This is $ valid documentation."
+        writer.dokka(docs)
+        val result = writer.toString()
+        Assertions.assertTrue(result.contains("/**\n * " + docs + "\n */\n"))
+    }
+}

--- a/smithy-kotlin/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/UnionGeneratorTest.kt
+++ b/smithy-kotlin/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/UnionGeneratorTest.kt
@@ -22,11 +22,12 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.model.traits.DocumentationTrait
 
 class UnionGeneratorTest {
     @Test
     fun `it renders unions`() {
-        val member1 = MemberShape.builder().id("com.test#MyUnion\$foo").target("smithy.api#String").build()
+        val member1 = MemberShape.builder().id("com.test#MyUnion\$foo").target("smithy.api#String").addTrait(DocumentationTrait("Documentation for foo")).build()
         val member2 = MemberShape.builder().id("com.test#MyUnion\$bar").target("smithy.api#PrimitiveInteger").build()
         val member3 = MemberShape.builder().id("com.test#MyUnion\$baz").target("smithy.api#Integer").build()
         val member4 = MemberShape.builder().id("com.test#MyStruct\$qux").target("smithy.api#String").build()
@@ -41,6 +42,7 @@ class UnionGeneratorTest {
                 .addMember(member2)
                 .addMember(member3)
                 .addMember(struct.defaultName(), struct.id)
+                .addTrait(DocumentationTrait("Documentation for MyUnion"))
                 .build()
         val model = Model.assembler()
                 .addShapes(union, struct, member1, member2, member3, member4)
@@ -56,10 +58,16 @@ class UnionGeneratorTest {
         assertTrue(contents.contains("package com.test"))
 
         val expectedClassDecl = """
+/**
+ * Documentation for MyUnion
+ */
 sealed class MyUnion {
     data class MyStruct(val myStruct: MyStruct) : MyUnion()
     data class Bar(val bar: Integer) : MyUnion()
     data class Baz(val baz: Integer) : MyUnion()
+    /**
+     * Documentation for foo
+     */
     data class Foo(val foo: String) : MyUnion()
 }
 """


### PR DESCRIPTION
Shapes and members in Smithy may have a documentation trait that uses
the CommonMark format. In this commit we generate the docs associated
with each shape.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
