### PR TITLE
chore: inject encoder/decoder to protocol codegentests

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolTestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolTestGenerator.kt
@@ -24,6 +24,7 @@ class HttpProtocolTestGenerator(
     private val responseTestBuilder: HttpProtocolUnitTestResponseGenerator.Builder,
     private val errorTestBuilder: HttpProtocolUnitTestErrorGenerator.Builder,
     private val httpProtocolCustomizable: HttpProtocolCustomizable,
+    private val serdeContext: HttpProtocolUnitTestGenerator.SerdeContext,
     // list of test IDs to ignore/skip
     private val testsToIgnore: Set<String> = setOf()
 ) {
@@ -65,6 +66,7 @@ class HttpProtocolTestGenerator(
                             .serviceName(serviceSymbol.name)
                             .testCases(testCases)
                             .httpProtocolCustomizable(httpProtocolCustomizable)
+                            .serdeContext(serdeContext)
                             .build()
                             .renderTestClass(testClassName)
                     }
@@ -96,6 +98,7 @@ class HttpProtocolTestGenerator(
                             .serviceName(serviceSymbol.name)
                             .testCases(testCases)
                             .httpProtocolCustomizable(httpProtocolCustomizable)
+                            .serdeContext(serdeContext)
                             .build()
                             .renderTestClass(testClassName)
                     }
@@ -131,6 +134,7 @@ class HttpProtocolTestGenerator(
                                 .serviceName(serviceSymbol.name)
                                 .testCases(testCases)
                                 .httpProtocolCustomizable(httpProtocolCustomizable)
+                                .serdeContext(serdeContext)
                                 .build()
                                 .renderTestClass(testClassName)
                         }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestGenerator.kt
@@ -25,6 +25,7 @@ protected constructor(builder: Builder<T>) {
     protected val operation: OperationShape = builder.operation!!
     protected val writer: SwiftWriter = builder.writer!!
     protected val httpProtocolCustomizable = builder.httpProtocolCustomizable!!
+    protected val serdeContext = builder.serdeContext!!
     protected val serviceName: String = builder.serviceName!!
     abstract val baseTestClassName: String
 
@@ -62,6 +63,12 @@ protected constructor(builder: Builder<T>) {
      */
     protected abstract fun renderTestBody(test: T)
 
+    data class SerdeContext(
+        val protocolEncoder: String,
+        val protocolDecoder: String,
+        val defaultTimestampFormat: String? = null
+    )
+
     abstract class Builder<T : HttpMessageTestCase> {
         var symbolProvider: SymbolProvider? = null
         var model: Model? = null
@@ -70,6 +77,7 @@ protected constructor(builder: Builder<T>) {
         var writer: SwiftWriter? = null
         var serviceName: String? = null
         var httpProtocolCustomizable: HttpProtocolCustomizable? = null
+        var serdeContext: SerdeContext? = null
 
         fun symbolProvider(provider: SymbolProvider): Builder<T> = apply { this.symbolProvider = provider }
         fun model(model: Model): Builder<T> = apply { this.model = model }
@@ -78,6 +86,7 @@ protected constructor(builder: Builder<T>) {
         fun writer(writer: SwiftWriter): Builder<T> = apply { this.writer = writer }
         fun serviceName(serviceName: String): Builder<T> = apply { this.serviceName = serviceName }
         fun httpProtocolCustomizable(httpProtocolCustomizable: HttpProtocolCustomizable): Builder<T> = apply { this.httpProtocolCustomizable = httpProtocolCustomizable }
+        fun serdeContext(serdeContext: SerdeContext): Builder<T> = apply { this.serdeContext = serdeContext }
         abstract fun build(): HttpProtocolUnitTestGenerator<T>
     }
 }

--- a/smithy-swift-codegen/src/test/kotlin/MockHttpRestJsonProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/MockHttpRestJsonProtocolGenerator.kt
@@ -8,6 +8,7 @@ import software.amazon.smithy.swift.codegen.integration.HttpBindingProtocolGener
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolCustomizable
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolTestGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestErrorGenerator
+import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestRequestGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
@@ -29,7 +30,6 @@ class MockHttpRestJsonProtocolGenerator : HttpBindingProtocolGenerator() {
     )
 
     override fun generateProtocolUnitTests(ctx: ProtocolGenerator.GenerationContext) {
-
         val requestTestBuilder = HttpProtocolUnitTestRequestGenerator.Builder()
         val responseTestBuilder = HttpProtocolUnitTestResponseGenerator.Builder()
         val errorTestBuilder = HttpProtocolUnitTestErrorGenerator.Builder()
@@ -39,7 +39,8 @@ class MockHttpRestJsonProtocolGenerator : HttpBindingProtocolGenerator() {
             requestTestBuilder,
             responseTestBuilder,
             errorTestBuilder,
-            httpProtocolCustomizable
+            httpProtocolCustomizable,
+            HttpProtocolUnitTestGenerator.SerdeContext("JSONEncoder()", "JSONDecoder()", ".secondsSince1970")
         ).generateProtocolTests()
     }
 }

--- a/smithy-swift-codegen/src/test/kotlin/MockHttpRestXMLProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/MockHttpRestXMLProtocolGenerator.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.swift.codegen.integration.HttpBindingProtocolGener
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolCustomizable
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolTestGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestErrorGenerator
+import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestRequestGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
@@ -30,7 +31,6 @@ class MockHttpRestXMLProtocolGenerator : HttpBindingProtocolGenerator() {
     )
 
     override fun generateProtocolUnitTests(ctx: ProtocolGenerator.GenerationContext) {
-
         val requestTestBuilder = HttpProtocolUnitTestRequestGenerator.Builder()
         val responseTestBuilder = HttpProtocolUnitTestResponseGenerator.Builder()
         val errorTestBuilder = HttpProtocolUnitTestErrorGenerator.Builder()
@@ -40,7 +40,8 @@ class MockHttpRestXMLProtocolGenerator : HttpBindingProtocolGenerator() {
             requestTestBuilder,
             responseTestBuilder,
             errorTestBuilder,
-            httpProtocolCustomizable
+            httpProtocolCustomizable,
+            HttpProtocolUnitTestGenerator.SerdeContext("XMLEncoder()", "XMLDecoder()")
         ).generateProtocolTests()
     }
 }


### PR DESCRIPTION
https://github.com/awslabs/aws-sdk-swift/pull/82
Protocols should decide which protocol to use in protocol unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
