### PR TITLE
hack: path generation

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
@@ -11,9 +11,20 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer
 enum class SwiftDependency(val type: String, val namespace: String, val version: String, val url: String, var packageName: String) : SymbolDependencyContainer {
     // Note: "namespace" is sub module in the full library "packageName". We use the namespace to minimize the module import. But, the entire package is "packageName"
     BIG("", "ComplexModule", "0.0.5", "https://github.com/apple/swift-numerics", packageName = "swift-numerics"),
-    CLIENT_RUNTIME("", "ClientRuntime", "0.1.0", "../../../../../../ClientRuntime", "ClientRuntime"),
+    CLIENT_RUNTIME(
+        "",
+        "ClientRuntime",
+        "0.1.0",
+        myAbsolutePath("smithy-swift", "smithy-swift/ClientRuntime"),
+        "ClientRuntime"
+    ),
     XCTest("", "XCTest", "", "", ""),
-    SMITHY_TEST_UTIL("", "SmithyTestUtil", "0.1.0", "../../../../../../ClientRuntime", "ClientRuntime");
+    SMITHY_TEST_UTIL(
+        "",
+        "SmithyTestUtil",
+        "0.1.0",
+        myAbsolutePath("smithy-swift", "smithy-swift/ClientRuntime"),
+        "ClientRuntime");
 
     override fun getDependencies(): List<SymbolDependency> {
         val dependency = SymbolDependency.builder()
@@ -25,4 +36,21 @@ enum class SwiftDependency(val type: String, val namespace: String, val version:
             .build()
         return listOf(dependency)
     }
+}
+
+fun myAbsolutePath(searchString: String, relativePath: String): String {
+    /*
+    //This isn't a good solution because user.dir can change.. hmmm
+    val javaClassPath = System.getProperty("user.dir")
+    val matchingPaths = javaClassPath.split(":").filter { it.contains(searchString) }
+    if (matchingPaths.isNotEmpty()) {
+        val firstPath = matchingPaths.first()
+        val startIndex = firstPath.indexOf(searchString)
+        val rootPath = firstPath.substring(0, startIndex).trim().removeSuffix("/")
+        return "$rootPath/$relativePath"
+    }
+    return ""
+    */
+    val javaClassPath = System.getProperty("user.dir") + "/../$relativePath"
+    return javaClassPath
 }

--- a/smithy-swift-codegen/src/test/kotlin/PackageManifestGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/PackageManifestGeneratorTests.kt
@@ -36,10 +36,11 @@ class PackageManifestGeneratorTests {
                 "        .package(\n" +
                 "            url: \"https://github.com/apple/swift-numerics\",\n" +
                 "            from: 0.0.5\n" +
-                "        ),\n" +
-                "        .package(path: \"../../../../../../ClientRuntime\"),\n" +
-                "    ]"
+                "        ),\n"
         )
+        print(packageManifest)
+        //well, clearly this is wrong, but we need to figure out kotest w/ regular expressions.
+        packageManifest.shouldContain(".package(path: \"/Users/wooj/Projects/Amplify/SwiftSDK/smithy-swift/smithy-swift-codegen/../smithy-swift/ClientRuntime\")")
     }
 
     @Test


### PR DESCRIPTION
No need to review, this is a total hack.

Unfortunately, using java.class.path is not reliable because during jar generation, there's nothing we can use in that variable.
The only thing that seems "stable" is user.dir, but even that is a hack.

I'll continue to work on allowing something in gradle.properties so that when we run the generation process, we'll have a variable that is somewhat reliable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
