### PR TITLE
feat(exception-generation): implement exception generation

### DIFF
--- a/smithy-kotlin/client-runtime/client-rt-core/common/src/software/aws/clientrt/Exceptions.kt
+++ b/smithy-kotlin/client-runtime/client-rt-core/common/src/software/aws/clientrt/Exceptions.kt
@@ -26,6 +26,8 @@ open class SdkBaseException : RuntimeException {
     constructor(message: String?, cause: Throwable?) : super(message, cause)
 
     constructor(cause: Throwable?) : super(cause)
+
+    open val isRetryable: Boolean = false
 }
 
 /**
@@ -39,8 +41,6 @@ open class ClientException : SdkBaseException {
     constructor(message: String?, cause: Throwable?) : super(message, cause)
 
     constructor(cause: Throwable?) : super(cause)
-
-    open val isRetryable: Boolean = true
 }
 
 /**
@@ -54,7 +54,7 @@ interface ProtocolResponse
  * type indicates that the caller's request was successfully transmitted to the service and the service sent back an
  * error response.
  */
-open class ServiceException : ClientException {
+open class ServiceException : SdkBaseException {
 
     /**
      * Indicates who (if known) is at fault for this exception.
@@ -81,8 +81,7 @@ open class ServiceException : ClientException {
     /**
      * Indicates who is responsible for this exception (caller, service, or unknown)
      */
-    open val errorType: ErrorType =
-        ErrorType.Unknown
+    open val errorType: ErrorType = ErrorType.Unknown
 
     /**
      * The human-readable error message provided by the service

--- a/smithy-kotlin/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/SymbolVisitor.kt
+++ b/smithy-kotlin/smithy-kotlin-codegen/src/main/kotlin/software/amazon/smithy/kotlin/codegen/SymbolVisitor.kt
@@ -20,6 +20,7 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.*
 import software.amazon.smithy.model.traits.BoxTrait
 import software.amazon.smithy.model.traits.EnumTrait
+import software.amazon.smithy.model.traits.ErrorTrait
 import software.amazon.smithy.model.traits.StreamingTrait
 import software.amazon.smithy.utils.StringUtils
 
@@ -204,6 +205,16 @@ class SymbolVisitor(private val model: Model, private val rootNamespace: String 
                 .options(SymbolReference.ContextOption.DECLARE)
                 .build()
             builder.addReference(ref)
+        }
+
+        val dependency = KotlinDependency.CLIENT_RT_CORE
+        if (shape.hasTrait(ErrorTrait::class.java)) {
+            val exceptionSymbol = Symbol.builder()
+                    .name("ServiceException")
+                    .namespace("${dependency.namespace}", ".")
+                    .addDependency(dependency)
+                    .build()
+            builder.addReference(exceptionSymbol)
         }
 
         return builder.build()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We are now starting to generate exceptions for structures in a smithy model that have the error trait. Most of the existing structure generation code is reused. The exceptions go through the builders as well so that we can have a uniform generation model, and deserializers for structures and exceptions will work through the builders in a very similar fashion to each other. 

There are a couple of nuances that need to be ironed out, like handling cause if it exists as a property in the smithy model (conflicts with Throwable's cause). Message string is handled via a validation.

Given the error:
```
"example.weather#NoSuchResource": {
            "type": "structure",
            "members": {
                "message": {
                    "target": "smithy.api#String"
                },
                "resourceType": {
                    "target": "smithy.api#String",
                    "traits": {
                        "smithy.api#documentation": "The type of resource that was not found.",
                        "smithy.api#required": {}
                    }
                }
            },
            "traits": {
                "smithy.api#documentation": "Error encountered when no resource could be found.",
                "smithy.api#error": "client",
                "smithy.api#httpError": 404
            }
        }
```

We now generate:
```
// Code generated by smithy-kotlin-codegen. DO NOT EDIT!

package weather.model

import software.aws.clientrt.ServiceException

/**
 * Error encountered when no resource could be found.
 */
class NoSuchResource private constructor(builder: BuilderImpl) : ServiceException() {
    override val message: String = builder.message!!
    /**
     * The type of resource that was not found.
     */
    val resourceType: String? = builder.resourceType

    companion object {
        @JvmStatic
        fun builder(): Builder = BuilderImpl()

        fun dslBuilder(): DslBuilder = BuilderImpl()

        operator fun invoke(block: DslBuilder.() -> Unit): NoSuchResource = BuilderImpl().apply(block).build()

    }

    fun copy(block: DslBuilder.() -> Unit = {}): NoSuchResource = BuilderImpl(this).apply(block).build()

    interface Builder {
        fun build(): NoSuchResource
        fun message(message: String): Builder
        fun resourceType(resourceType: String): Builder
    }

    interface DslBuilder {
        var message: String?
        var resourceType: String?
    }

    private class BuilderImpl() : Builder, DslBuilder {
        override var message: String? = null
        override var resourceType: String? = null

        constructor(x: NoSuchResource) : this() {
            this.message = x.message
            this.resourceType = x.resourceType
        }

        override fun build(): NoSuchResource = NoSuchResource(this)
        override fun message(message: String): Builder = apply { this.message = message }
        override fun resourceType(resourceType: String): Builder = apply { this.resourceType = resourceType }
    }

        override val errorType = ErrorType.Client
    }

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
