### PR TITLE
fix: support awsQueryError trait

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HttpResponseBindingErrorNarrowGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HttpResponseBindingErrorNarrowGenerator.kt
@@ -45,7 +45,7 @@ class HttpResponseBindingErrorNarrowGenerator(
         }
     }
 
-    //TODO: Move to be called from a protocol
+    // TODO: Move to be called from a protocol
     private fun resolveErrorShapeName(errorShape: StructureShape): String {
         errorShape.getTrait<AwsQueryErrorTrait>()?.let {
             return it.code


### PR DESCRIPTION
This feels a little bit hacky since smithy-swift should limit how much it knows about protocol specific traits.  If this is too hacky, it'll take a little bit longer to make this class injectable from a protocol.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
