### PR TITLE
feat: support for enum cases with Swift reserved words (#183)

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/EnumGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/EnumGenerator.kt
@@ -149,11 +149,11 @@ class EnumGenerator(
     }
 
     fun addEnumCaseToAllCases(definition: EnumDefinition) {
-        allCasesBuilder.add(".${definition.swiftEnumCaseName()}")
+        allCasesBuilder.add(".${definition.swiftEnumCaseName(false)}")
     }
 
     fun addEnumCaseToRawValuesEnum(definition: EnumDefinition) {
-        rawValuesBuilder.add("case .${definition.swiftEnumCaseName()}: return \"${definition.value}\"")
+        rawValuesBuilder.add("case .${definition.swiftEnumCaseName(false)}: return \"${definition.value}\"")
     }
 
     fun createEnumWriterContexts() {
@@ -206,7 +206,7 @@ class EnumGenerator(
      * Uses either name or value attributes of EnumDefinition in that order and formats
      * them to camelCase after removing chars except alphanumeric, space and underscore.
      */
-    fun EnumDefinition.swiftEnumCaseName(): String {
+    fun EnumDefinition.swiftEnumCaseName(shouldBeEscaped: Boolean = true): String {
         var enumCaseName = CaseUtils.toCamelCase(
             name.orElseGet {
                 value
@@ -216,7 +216,7 @@ class EnumGenerator(
             enumCaseName = "_$enumCaseName"
         }
 
-        if (reservedKeywords.contains(enumCaseName)) {
+        if (shouldBeEscaped && reservedKeywords.contains(enumCaseName)) {
             enumCaseName = SymbolVisitor.escapeReservedWords(enumCaseName)
         }
 

--- a/smithy-swift-codegen/src/test/kotlin/ReservedWordsGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ReservedWordsGeneratorTests.kt
@@ -1,0 +1,60 @@
+
+import io.kotest.matchers.string.shouldContainOnlyOnce
+import org.junit.jupiter.api.Test
+
+class ReservedWordsGeneratorTests {
+    @Test
+    fun `test enum`() {
+        val context = setupTests("reserved-name-enum-test.smithy", "com.test#Example")
+        val contents = getFileContents(context.manifest, "/example/models/ReservedWordsEnum.swift")
+        val expectedContents =
+            """
+                public enum ReservedWordsEnum {
+                    case any
+                    case `open`
+                    case `self`
+                    case `protocol`
+                    case sdkUnknown(String)
+                }
+
+                extension ReservedWordsEnum : Equatable, RawRepresentable, Codable, CaseIterable, Hashable {
+                    public static var allCases: [ReservedWordsEnum] {
+                        return [
+                            .any,
+                            .open,
+                            .self,
+                            .protocol,
+                            .sdkUnknown("")
+                        ]
+                    }
+                    public init?(rawValue: String) {
+                        let value = Self.allCases.first(where: { ${'$'}0.rawValue == rawValue })
+                        self = value ?? Self.sdkUnknown(rawValue)
+                    }
+                    public var rawValue: String {
+                        switch self {
+                        case .any: return "Any"
+                        case .open: return "OPEN"
+                        case .self: return "Self"
+                        case .protocol: return "PROTOCOL"
+                        case let .sdkUnknown(s): return s
+                        }
+                    }
+                    public init(from decoder: Decoder) throws {
+                        let container = try decoder.singleValueContainer()
+                        let rawValue = try container.decode(RawValue.self)
+                        self = ReservedWordsEnum(rawValue: rawValue) ?? ReservedWordsEnum.sdkUnknown(rawValue)
+                    }
+                }
+            """.trimIndent()
+
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {
+        val context = TestContext.initContextFrom(smithyFile, serviceShapeId)
+        context.generator.generateSerializers(context.generationCtx)
+        context.generationCtx.delegator.flushWriters()
+        return context
+    }
+}

--- a/smithy-swift-codegen/src/test/resources/reserved-name-enum-test.smithy
+++ b/smithy-swift-codegen/src/test/resources/reserved-name-enum-test.smithy
@@ -1,0 +1,50 @@
+$version: "1.0"
+namespace com.test
+
+use aws.protocols#restJson1
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@restJson1
+service Example {
+    version: "1.0.0",
+    operations: [
+            EnumInput
+    ]
+}
+
+@http(method: "POST", uri: "/input/enum")
+operation EnumInput {
+    input: EnumInputRequest
+}
+
+structure EnumInputRequest {
+    nestedWithEnum: NestedEnum,
+
+    @httpHeader("X-EnumHeader")
+    enumHeader: ReservedWordsEnum
+}
+
+structure NestedEnum {
+    myEnum: ReservedWordsEnum
+}
+
+@enum([
+    {
+        value: "PROTOCOL",
+        name: "protocol"
+    },
+    {
+        value: "OPEN",
+        name: "OPEN"
+    },
+    {
+        value: "Self",
+        name: "Self"
+    },
+    {
+        value: "Any",
+        name: "Any"
+    }
+])
+string ReservedWordsEnum


### PR DESCRIPTION
*Description of changes:*
When handling enum case names with Swift reserved words, the existing function EnumDefinition.swiftEnumCaseName can now accommodate both dot notation dereferencing and regular field declaration.
No corresponding PR in other repos.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
