### PR TITLE
fix: stop generation of response binding for awsjson1.x

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/ErrorFromHttpResponseGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/ErrorFromHttpResponseGenerator.kt
@@ -5,3 +5,8 @@ import software.amazon.smithy.model.shapes.OperationShape
 interface ErrorFromHttpResponseGenerator {
     fun generateInitOperationFromHttpResponse(ctx: ProtocolGenerator.GenerationContext, op: OperationShape)
 }
+
+class EmptyErrorFromHttpResponseGenerator : ErrorFromHttpResponseGenerator {
+    override fun generateInitOperationFromHttpResponse(ctx: ProtocolGenerator.GenerationContext, op: OperationShape) {
+    }
+}


### PR DESCRIPTION
Corresponding:
https://github.com/awslabs/aws-sdk-swift/pull/40


@kneekey23  pointed this out in this pr here:
https://github.com/awslabs/aws-sdk-swift/pull/36

This stops generation of the extension of HttpResponseBinding for awsjson 1.1 protocols



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
