### PR TITLE
fix: fix reserved words in shapevaluegenerator and protocol client

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ShapeValueGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ShapeValueGenerator.kt
@@ -212,7 +212,7 @@ class ShapeValueGenerator(
                         }
                         val recursiveMemberWithTrait = member.hasTrait(SwiftBoxTrait::class.java)
                         memberShape = generator.model.expectShape(member.target)
-                        val memberName = generator.symbolProvider.toMemberName(member)
+                        val memberName = generator.symbolProvider.toMemberNames(member).second
                         // NOTE - `write()` appends a newline and keeps indentation,
                         // `writeInline()` doesn't keep indentation but also doesn't append a newline
                         // ...except it does insert indentation if it encounters a newline.

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolClientGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolClientGenerator.kt
@@ -25,6 +25,7 @@ import software.amazon.smithy.swift.codegen.camelCaseName
 import software.amazon.smithy.swift.codegen.capitalizedName
 import software.amazon.smithy.swift.codegen.isBoxed
 import software.amazon.smithy.swift.codegen.swiftFunctionParameterIndent
+import software.amazon.smithy.swift.codegen.toMemberNames
 
 /**
  * Renders an implementation of a service interface for HTTP protocol
@@ -80,7 +81,7 @@ open class HttpProtocolClientGenerator(
 
                 // shape must be string, number, boolean, or timestamp
                 val targetShape = model.expectShape(binding.member.target)
-                val labelMemberName = binding.member.memberName.decapitalize()
+                val labelMemberName = ctx.symbolProvider.toMemberNames(binding.member).first.decapitalize()
                 val formattedLabel: String
                 if (targetShape.isTimestampShape) {
                     val bindingIndex = HttpBindingIndex.of(model)


### PR DESCRIPTION
**no need to review yet -- still self reviewing**

Corresponding
https://github.com/awslabs/aws-sdk-swift/pull/87

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
