### PR TITLE
feat: refactor decode symbol creation

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SymbolVisitor.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SymbolVisitor.kt
@@ -93,6 +93,14 @@ fun Symbol.defaultValue(): String? {
     return if (default.isPresent) default.get() else null
 }
 
+fun Symbol.bodySymbol(): Symbol {
+    return Symbol.builder()
+        .name("${name}Body")
+        .putProperty("boxed", isBoxed())
+        .putProperty("defaultValue", defaultValue())
+        .build()
+}
+
 fun Shape.defaultName(): String = StringUtils.capitalize(this.id.name)
 
 fun Shape.camelCaseName(): String = StringUtils.uncapitalize(this.id.name)


### PR DESCRIPTION
*Description of changes:*

Refactored the way decode symbol is created so that the symbol itself has the correct name.  It was achieved by adding a new extension function to return Symbol.Builder object with the correct name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
