### PR TITLE
chore: updating ci system to use environment variables instead of computed path

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,6 +15,8 @@ env:
   PACKAGE_NAME: smithy-swift
   LINUX_BASE_IMAGE: ubuntu-16-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
+  AWS_SDK_SWIFT_CI_DIR: /Users/runner/work/smithy-swift/smithy-swift/target/build/deps/aws-sdk-swift
+  SMITHY_SWIFT_CI_DIR: /Users/runner/work/smithy-swift/smithy-swift
 
 jobs:
   macos-compat:
@@ -40,7 +42,7 @@ jobs:
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
           chmod a+x builder.pyz
-          GIT_ASKPASS="$(pwd)/.github/scripts/git-ci-askpass.sh" BRANCH_NAME="${GITHUB_HEAD_REF}" ./builder.pyz build -p ${{ env.PACKAGE_NAME }}
+          GIT_ASKPASS="$(pwd)/.github/scripts/git-ci-askpass.sh" BRANCH_NAME="${GITHUB_HEAD_REF}" AWS_SDK_SWIFT_CI_DIR="${{ env.AWS_SDK_SWIFT_CI_DIR }}" SMITHY_SWIFT_CI_DIR="${{ env.SMITHY_SWIFT_CI_DIR }}" ./builder.pyz build -p ${{ env.PACKAGE_NAME }}
 
   downstream:
     needs: macos-compat
@@ -66,4 +68,4 @@ jobs:
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
           chmod a+x builder
-          GIT_ASKPASS="$(pwd)/.github/scripts/git-ci-askpass.sh" BRANCH_NAME="${GITHUB_HEAD_REF}" ./builder build -p ${{ env.PACKAGE_NAME }} --spec downstream
+          GIT_ASKPASS="$(pwd)/.github/scripts/git-ci-askpass.sh" BRANCH_NAME="${GITHUB_HEAD_REF}" AWS_SDK_SWIFT_CI_DIR="${{ env.AWS_SDK_SWIFT_CI_DIR }}" SMITHY_SWIFT_CI_DIR="${{ env.SMITHY_SWIFT_CI_DIR }}" ./builder build -p ${{ env.PACKAGE_NAME }} --spec downstream

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
@@ -17,16 +17,7 @@ enum class SwiftDependency(val type: String, val target: String, val branch: Str
         "ClientRuntime",
         null,
         "0.1.0",
-        computeAbsolutePath(
-            mapOf(
-                // For aws-sdk-swift CI
-                "aws-sdk-swift/target/build/deps/smithy-swift" to "aws-sdk-swift/target/build/deps/smithy-swift",
-                // For smithy-swift CI
-                "smithy-swift/target/build/deps/aws-sdk-swift" to "smithy-swift",
-                // For development
-                "smithy-swift/Packages" to "smithy-swift/Packages"
-            )
-        ),
+        computeAbsolutePath("smithy-swift/Packages"),
         "ClientRuntime"
     ),
     XCTest("", "XCTest", null, "", "", ""),
@@ -35,16 +26,7 @@ enum class SwiftDependency(val type: String, val target: String, val branch: Str
         "SmithyTestUtil",
         null,
         "0.1.0",
-        computeAbsolutePath(
-            mapOf(
-                // For aws-sdk-swift CI
-                "target/build/deps/smithy-swift" to "target/build/deps/smithy-swift",
-                // For smithy-swift CI
-                "target/build/deps/aws-sdk-swift" to "",
-                // For development
-                "smithy-swift/Packages" to "smithy-swift/Packages"
-            )
-        ),
+        computeAbsolutePath("smithy-swift/Packages"),
         "ClientRuntime"
     );
 
@@ -61,35 +43,19 @@ enum class SwiftDependency(val type: String, val target: String, val branch: Str
     }
 }
 
-private fun computeAbsolutePath(relativePaths: Map<String, String>): String {
-    for (relativePath in relativePaths.keys) {
-        var userDirPath = System.getProperty("user.dir")
-        while (userDirPath.isNotEmpty()) {
-            val fileNameForCheckDir = userDirPath.removeSuffix("/") + "/" + relativePath
-            val fileNameForAbsolutePath = userDirPath.removeSuffix("/") + "/" + relativePaths[relativePath]
-            if (File(fileNameForCheckDir).isDirectory) {
-                return fileNameForAbsolutePath
-            }
-            userDirPath = userDirPath.substring(0, userDirPath.length - 1)
+private fun computeAbsolutePath(relativePath: String): String {
+    val userDirPathOverride = System.getenv("SMITHY_SWIFT_CI_DIR")
+    if (!userDirPathOverride.isNullOrEmpty()) {
+        return userDirPathOverride
+    }
+
+    var userDirPath = System.getProperty("user.dir")
+    while (userDirPath.isNotEmpty()) {
+        val fileName = userDirPath.removeSuffix("/") + "/" + relativePath
+        if (File(fileName).isDirectory) {
+            return fileName
         }
+        userDirPath = userDirPath.substring(0, userDirPath.length - 1)
     }
     return ""
 }
-
-/*  To be used for CI at a later time
-private fun getGitBranchName(): String {
-    val process = Runtime.getRuntime().exec("git rev-parse --abbrev-ref HEAD")
-    val sb: StringBuilder = StringBuilder()
-    while (true) {
-        val char = process.inputStream.read()
-        if (char == -1) break
-        sb.append(char.toChar())
-    }
-    var branchName = sb.removeSuffix("\n").toString()
-    if (branchName == "HEAD") {
-        branchName = System.getenv("BRANCH_NAME")
-    }
-
-    return branchName
-}
-*/


### PR DESCRIPTION
Corresponding PR:
https://github.com/awslabs/aws-sdk-swift/pull/61

I think this is a way cleaner approach than what we previously had.  What do you think?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
