### PR TITLE
fix(codegen): write uri path as a literal

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolClientGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolClientGenerator.kt
@@ -184,7 +184,7 @@ class HttpProtocolClientGenerator(
         }
 
         val uri = resolvedURIComponents.joinToString(separator = "/", prefix = "/", postfix = "")
-        writer.write("let path = \"$uri\"")
+        writer.write("let path = \"\$L\"", uri)
     }
 
     private fun renderOperationInputSerializationBlock(opIndex: OperationIndex, op: OperationShape) {


### PR DESCRIPTION
*Description of changes:*

This small change to write the `uri` string as a literal fixes the issue with code-generating `greengrass.2017-06-07, iot-jobs-data-plane.2017-09-29 and lex-model-building-service.2017-04-19` models. These models had operations with `$` character in one of their `uri` components, causing `CodeWriter` to interpret as a formatted string. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
