### PR TITLE
fix: automatically add copyright header to new files

### DIFF
--- a/ClientRuntime/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/ClientRuntime/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string>
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//</string>
+</dict>
+</plist>


### PR DESCRIPTION
Corresponding pr: https://github.com/awslabs/aws-sdk-swift/pull/43

This is the header that we are using for amplify, i think we should adopt it for our project in smithy-swift

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
