### PR TITLE
chore: workaround for broken protocol tests

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
@@ -78,7 +78,7 @@ open class HttpProtocolUnitTestResponseGenerator protected constructor(builder: 
                 responseDecoder = when (bodyMediaType.toLowerCase()) {
                     "application/json" -> "JSONDecoder()"
                     "application/xml" -> "XMLDecoder()"
-                    //TODO: Remove this once we upgrade our version of smithy
+                    // TODO: Remove this once we upgrade our version of smithy
                     // https://github.com/awslabs/smithy/blob/3488bf6e742d6a56443267f5697bcecffff6064b/smithy-aws-protocol-tests/model/restXml/http-query.smithy#L268
                     "xml" -> "XMLDecoder()"
                     "application/x-www-form-urlencoded" -> TODO("urlencoded form assertion not implemented yet")


### PR DESCRIPTION
This is a bit of a workaround until we update our version of smithy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
