### PR TITLE
fix: make timestamp wrappers in client runtime public

### DIFF
--- a/Packages/ClientRuntime/Sources/Serialization/SerializationUtils/TimestampFormat.swift
+++ b/Packages/ClientRuntime/Sources/Serialization/SerializationUtils/TimestampFormat.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-enum TimestampFormat {
+public enum TimestampFormat {
     case epochSeconds
     case dateTime
     case httpDate

--- a/Packages/ClientRuntime/Sources/Serialization/SerializationUtils/TimestampWrapper.swift
+++ b/Packages/ClientRuntime/Sources/Serialization/SerializationUtils/TimestampWrapper.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct TimestampWrapper: Encodable {
+public struct TimestampWrapper: Encodable {
     public let date: Date
     public let format: TimestampFormat
     

--- a/Packages/ClientRuntime/Sources/Serialization/SerializationUtils/TimestampWrapperDecoder.swift
+++ b/Packages/ClientRuntime/Sources/Serialization/SerializationUtils/TimestampWrapperDecoder.swift
@@ -7,10 +7,10 @@
 
 import Foundation
 
-struct TimestampWrapperDecoder {
-    static func parseDateStringValue(_ dateStringValue: String,
-                                     format: TimestampFormat,
-                                     codingPath: [CodingKey]? = nil) throws -> Date {
+public struct TimestampWrapperDecoder {
+    static public func parseDateStringValue(_ dateStringValue: String,
+                                            format: TimestampFormat,
+                                            codingPath: [CodingKey]? = nil) throws -> Date {
         let formatter: DateFormatter?
         switch format {
         case .epochSeconds:
@@ -20,7 +20,7 @@ struct TimestampWrapperDecoder {
         case .httpDate:
             formatter = DateFormatter.rfc5322DateFormatter
         }
-
+        
         guard let formattedDate = formatter!.date(from: dateStringValue) else {
             let context = DecodingError.Context(codingPath: codingPath ?? [],
                                                 debugDescription: "Unable to parse: \(dateStringValue) to format \(format)")


### PR DESCRIPTION
No corresponding pr

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
