### PR TITLE
Change visibility of members of KtorUtils to resolve compiler errors …

### DIFF
--- a/smithy-kotlin/client-runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/software/aws/clientrt/http/engine/ktor/KtorUtils.kt
+++ b/smithy-kotlin/client-runtime/protocol/http-client-engines/http-client-engine-ktor/jvm/src/software/aws/clientrt/http/engine/ktor/KtorUtils.kt
@@ -28,7 +28,7 @@ import software.aws.clientrt.http.response.HttpResponse as SdkHttpResponse
 import software.aws.clientrt.io.Source
 
 // convert everything **except** the body from an Sdk HttpRequestBuilder to equivalent Ktor abstraction
-internal fun HttpRequestBuilder.toKtorRequestBuilder(): KtorHttpRequestBuilder {
+fun HttpRequestBuilder.toKtorRequestBuilder(): KtorHttpRequestBuilder {
     val builder = KtorHttpRequestBuilder()
     builder.method = HttpMethod.parse(this.method.name)
     val sdkUrl = this.url
@@ -60,7 +60,7 @@ internal fun HttpRequestBuilder.toKtorRequestBuilder(): KtorHttpRequestBuilder {
 }
 
 // wrapper around ktor headers that implements expected SDK interface for Headers
-internal class KtorHeaders(private val headers: Headers) : software.aws.clientrt.http.Headers {
+class KtorHeaders(private val headers: Headers) : software.aws.clientrt.http.Headers {
     override val caseInsensitiveName: Boolean = true
     override fun getAll(name: String): List<String>? = headers.getAll(name)
     override fun names(): Set<String> = headers.names()
@@ -70,7 +70,7 @@ internal class KtorHeaders(private val headers: Headers) : software.aws.clientrt
 }
 
 // wrapper around ByteReadChannel that implements the [Source] interface
-internal class KtorContentStream(private val channel: ByteReadChannel, private val onClose: (() -> Unit)? = null) : Source {
+class KtorContentStream(private val channel: ByteReadChannel, private val onClose: (() -> Unit)? = null) : Source {
     override val availableForRead: Int
         get() = channel.availableForRead
 


### PR DESCRIPTION
…in KtorUtilsTest.kt

I found compiler errors after pulling latest.  I followed the IDE suggestions to change the accessibility modifiers from internal to public to resolve the errors.  Not sure why only I would be getting this, perhaps it's a local issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
