### PR TITLE
feat: restXML serde for nested lists

### DIFF
--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/StructDecodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/StructDecodeXMLGenerationTests.kt
@@ -21,16 +21,16 @@ class StructDecodeXMLGenerationTests {
             
                 public init (from decoder: Decoder) throws {
                     let containerValues = try decoder.container(keyedBy: CodingKeys.self)
-                    let myGroceryListContainer = try containerValues.nestedContainer(keyedBy: WrappedListMember.CodingKeys.self, forKey: .myGroceryList)
-                    let myGroceryListItemContainer = try myGroceryListContainer.decodeIfPresent([String].self, forKey: .member)
-                    var myGroceryListDecoded0:[String]? = nil
-                    if let myGroceryListItemContainer = myGroceryListItemContainer {
-                        myGroceryListDecoded0 = [String]()
-                        for string0 in myGroceryListItemContainer {
-                            myGroceryListDecoded0?.append(string0)
+                    let myGroceryListWrappedContainer = try containerValues.nestedContainer(keyedBy: WrappedListMember.CodingKeys.self, forKey: .myGroceryList)
+                    let myGroceryListContainer = try myGroceryListWrappedContainer.decodeIfPresent([String].self, forKey: .member)
+                    var myGroceryListBuffer:[String]? = nil
+                    if let myGroceryListContainer = myGroceryListContainer {
+                        myGroceryListBuffer = [String]()
+                        for stringContainer0 in myGroceryListContainer {
+                            myGroceryListBuffer?.append(stringContainer0)
                         }
                     }
-                    myGroceryList = myGroceryListDecoded0
+                    myGroceryList = myGroceryListBuffer
                 }
             }
         """.trimIndent()
@@ -51,15 +51,15 @@ class StructDecodeXMLGenerationTests {
 
                 public init (from decoder: Decoder) throws {
                     let containerValues = try decoder.container(keyedBy: CodingKeys.self)
-                    let myGroceryListItemContainer = try containerValues.decodeIfPresent([String].self, forKey: .myGroceryList)
-                    var myGroceryListDecoded0:[String]? = nil
-                    if let myGroceryListItemContainer = myGroceryListItemContainer {
-                        myGroceryListDecoded0 = [String]()
-                        for string0 in myGroceryListItemContainer {
-                            myGroceryListDecoded0?.append(string0)
+                    let myGroceryListContainer = try containerValues.decodeIfPresent([String].self, forKey: .myGroceryList)
+                    var myGroceryListBuffer:[String]? = nil
+                    if let myGroceryListContainer = myGroceryListContainer {
+                        myGroceryListBuffer = [String]()
+                        for stringContainer0 in myGroceryListContainer {
+                            myGroceryListBuffer?.append(stringContainer0)
                         }
                     }
-                    myGroceryList = myGroceryListDecoded0
+                    myGroceryList = myGroceryListBuffer
                 }
             }
         """.trimIndent()
@@ -113,6 +113,85 @@ class StructDecodeXMLGenerationTests {
         contents.shouldContainOnlyOnce(expectedContents)
     }
 
+    @Test
+    fun `nestednested wrapped list deserialization`() {
+        val context = setupTests("Isolated/Restxml/xml-nestednested-wrapped-list.smithy", "aws.protocoltests.restxml#RestXml")
+        val contents = getFileContents(context.manifest, "/example/models/XmlNestedNestedWrappedListOutputBody+Decodable.swift")
+        val expectedContents = """
+            extension XmlNestedNestedWrappedListOutputBody: Decodable {
+                private enum CodingKeys: String, CodingKey {
+                    case nestedNestedStringList
+                }
+            
+                public init (from decoder: Decoder) throws {
+                    let containerValues = try decoder.container(keyedBy: CodingKeys.self)
+                    let nestedNestedStringListWrappedContainer = try containerValues.nestedContainer(keyedBy: WrappedListMember.CodingKeys.self, forKey: .nestedNestedStringList)
+                    let nestedNestedStringListContainer = try nestedNestedStringListWrappedContainer.decodeIfPresent([[[String]?]?].self, forKey: .member)
+                    var nestedNestedStringListBuffer:[[[String]?]?]? = nil
+                    if let nestedNestedStringListContainer = nestedNestedStringListContainer {
+                        nestedNestedStringListBuffer = [[[String]?]?]()
+                        for listContainer0 in nestedNestedStringListContainer {
+                            var listBuffer0 = [[String]?]()
+                            if let listContainer0 = listContainer0 {
+                                for listContainer1 in listContainer0 {
+                                    var listBuffer1 = [String]()
+                                    if let listContainer1 = listContainer1 {
+                                        for stringContainer2 in listContainer1 {
+                                            listBuffer1.append(stringContainer2)
+                                        }
+                                    }
+                                    listBuffer0.append(listBuffer1)
+                                }
+                            }
+                            nestedNestedStringListBuffer?.append(listBuffer0)
+                        }
+                    }
+                    nestedNestedStringList = nestedNestedStringListBuffer
+                }
+            }
+        """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    @Test
+    fun `nestednested flattened list serialization`() {
+        val context = setupTests("Isolated/Restxml/xml-nestednested-Flattened-list.smithy", "aws.protocoltests.restxml#RestXml")
+        val contents = getFileContents(context.manifest, "/example/models/XmlNestedNestedFlattenedListOutputBody+Decodable.swift")
+        val expectedContents =
+            """
+            extension XmlNestedNestedFlattenedListOutputBody: Decodable {
+                private enum CodingKeys: String, CodingKey {
+                    case nestedNestedStringList
+                }
+            
+                public init (from decoder: Decoder) throws {
+                    let containerValues = try decoder.container(keyedBy: CodingKeys.self)
+                    let nestedNestedStringListContainer = try containerValues.decodeIfPresent([[[String]?]?].self, forKey: .nestedNestedStringList)
+                    var nestedNestedStringListBuffer:[[[String]?]?]? = nil
+                    if let nestedNestedStringListContainer = nestedNestedStringListContainer {
+                        nestedNestedStringListBuffer = [[[String]?]?]()
+                        for listContainer0 in nestedNestedStringListContainer {
+                            var listBuffer0 = [[String]?]()
+                            if let listContainer0 = listContainer0 {
+                                for listContainer1 in listContainer0 {
+                                    var listBuffer1 = [String]()
+                                    if let listContainer1 = listContainer1 {
+                                        for stringContainer2 in listContainer1 {
+                                            listBuffer1.append(stringContainer2)
+                                        }
+                                    }
+                                    listBuffer0.append(listBuffer1)
+                                }
+                            }
+                            nestedNestedStringListBuffer?.append(listBuffer0)
+                        }
+                    }
+                    nestedNestedStringList = nestedNestedStringListBuffer
+                }
+            }
+            """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
     private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {
         val context = TestContext.initContextFrom(smithyFile, serviceShapeId, MockHttpRestXMLProtocolGenerator()) { model ->
             model.defaultSettings(serviceShapeId, "RestXml", "2019-12-16", "Rest Xml Protocol")

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/StructEncodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/StructEncodeXMLGenerationTests.kt
@@ -23,8 +23,8 @@ class StructEncodeXMLGenerationTests {
                     var container = encoder.container(keyedBy: CodingKeys.self)
                     if let myGroceryList = myGroceryList {
                         var myGroceryListContainer = container.nestedContainer(keyedBy: WrappedListMember.CodingKeys.self, forKey: .myGroceryList)
-                        for grocerylist0 in myGroceryList {
-                            try myGroceryListContainer.encode(grocerylist0, forKey: .member)
+                        for string0 in myGroceryList {
+                            try myGroceryListContainer.encode(string0, forKey: .member)
                         }
                     }
                 }
@@ -49,8 +49,8 @@ class StructEncodeXMLGenerationTests {
                     var container = encoder.container(keyedBy: CodingKeys.self)
                     if let myGroceryList = myGroceryList {
                         var myGroceryListContainer = container.nestedUnkeyedContainer(forKey: .myGroceryList)
-                        for grocerylist0 in myGroceryList {
-                            try myGroceryListContainer.encode(grocerylist0)
+                        for string0 in myGroceryList {
+                            try myGroceryListContainer.encode(string0)
                         }
                     }
                 }
@@ -113,11 +113,115 @@ class StructEncodeXMLGenerationTests {
             """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }
+    @Test
+    fun `nested wrapped list serialization`() {
+        val context = setupTests("Isolated/Restxml/xml-nested-wrapped-list.smithy", "aws.protocoltests.restxml#RestXml")
+        val contents = getFileContents(context.manifest, "/example/models/XmlNestedWrappedListInput+Encodable.swift")
+        val expectedContents =
+            """
+            extension XmlNestedWrappedListInput: Encodable, Reflection {
+                private enum CodingKeys: String, CodingKey {
+                    case nestedStringList
+                }
+            
+                public func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    if let nestedStringList = nestedStringList {
+                        var nestedStringListContainer = container.nestedContainer(keyedBy: WrappedListMember.CodingKeys.self, forKey: .nestedStringList)
+                        for stringlist0 in nestedStringList {
+                            if let stringlist0 = stringlist0 {
+                                var stringlist0Container0 = nestedStringListContainer.nestedContainer(keyedBy: WrappedListMember.CodingKeys.self, forKey: .member)
+                                for string1 in stringlist0 {
+                                    try stringlist0Container0.encode(string1, forKey: .member)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    @Test
+    fun `nestednested wrapped list serialization`() {
+        val context = setupTests("Isolated/Restxml/xml-nestednested-wrapped-list.smithy", "aws.protocoltests.restxml#RestXml")
+        val contents = getFileContents(context.manifest, "/example/models/XmlNestedNestedWrappedListInput+Encodable.swift")
+        val expectedContents =
+            """
+            extension XmlNestedNestedWrappedListInput: Encodable, Reflection {
+                private enum CodingKeys: String, CodingKey {
+                    case nestedNestedStringList
+                }
+            
+                public func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    if let nestedNestedStringList = nestedNestedStringList {
+                        var nestedNestedStringListContainer = container.nestedContainer(keyedBy: WrappedListMember.CodingKeys.self, forKey: .nestedNestedStringList)
+                        for nestedstringlist0 in nestedNestedStringList {
+                            if let nestedstringlist0 = nestedstringlist0 {
+                                var nestedstringlist0Container0 = nestedNestedStringListContainer.nestedContainer(keyedBy: WrappedListMember.CodingKeys.self, forKey: .member)
+                                for stringlist1 in nestedstringlist0 {
+                                    if let stringlist1 = stringlist1 {
+                                        var stringlist1Container1 = nestedstringlist0Container0.nestedContainer(keyedBy: WrappedListMember.CodingKeys.self, forKey: .member)
+                                        for string2 in stringlist1 {
+                                            try stringlist1Container1.encode(string2, forKey: .member)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    @Test
+    fun `nestednested flattened list serialization`() {
+        val context = setupTests("Isolated/Restxml/xml-nestednested-Flattened-list.smithy", "aws.protocoltests.restxml#RestXml")
+        print(getFileContents(context.manifest, "/example/models/XmlNestedNestedFlattenedListInput.swift"))
+        val contents = getFileContents(context.manifest, "/example/models/XmlNestedNestedFlattenedListInput+Encodable.swift")
+        print(contents)
+        val expectedContents =
+            """
+            extension XmlNestedNestedFlattenedListInput: Encodable, Reflection {
+                private enum CodingKeys: String, CodingKey {
+                    case nestedNestedStringList
+                }
+            
+                public func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    if let nestedNestedStringList = nestedNestedStringList {
+                        var nestedNestedStringListContainer = container.nestedUnkeyedContainer(forKey: .nestedNestedStringList)
+                        for nestedstringlist0 in nestedNestedStringList {
+                            if let nestedstringlist0 = nestedstringlist0 {
+                                var nestedstringlist0ContainerForUnkeyed0 = nestedNestedStringListContainer.nestedContainer(keyedBy: WrappedListMember.CodingKeys.self)
+                                var nestedstringlist0Container0 = nestedstringlist0ContainerForUnkeyed0.nestedUnkeyedContainer(forKey: .member)
+                                for stringlist1 in nestedstringlist0 {
+                                    if let stringlist1 = stringlist1 {
+                                        var stringlist1ContainerForUnkeyed1 = nestedstringlist0Container0.nestedContainer(keyedBy: WrappedListMember.CodingKeys.self)
+                                        var stringlist1Container1 = stringlist1ContainerForUnkeyed1.nestedUnkeyedContainer(forKey: .member)
+                                        for string2 in stringlist1 {
+                                            try stringlist1Container1.encode(string2)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
 
     private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {
         val context = TestContext.initContextFrom(smithyFile, serviceShapeId, MockHttpRestXMLProtocolGenerator()) { model ->
             model.defaultSettings(serviceShapeId, "RestXml", "2019-12-16", "Rest Xml Protocol")
         }
+        context.generator.generateCodableConformanceForNestedTypes(context.generationCtx)
         context.generator.generateSerializers(context.generationCtx)
         context.generationCtx.delegator.flushWriters()
         return context

--- a/smithy-swift-codegen/src/test/resources/Isolated/Restxml/xml-nested-wrapped-list.smithy
+++ b/smithy-swift-codegen/src/test/resources/Isolated/Restxml/xml-nested-wrapped-list.smithy
@@ -1,0 +1,35 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restxml
+
+use aws.api#service
+use aws.protocols#restXml
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@service(sdkId: "Rest Xml List")
+@restXml
+service RestXml {
+    version: "2019-12-16",
+    operations: [
+        XmlNestedWrappedList
+    ]
+}
+
+@http(uri: "/XmlNestedWrappedList", method: "POST")
+operation XmlNestedWrappedList {
+    input: XmlNestedWrappedListInputOutput,
+    output: XmlNestedWrappedListInputOutput
+}
+
+structure XmlNestedWrappedListInputOutput {
+    nestedStringList: NestedStringList
+}
+
+ list NestedStringList {
+     member: StringList
+ }
+
+ list StringList {
+     member: String
+ }

--- a/smithy-swift-codegen/src/test/resources/Isolated/Restxml/xml-nestednested-flattened-list.smithy
+++ b/smithy-swift-codegen/src/test/resources/Isolated/Restxml/xml-nestednested-flattened-list.smithy
@@ -1,0 +1,40 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restxml
+
+use aws.api#service
+use aws.protocols#restXml
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@service(sdkId: "Rest Xml List")
+@restXml
+service RestXml {
+    version: "2019-12-16",
+    operations: [
+        XmlNestedNestedFlattenedList
+    ]
+}
+
+@http(uri: "/XmlNestedNestedFlattenedList", method: "POST")
+operation XmlNestedNestedFlattenedList {
+    input: XmlNestedNestedFlattenedListInputOutput,
+    output: XmlNestedNestedFlattenedListInputOutput
+}
+
+structure XmlNestedNestedFlattenedListInputOutput {
+    @xmlFlattened
+    nestedNestedStringList: NestedNestedStringList
+}
+
+list NestedNestedStringList {
+    member: NestedStringList
+}
+
+list NestedStringList {
+    member: StringList
+}
+
+list StringList {
+    member: String
+}

--- a/smithy-swift-codegen/src/test/resources/Isolated/Restxml/xml-nestednested-wrapped-list.smithy
+++ b/smithy-swift-codegen/src/test/resources/Isolated/Restxml/xml-nestednested-wrapped-list.smithy
@@ -1,0 +1,39 @@
+$version: "1.0"
+
+namespace aws.protocoltests.restxml
+
+use aws.api#service
+use aws.protocols#restXml
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@service(sdkId: "Rest Xml List")
+@restXml
+service RestXml {
+    version: "2019-12-16",
+    operations: [
+        XmlNestedNestedWrappedList
+    ]
+}
+
+@http(uri: "/XmlNestedNestedWrappedList", method: "POST")
+operation XmlNestedNestedWrappedList {
+    input: XmlNestedNestedWrappedListInputOutput,
+    output: XmlNestedNestedWrappedListInputOutput
+}
+
+structure XmlNestedNestedWrappedListInputOutput {
+    nestedNestedStringList: NestedNestedStringList
+}
+
+list NestedNestedStringList {
+    member: NestedStringList
+}
+
+list NestedStringList {
+    member: StringList
+}
+
+list StringList {
+    member: String
+}


### PR DESCRIPTION
~~In flight, not ready for review. only worked on decoder -- only pushing to save work.~~
Ready for review.
- Supports serde for nested lists. Based on the smithy interpreter, it seems that @xmlFlattened can only be applied to structs and unions, so based on this, I believe only the first level gets flattened.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
