### PR TITLE
fix: make ci work across smithy-swift and aws-sdk-swift

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
@@ -20,9 +20,9 @@ enum class SwiftDependency(val type: String, val target: String, val branch: Str
         computeAbsolutePath(
             mapOf(
                 // For aws-sdk-swift CI
-                "target/build/deps/smithy-swift" to "target/build/deps/smithy-swift",
+                "aws-sdk-swift/target/build/deps/smithy-swift" to "aws-sdk-swift/target/build/deps/smithy-swift",
                 // For smithy-swift CI
-                "target/build/deps/aws-sdk-swift" to "",
+                "smithy-swift/target/build/deps/aws-sdk-swift" to "smithy-swift",
                 // For development
                 "smithy-swift/Packages" to "smithy-swift/Packages"
             )


### PR DESCRIPTION
Fixing ci to work across smithy-swift and aws-sdk-swift. Shoutout to @kneekey23 for laying the foundation in a previous pr

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
