### PR TITLE
refactor copy implementation and add missing method

### DIFF
--- a/smithy-kotlin/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/StructureGenerator.kt
+++ b/smithy-kotlin/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/StructureGenerator.kt
@@ -103,6 +103,8 @@ class StructureGenerator(
             write("@JvmStatic")
             write("fun builder(): Builder = BuilderImpl()")
             write("")
+            write("fun dslBuilder(): DslBuilder = BuilderImpl()")
+            write("")
             write("operator fun invoke(block: DslBuilder.() -> Unit): \$class.name:L = BuilderImpl().apply(block).build()")
             write("")
         }

--- a/smithy-kotlin/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/StructureGeneratorTest.kt
+++ b/smithy-kotlin/smithy-kotlin-codegen/src/test/kotlin/software/amazon/smithy/kotlin/codegen/StructureGeneratorTest.kt
@@ -126,6 +126,8 @@ class MyStruct private constructor(builder: BuilderImpl) {
         @JvmStatic
         fun builder(): Builder = BuilderImpl()
 
+        fun dslBuilder(): DslBuilder = BuilderImpl()
+
         operator fun invoke(block: DslBuilder.() -> Unit): MyStruct = BuilderImpl().apply(block).build()
 
     }


### PR DESCRIPTION
Original `copy()` design was supposed to go through a builder but the design doc was never updated and I implemented it off the design doc. I've since updated the doc to reflect the way copy should work which goes through a builder and back out the other side. This ensures things like enums are copied using their raw value correctly as well as avoiding the issues with positional arguments.

Also added a missing method on the companion object to get an instance of a `DslBuilder`. I don't care what this method or the Java builder is called, we could favor `builder()` to return a `DslBuilder` or whatever makes sense but we need a way to create one for deserialization implementations to use. 
