### PR TITLE
fix: base64 encoded header and dateEncodingStrategy for Encoder

### DIFF
--- a/smithy-swift/ClientRuntime/ClientRuntime/PrimitiveTypeExtensions/String+Extensions.swift
+++ b/smithy-swift/ClientRuntime/ClientRuntime/PrimitiveTypeExtensions/String+Extensions.swift
@@ -52,11 +52,12 @@ extension StringProtocol {
     }
 }
 
+/// Encode the String using Base64 Encoding
 extension StringProtocol {
     public func base64EncodedString() throws -> String {
         let utf8Encoded = self.data(using: .utf8)
         guard let base64String = utf8Encoded?.base64EncodedString() else {
-            throw ClientError.serializationFailed("Failed to base64 encode a String")
+            throw ClientError.serializationFailed("Failed to base64 encode a string")
         }
         return base64String
     }
@@ -74,5 +75,16 @@ extension StringProtocol {
     public func removePrefix(_ prefix: String) -> String {
         guard self.hasPrefix(prefix) else { return String(self) }
         return String(self.dropFirst(prefix.count))
+    }
+}
+
+/// Decode the Base64 Encoded String
+extension StringProtocol {
+    public func base64DecodedString() throws -> String {
+        guard let base64EncodedData = Data(base64Encoded: String(self)),
+            let decodedString = String(data: base64EncodedData, encoding: .utf8) else {
+            throw ClientError.serializationFailed("Failed to decode a base64 encoded string")
+        }
+        return decodedString
     }
 }

--- a/smithy-swift/ClientRuntime/ClientRuntimeTests/PrimitiveTypeExtensionsTests/StringExtensionsTests.swift
+++ b/smithy-swift/ClientRuntime/ClientRuntimeTests/PrimitiveTypeExtensionsTests/StringExtensionsTests.swift
@@ -75,4 +75,13 @@ class StringExtensionsTests: XCTestCase {
         let stringWithoutPrefix = "ABC"
         XCTAssertEqual(stringWithoutPrefix.removePrefix("X-Foo-"), "ABC")
     }
+    
+    func testDecodingBase64EncodedString() {
+        let base64EncodedString = "dHJ1ZQ=="
+        guard let decodedString = try? base64EncodedString.base64DecodedString() else {
+            XCTFail("Failed to decode a valid base64 encoded string")
+            return
+        }
+        XCTAssertEqual(decodedString, "true")
+    }
 }

