### PR TITLE
feat: sensitive trait CustomStringConvertible extension generator

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDelegator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDelegator.kt
@@ -93,6 +93,18 @@ class SwiftDelegator(
         writer.popState()
     }
 
+    fun useShapeExtensionWriter(shape: Shape, extensionName: String, block: (SwiftWriter) -> Unit) {
+        val symbol = symbolProvider.toSymbol(shape)
+        val extensionSymbol = Symbol.builder()
+            .name("${symbol.name}")
+            .definitionFile("${symbol.definitionFile.replace(".swift", "+$extensionName.swift")}")
+            .putProperty("boxed", symbol.isBoxed())
+            .putProperty("defaultValue", symbol.defaultValue())
+            .build()
+
+        useShapeWriter(extensionSymbol, block)
+    }
+
     /**
      * Gets a previously created writer or creates a new one if needed
      * and adds a new line if the writer already exists.

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/CustomStringConvertibleGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/CustomStringConvertibleGenerator.kt
@@ -1,0 +1,78 @@
+package software.amazon.smithy.swift.codegen.integration
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.codegen.core.SymbolProvider
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.traits.SensitiveTrait
+import software.amazon.smithy.swift.codegen.SwiftWriter
+import software.amazon.smithy.swift.codegen.toMemberNames
+
+class CustomStringConvertibleGenerator(
+    private val symbolProvider: SymbolProvider,
+    private val writer: SwiftWriter,
+    private val shape: StructureShape
+) {
+    companion object {
+        const val REDACT_STRING = "CONTENT_REDACTED"
+    }
+
+    private val structSymbol: Symbol by lazy {
+        symbolProvider.toSymbol(shape)
+    }
+
+    private val membersSortedByName: List<MemberShape> = shape.allMembers.values.sortedBy { symbolProvider.toMemberName(it) }
+
+    fun render() {
+        writer.openBlock("extension ${structSymbol.name}: CustomStringConvertible {", "}") {
+            writer.openBlock("public var description: String {", "}") {
+                if (shape.hasTrait(SensitiveTrait::class.java)) {
+                    writer.write("\"$REDACT_STRING\"")
+                } else {
+                    renderDescription()
+                }
+            }
+        }
+    }
+
+    private fun renderDescription() {
+        val symbolName = structSymbol.name
+        writer.writeInline("\"$symbolName(")
+        val membersWithoutSensitiveTrait = membersSortedByName
+            .filterNot { it.hasTrait(SensitiveTrait::class.java) }
+            .sortedBy { it.memberName }
+            .toList()
+        val membersWithSensitiveTrait = membersSortedByName
+            .filter { it.hasTrait(SensitiveTrait::class.java) }
+            .sortedBy { it.memberName }
+            .toList()
+        for (member in membersWithoutSensitiveTrait) {
+            renderMemberDescription(writer, member, false)
+            renderComma(writer, member != membersWithoutSensitiveTrait.last())
+        }
+        if (membersWithSensitiveTrait.isNotEmpty()) {
+            renderComma(writer, membersWithoutSensitiveTrait.isNotEmpty())
+            for (member in membersWithSensitiveTrait) {
+                renderMemberDescription(writer, member, true)
+                renderComma(writer, member != membersWithSensitiveTrait.last())
+            }
+        }
+        writer.writeInline(")\"")
+    }
+
+    private fun renderMemberDescription(
+        writer: SwiftWriter,
+        member: MemberShape,
+        isRedacted: Boolean
+    ) {
+        val memberNames = symbolProvider.toMemberNames(member)
+        val description = if (isRedacted) "\\\"$REDACT_STRING\\\"" else "\\(String(describing: ${memberNames.first}))"
+        writer.writeInline("${memberNames.second}: $description")
+    }
+
+    private fun renderComma(writer: SwiftWriter, shouldWriteComma: Boolean) {
+        if (shouldWriteComma) {
+            writer.writeInline(", ")
+        }
+    }
+}

--- a/smithy-swift-codegen/src/test/kotlin/SensitiveTraitGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/SensitiveTraitGeneratorTests.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+import io.kotest.matchers.string.shouldContainOnlyOnce
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.build.MockManifest
+import software.amazon.smithy.swift.codegen.SwiftCodegenPlugin
+
+class SensitiveTraitGeneratorTests {
+    @Test
+    fun `SensitiveTraitInRequestInput+CustomStringConvertible`() {
+        val manifest = setupTest()
+        var extensionWithSensitiveTrait = manifest
+            .getFileString("example/models/SensitiveTraitInRequestInput+CustomStringConvertible.swift").get()
+        extensionWithSensitiveTrait.shouldSyntacticSanityCheck()
+        val expectedContents =
+            """
+            extension SensitiveTraitInRequestInput: CustomStringConvertible {
+                public var description: String {
+                    "SensitiveTraitInRequestInput(foo: \(String(describing: foo)), baz: \"CONTENT_REDACTED\")"}
+            }
+            """.trimIndent()
+        extensionWithSensitiveTrait.shouldContainOnlyOnce(expectedContents)
+    }
+
+    @Test
+    fun `SensitiveTraitInRequestOutput+CustomStringConvertible`() {
+        val manifest = setupTest()
+        var extensionWithSensitiveTrait = manifest
+            .getFileString("example/models/SensitiveTraitInRequestOutput+CustomStringConvertible.swift").get()
+        extensionWithSensitiveTrait.shouldSyntacticSanityCheck()
+        val expectedContents =
+            """
+            extension SensitiveTraitInRequestOutput: CustomStringConvertible {
+                public var description: String {
+                    "CONTENT_REDACTED"
+                }
+            }
+            """.trimIndent()
+        extensionWithSensitiveTrait.shouldContainOnlyOnce(expectedContents)
+    }
+
+    @Test
+    fun `NoSensitiveMemberStruct+CustomStringConvertible`() {
+        val manifest = setupTest()
+        var extensionWithSensitiveTrait = manifest
+            .getFileString("example/models/SensitiveTraitTestRequestInput+CustomStringConvertible.swift").get()
+        extensionWithSensitiveTrait.shouldSyntacticSanityCheck()
+        val expectedContents =
+            """
+            extension SensitiveTraitTestRequestInput: CustomStringConvertible {
+                public var description: String {
+                    "SensitiveTraitTestRequestInput(bar: \(String(describing: bar)), baz: \(String(describing: baz)), foo: \(String(describing: foo)))"}
+            }
+            """.trimIndent()
+        extensionWithSensitiveTrait.shouldContainOnlyOnce(expectedContents)
+    }
+
+    @Test
+    fun `AllSensitiveMemberStruct+CustomStringConvertible`() {
+        val manifest = setupTest()
+        var extensionWithSensitiveTrait = manifest
+            .getFileString("example/models/SensitiveTraitTestRequestOutput+CustomStringConvertible.swift").get()
+        extensionWithSensitiveTrait.shouldSyntacticSanityCheck()
+        val expectedContents =
+            """
+            extension SensitiveTraitTestRequestOutput: CustomStringConvertible {
+                public var description: String {
+                    "SensitiveTraitTestRequestOutput(bar: \"CONTENT_REDACTED\", baz: \"CONTENT_REDACTED\", foo: \"CONTENT_REDACTED\")"}
+            }
+            """.trimIndent()
+        extensionWithSensitiveTrait.shouldContainOnlyOnce(expectedContents)
+    }
+
+    private fun setupTest(): MockManifest {
+        val model = javaClass.getResource("sensitive-trait-test.smithy").asSmithy()
+        val manifest = MockManifest()
+        val context = buildMockPluginContext(model, manifest, "smithy.example#Example")
+        SwiftCodegenPlugin().execute(context)
+        return manifest
+    }
+}

--- a/smithy-swift-codegen/src/test/resources/sensitive-trait-test.smithy
+++ b/smithy-swift-codegen/src/test/resources/sensitive-trait-test.smithy
@@ -1,0 +1,55 @@
+$version: "1.0"
+
+namespace smithy.example
+
+use aws.api#service
+use aws.protocols#restJson1
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@service(sdkId: "Rest Json Protocol")
+@restJson1
+service Example {
+    version: "2019-12-16",
+    operations: [
+        SensitiveTraitInRequest,
+        SensitiveTraitTestRequest
+    ]
+}
+@http(uri: "/SensitiveTraitInRequest", method: "POST")
+operation SensitiveTraitInRequest {
+    input: SensitiveTraitInRequestInput,
+    output: SensitiveTraitInRequestOutput
+}
+
+@http(uri: "/SensitiveTraitTestRequest", method: "POST")
+operation SensitiveTraitTestRequest {
+    input: SensitiveTraitTestRequestInput,
+    output: SensitiveTraitTestRequestOutput
+}
+
+structure SensitiveTraitInRequestInput {
+    @sensitive
+    baz: String,
+    foo: String
+}
+
+@sensitive
+structure SensitiveTraitInRequestOutput {
+    bar: String
+}
+
+structure SensitiveTraitTestRequestInput {
+   foo: String,
+   bar: String,
+   baz: String
+}
+
+structure SensitiveTraitTestRequestOutput {
+   @sensitive
+   foo: String,
+   @sensitive
+   bar: String,
+   @sensitive
+   baz: String
+}


### PR DESCRIPTION
*Description of changes:*
Added CustomStringConvertibleGenerator that can be used to generate a new file (Filename+CustomStringConvertible.swift) that contains the extension.
This PR contains the extension generator for "structure" + unit test.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
