### PR TITLE
fix: generation of empty set

### DIFF
--- a/smithy-swift-codegen/src/test/kotlin/ShapeValueGeneratorTest.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ShapeValueGeneratorTest.kt
@@ -128,6 +128,32 @@ Set<String>(arrayLiteral:
     }
 
     @Test
+    fun `it renders empty sets`() {
+        val valueMember = MemberShape.builder().id("foo.bar#MySet\$member").target("smithy.api#String").build()
+        val set = SetShape.builder()
+            .id("foo.bar#MySet")
+            .member(valueMember)
+            .build()
+        val model = Model.assembler()
+            .addShapes(set, valueMember)
+            .assemble()
+            .unwrap()
+
+        val provider: SymbolProvider = SwiftCodegenPlugin.createSymbolProvider(model, "test", "MySet")
+        val setShape = model.expectShape(ShapeId.from("foo.bar#MySet"))
+        val writer = SwiftWriter("test")
+
+        val values: Array<Node> = emptyArray()
+        val params = Node.arrayNode(*values)
+
+        ShapeValueGenerator(model, provider).writeShapeValueInline(writer, setShape, params)
+        val contents = writer.toString()
+
+        val expected = "Set<String>()".trimIndent()
+        contents.shouldContainOnlyOnce(expected)
+    }
+
+    @Test
     fun `it renders structs`() {
         val member1 = MemberShape.builder().id("foo.bar#MyStruct\$stringMember").target("smithy.api#String").build()
         val member2 = MemberShape.builder().id("foo.bar#MyStruct\$boolMember").target("smithy.api#Boolean").build()


### PR DESCRIPTION
* no corresponding pr in aws swift sdk
* need to support empty sets for protocol codegen tests for rest xml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