--- a/smithy-swift/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpBindingProtocolGenerator.kt
+++ b/smithy-swift/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpBindingProtocolGenerator.kt
@@ -248,7 +248,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
                             memberValue = "${enumSymbol.name}(rawValue: $headerDeclaration)"
                         }
                         memberTarget.hasTrait(MediaTypeTrait::class.java) -> {
-                            memberValue = "try $headerDeclaration.base64EncodedString()"
+                            memberValue = "try $headerDeclaration.base64DecodedString()"
                         }
                         else -> {
                             memberValue = headerDeclaration

--- a/smithy-swift/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
+++ b/smithy-swift/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
@@ -88,9 +88,10 @@ open class HttpProtocolUnitTestRequestGenerator protected constructor(builder: B
                 }
                 .write("")
             writer.openBlock("do {", "} catch let err {") {
-
+                writer.write("let encoder = \$L", requestEncoder)
+                writer.write("encoder.dateEncodingStrategy = .secondsSince1970")
                 writer.write(
-                    "let actual = try input.buildHttpRequest(method: .${test.method.toLowerCase()}, path: \$S, encoder: $requestEncoder)",
+                    "let actual = try input.buildHttpRequest(method: .${test.method.toLowerCase()}, path: \$S, encoder: encoder)",
                     test.uri
                 )
 

--- a/smithy-swift/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/HttpProtocolUnitTestRequestGeneratorTests.kt
+++ b/smithy-swift/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/HttpProtocolUnitTestRequestGeneratorTests.kt
@@ -93,7 +93,9 @@ class HttpProtocolUnitTestRequestGeneratorTests : TestsBase() {
             query1: "Query 1"
         )
         do {
-            let actual = try input.buildHttpRequest(method: .post, path: "/smoketest/{label1}/foo", encoder: JSONEncoder())
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .secondsSince1970
+            let actual = try input.buildHttpRequest(method: .post, path: "/smoketest/{label1}/foo", encoder: encoder)
             let requiredHeaders = ["Content-Length"]
             // assert required headers do exist
             for requiredHeader in requiredHeaders {
@@ -139,7 +141,9 @@ class HttpProtocolUnitTestRequestGeneratorTests : TestsBase() {
             payload1: "explicit string"
         )
         do {
-            let actual = try input.buildHttpRequest(method: .post, path: "/explicit/string", encoder: JSONEncoder())
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .secondsSince1970
+            let actual = try input.buildHttpRequest(method: .post, path: "/explicit/string", encoder: encoder)
             let requiredHeaders = ["Content-Length"]
             // assert required headers do exist
             for requiredHeader in requiredHeaders {
@@ -180,7 +184,9 @@ class HttpProtocolUnitTestRequestGeneratorTests : TestsBase() {
         let input = EmptyInputAndEmptyOutputInput(
         )
         do {
-            let actual = try input.buildHttpRequest(method: .post, path: "/EmptyInputAndEmptyOutput", encoder: JSONEncoder())
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .secondsSince1970
+            let actual = try input.buildHttpRequest(method: .post, path: "/EmptyInputAndEmptyOutput", encoder: encoder)
             assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNil(actualHttpBody, "The actual HttpBody is not nil as expected")
                 XCTAssertNil(expectedHttpBody, "The expected HttpBody is not nil as expected")
@@ -215,7 +221,9 @@ class HttpProtocolUnitTestRequestGeneratorTests : TestsBase() {
             stringValue: nil
         )
         do {
-            let actual = try input.buildHttpRequest(method: .put, path: "/SimpleScalarProperties", encoder: JSONEncoder())
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .secondsSince1970
+            let actual = try input.buildHttpRequest(method: .put, path: "/SimpleScalarProperties", encoder: encoder)
             assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNil(actualHttpBody, "The actual HttpBody is not nil as expected")
                 XCTAssertNil(expectedHttpBody, "The expected HttpBody is not nil as expected")
@@ -254,7 +262,9 @@ class HttpProtocolUnitTestRequestGeneratorTests : TestsBase() {
             foo: "Foo"
         )
         do {
-            let actual = try input.buildHttpRequest(method: .post, path: "/StreamingTraits", encoder: JSONEncoder())
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .secondsSince1970
+            let actual = try input.buildHttpRequest(method: .post, path: "/StreamingTraits", encoder: encoder)
             assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
                 XCTAssertNotNil(expectedHttpBody, "The expected HttpBody is nil")
@@ -291,7 +301,9 @@ class HttpProtocolUnitTestRequestGeneratorTests : TestsBase() {
 
         )
         do {
-            let actual = try input.buildHttpRequest(method: .get, path: "/HttpPrefixHeaders", encoder: JSONEncoder())
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .secondsSince1970
+            let actual = try input.buildHttpRequest(method: .get, path: "/HttpPrefixHeaders", encoder: encoder)
             assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNil(actualHttpBody, "The actual HttpBody is not nil as expected")
                 XCTAssertNil(expectedHttpBody, "The expected HttpBody is not nil as expected")
@@ -333,7 +345,9 @@ class HttpProtocolUnitTestRequestGeneratorTests : TestsBase() {
 
         )
         do {
-            let actual = try input.buildHttpRequest(method: .put, path: "/JsonUnions", encoder: JSONEncoder())
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .secondsSince1970
+            let actual = try input.buildHttpRequest(method: .put, path: "/JsonUnions", encoder: encoder)
             assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
                 XCTAssertNotNil(expectedHttpBody, "The expected HttpBody is nil")


### PR DESCRIPTION
*Description of changes:*
1. Fix Deserialization of Headers with `mediaType` trait
2. Fix Timestamp encoding by setting `dateEncodingStrategy` on `JSONEncoder`
3. Unit tests for above changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
