### PR TITLE
fix: endpoint prefix can be nil

### DIFF
--- a/Packages/ClientRuntime/Sources/Networking/Http/HttpContext.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/HttpContext.swift
@@ -38,8 +38,8 @@ public struct HttpContext: MiddlewareContext {
         return attributes.get(key: AttributeKey<IdempotencyTokenGenerator>(name: "IdempotencyTokenGenerator"))!
     }
     
-    public func getHostPrefix() -> String {
-        return attributes.get(key: AttributeKey<String>(name: "HostPrefix"))!
+    public func getHostPrefix() -> String? {
+        return attributes.get(key: AttributeKey<String>(name: "HostPrefix"))
     }
 }
 


### PR DESCRIPTION
*Description of changes:*Endpoint Prefix can be nil, this PR accommodates for that.
Corresponding PR in aws-sdk-swift [here](https://github.com/awslabs/aws-sdk-swift/pull/68).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
