### PR TITLE
chore: refactor protocol client generator

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolClientGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolClientGenerator.kt
@@ -31,90 +31,23 @@ import software.amazon.smithy.swift.codegen.swiftFunctionParameterIndent
 open class HttpProtocolClientGenerator(
     ctx: ProtocolGenerator.GenerationContext,
     private val writer: SwiftWriter,
-    private val properties: List<ClientProperty>,
-    private val serviceConfig: ServiceConfig,
+    properties: List<ClientProperty>,
+    serviceConfig: ServiceConfig,
     private val httpBindingResolver: HttpBindingResolver,
     private val defaultContentType: String
 ) {
-    private val serviceName: String = ctx.settings.sdkId
     private val model: Model = ctx.model
     private val symbolProvider = ctx.symbolProvider
     private val serviceShape = ctx.service
+    private val clientGeneratorInitialization = HttpProtocolClientInitialization(ctx, writer, properties, serviceConfig)
 
     fun render() {
         val serviceSymbol = symbolProvider.toSymbol(serviceShape)
         writer.addImport(SwiftDependency.CLIENT_RUNTIME.namespace)
         writer.addFoundationImport()
-        renderClientInitialization(serviceSymbol)
+        clientGeneratorInitialization.renderClientInitialization(serviceSymbol)
         writer.write("")
         renderOperationsInExtension(serviceSymbol)
-    }
-
-    private fun renderClientInitialization(serviceSymbol: Symbol) {
-        writer.openBlock("public class ${serviceSymbol.name} {", "}") {
-            writer.write("let client: SdkHttpClient")
-            writer.write("let config: ${serviceConfig.typeName}")
-            writer.write("let serviceName = \"${serviceName}\"")
-            writer.write("let encoder: RequestEncoder")
-            writer.write("let decoder: ResponseDecoder")
-            properties.forEach { prop ->
-                prop.addImportsAndDependencies(writer)
-            }
-            writer.write("")
-            writer.openBlock("public init(config: ${serviceSymbol.name}Configuration) throws {", "}") {
-                writer.write("client = try SdkHttpClient(engine: config.httpClientEngine, config: config.httpClientConfiguration)")
-                properties.forEach { prop ->
-                    prop.renderInstantiation(writer)
-                    if (prop.needsConfigure) {
-                        prop.renderConfiguration(writer)
-                    }
-                    prop.renderInitialization(writer, "config")
-                }
-
-                writer.write("self.config = config")
-            }
-            writer.write("")
-            // FIXME: possible move generation of the config to a separate file or above the service client
-            renderConfig(serviceSymbol)
-        }
-    }
-
-    private fun renderConfig(serviceSymbol: Symbol) {
-
-        val configFields = serviceConfig.getConfigFields()
-        val inheritance = serviceConfig.getTypeInheritance()
-        writer.openBlock("public class ${serviceSymbol.name}Configuration: $inheritance {", "}") {
-            writer.write("")
-            configFields.forEach {
-                writer.write("public var ${it.name}: ${it.type}")
-            }
-            writer.write("")
-            renderConfigInit(configFields)
-            writer.write("")
-            serviceConfig.renderConvenienceInits(serviceSymbol)
-            writer.write("")
-            serviceConfig.renderStaticDefaultImplementation(serviceSymbol)
-        }
-    }
-
-    private fun renderConfigInit(configFields: List<ConfigField>) {
-        if (configFields.isNotEmpty()) {
-            val configFieldsSortedByName = configFields.sortedBy { it.name }
-            writer.openBlock("public init (", ")") {
-                for ((index, member) in configFieldsSortedByName.withIndex()) {
-                    val memberName = member.name
-                    val memberSymbol = member.type
-                    if (memberName == null) continue
-                    val terminator = if (index == configFieldsSortedByName.size - 1) "" else ","
-                    writer.write("\$L: \$L$terminator", memberName, memberSymbol)
-                }
-            }
-            writer.openBlock("{", "}") {
-                configFieldsSortedByName.forEach {
-                    writer.write("self.\$1L = \$1L", it.name)
-                }
-            }
-        }
     }
 
     private fun renderOperationsInExtension(serviceSymbol: Symbol) {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolClientInitialization.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolClientInitialization.kt
@@ -1,0 +1,80 @@
+package software.amazon.smithy.swift.codegen.integration
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.swift.codegen.SwiftWriter
+
+open class HttpProtocolClientInitialization(
+    ctx: ProtocolGenerator.GenerationContext,
+    private val writer: SwiftWriter,
+    private val properties: List<ClientProperty>,
+    private val serviceConfig: ServiceConfig
+) {
+    private val serviceName: String = ctx.settings.sdkId
+
+    fun renderClientInitialization(serviceSymbol: Symbol) {
+        writer.openBlock("public class ${serviceSymbol.name} {", "}") {
+            writer.write("let client: SdkHttpClient")
+            writer.write("let config: ${serviceConfig.typeName}")
+            writer.write("let serviceName = \"${serviceName}\"")
+            writer.write("let encoder: RequestEncoder")
+            writer.write("let decoder: ResponseDecoder")
+            properties.forEach { prop ->
+                prop.addImportsAndDependencies(writer)
+            }
+            writer.write("")
+            writer.openBlock("public init(config: ${serviceSymbol.name}Configuration) throws {", "}") {
+                writer.write("client = try SdkHttpClient(engine: config.httpClientEngine, config: config.httpClientConfiguration)")
+                properties.forEach { prop ->
+                    prop.renderInstantiation(writer)
+                    if (prop.needsConfigure) {
+                        prop.renderConfiguration(writer)
+                    }
+                    prop.renderInitialization(writer, "config")
+                }
+
+                writer.write("self.config = config")
+            }
+            writer.write("")
+            // FIXME: possible move generation of the config to a separate file or above the service client
+            renderConfig(serviceSymbol)
+        }
+    }
+
+    private fun renderConfig(serviceSymbol: Symbol) {
+
+        val configFields = serviceConfig.getConfigFields()
+        val inheritance = serviceConfig.getTypeInheritance()
+        writer.openBlock("public class ${serviceSymbol.name}Configuration: $inheritance {", "}") {
+            writer.write("")
+            configFields.forEach {
+                writer.write("public var ${it.name}: ${it.type}")
+            }
+            writer.write("")
+            renderConfigInit(configFields)
+            writer.write("")
+            serviceConfig.renderConvenienceInits(serviceSymbol)
+            writer.write("")
+            serviceConfig.renderStaticDefaultImplementation(serviceSymbol)
+        }
+    }
+
+    private fun renderConfigInit(configFields: List<ConfigField>) {
+        if (configFields.isNotEmpty()) {
+            val configFieldsSortedByName = configFields.sortedBy { it.name }
+            writer.openBlock("public init (", ")") {
+                for ((index, member) in configFieldsSortedByName.withIndex()) {
+                    val memberName = member.name
+                    val memberSymbol = member.type
+                    if (memberName == null) continue
+                    val terminator = if (index == configFieldsSortedByName.size - 1) "" else ","
+                    writer.write("\$L: \$L$terminator", memberName, memberSymbol)
+                }
+            }
+            writer.openBlock("{", "}") {
+                configFieldsSortedByName.forEach {
+                    writer.write("self.\$1L = \$1L", it.name)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
No corresponding pr.

This is a minor refactor which moves client initialization out of the client generator -- if individual protocols need customizations, we can build an interface around this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
