### PR TITLE
fix: use tilde-prefix for ClientRuntime

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
@@ -11,9 +11,9 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer
 enum class SwiftDependency(val type: String, val namespace: String, val version: String, val url: String, var packageName: String) : SymbolDependencyContainer {
     // Note: "namespace" is sub module in the full library "packageName". We use the namespace to minimize the module import. But, the entire package is "packageName"
     BIG("", "ComplexModule", "0.0.5", "https://github.com/apple/swift-numerics", packageName = "swift-numerics"),
-    CLIENT_RUNTIME("", "ClientRuntime", "0.1.0", "../../../../../../ClientRuntime", "ClientRuntime"),
+    CLIENT_RUNTIME("", "ClientRuntime", "0.1.0", "~/Projects/Amplify/SwiftSDK/smithy-swift/ClientRuntime", "ClientRuntime"),
     XCTest("", "XCTest", "", "", ""),
-    SMITHY_TEST_UTIL("", "SmithyTestUtil", "0.1.0", "../../../../../../ClientRuntime", "ClientRuntime");
+    SMITHY_TEST_UTIL("", "SmithyTestUtil", "0.1.0", "~/Projects/Amplify/SwiftSDK/smithy-swift/ClientRuntime", "ClientRuntime");
 
     override fun getDependencies(): List<SymbolDependency> {
         val dependency = SymbolDependency.builder()

--- a/smithy-swift-codegen/src/test/kotlin/PackageManifestGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/PackageManifestGeneratorTests.kt
@@ -37,7 +37,7 @@ class PackageManifestGeneratorTests {
                 "            url: \"https://github.com/apple/swift-numerics\",\n" +
                 "            from: 0.0.5\n" +
                 "        ),\n" +
-                "        .package(path: \"../../../../../../ClientRuntime\"),\n" +
+                "        .package(path: \"~/Projects/Amplify/SwiftSDK/smithy-swift/ClientRuntime\"),\n" +
                 "    ]"
         )
     }


### PR DESCRIPTION
Ideally we shouldn't be using ~/, but this alleviates a pain-point when generating projects.
I think it would be better to define a single variable which defines where `/Users/wooj/Projects/Amplify/SwiftSDK` lives, and then "assume" `smithy-swift` and `aws-sdk-swift` are located under that directoy.

Maybe we can define a environment variable like.. `SWIFTSDK_HOME`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
