### PR TITLE
chore: merge all models to single file

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ServiceGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ServiceGenerator.kt
@@ -180,7 +180,7 @@ class ServiceGenerator(
         val errorShapes = op.errors.map { model.expectShape(it) as StructureShape }.toSet().sorted()
         val operationErrorName = getOperationErrorShapeName(op)
         val operationErrorSymbol = Symbol.builder()
-            .definitionFile("./$rootNamespace/models/$operationErrorName.swift")
+            .definitionFile("./$rootNamespace/models/Models.swift")
             .name(operationErrorName)
             .build()
         val unknownServiceErrorSymbol = protocolGenerator?.unknownServiceErrorSymbol ?: ProtocolGenerator.DefaultUnknownServiceErrorSymbol

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SymbolVisitor.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SymbolVisitor.kt
@@ -327,7 +327,7 @@ class SymbolVisitor(private val model: Model, swiftSettings: SwiftSettings) :
         // All shapes except for the service are stored in models.
         return when (shapeType) {
             ShapeType.SERVICE -> "./$rootNamespace/${name}ClientProtocol.swift"
-            else -> "./$rootNamespace/models/$name.swift"
+            else -> "./$rootNamespace/models/Models.swift"
         }
     }
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpBindingProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpBindingProtocolGenerator.kt
@@ -139,7 +139,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
             val symbolName = symbol.name
             val rootNamespace = ctx.settings.moduleName
             val encodeSymbol = Symbol.builder()
-                .definitionFile("./$rootNamespace/models/$symbolName.swift")
+                .definitionFile("./$rootNamespace/models/Models.swift")
                 .name(symbolName)
                 .build()
 
@@ -193,7 +193,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
         val symbolName = symbol.name
         val rootNamespace = ctx.settings.moduleName
         val encodeSymbol = Symbol.builder()
-            .definitionFile("./$rootNamespace/models/$symbolName.swift")
+            .definitionFile("./$rootNamespace/models/Models.swift")
             .name(symbolName)
             .build()
 
@@ -233,7 +233,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
         val httpBodyMembers = shape.members().filter { it.isInHttpBody() }.toList()
 
         val decodeSymbol = Symbol.builder()
-            .definitionFile("./$rootNamespace/models/${bodySymbol.name}.swift")
+            .definitionFile("./$rootNamespace/models/Models.swift")
             .name(bodySymbol.name)
             .build()
 
@@ -377,7 +377,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
 
         val rootNamespace = ctx.settings.moduleName
         val headerMiddlewareSymbol = Symbol.builder()
-            .definitionFile("./$rootNamespace/models/${inputSymbol.name}.swift")
+            .definitionFile("./$rootNamespace/models/Models.swift")
             .name(inputSymbol.name)
             .build()
         ctx.delegator.useShapeWriter(headerMiddlewareSymbol) { writer ->
@@ -403,7 +403,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
 
         val rootNamespace = ctx.settings.moduleName
         val headerMiddlewareSymbol = Symbol.builder()
-            .definitionFile("./$rootNamespace/models/${inputSymbol.name}.swift")
+            .definitionFile("./$rootNamespace/models/Models.swift")
             .name(inputSymbol.name)
             .build()
         ctx.delegator.useShapeWriter(headerMiddlewareSymbol) { writer ->
@@ -421,7 +421,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
             val rootNamespace = ctx.settings.moduleName
             val inputSymbol = ctx.symbolProvider.toSymbol(inputShape)
             val headerMiddlewareSymbol = Symbol.builder()
-                .definitionFile("./$rootNamespace/models/${inputSymbol.name}.swift")
+                .definitionFile("./$rootNamespace/models/Models.swift")
                 .name(inputSymbol.name)
                 .build()
             ctx.delegator.useShapeWriter(headerMiddlewareSymbol) { writer ->

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HttpResponseBindingErrorInitGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HttpResponseBindingErrorInitGenerator.kt
@@ -42,7 +42,7 @@ class HttpResponseBindingErrorInitGenerator(
         val errorShapeName = ctx.symbolProvider.toSymbol(shape).name
 
         val httpBindingSymbol = Symbol.builder()
-            .definitionFile("./$rootNamespace/models/$errorShapeName.swift")
+            .definitionFile("./$rootNamespace/models/Models.swift")
             .name(errorShapeName)
             .build()
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HttpResponseBindingErrorNarrowGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HttpResponseBindingErrorNarrowGenerator.kt
@@ -20,7 +20,7 @@ class HttpResponseBindingErrorNarrowGenerator(
         val operationErrorName = ServiceGenerator.getOperationErrorShapeName(op)
         val rootNamespace = ctx.settings.moduleName
         val httpBindingSymbol = Symbol.builder()
-            .definitionFile("./$rootNamespace/models/$operationErrorName.swift")
+            .definitionFile("./$rootNamespace/models/Models.swift")
             .name(operationErrorName)
             .build()
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HttpResponseBindingOutputGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HttpResponseBindingOutputGenerator.kt
@@ -32,7 +32,7 @@ class HttpResponseBindingOutputGenerator(
             .sortedBy { it.memberName }
         val rootNamespace = ctx.settings.moduleName
         val httpBindingSymbol = Symbol.builder()
-            .definitionFile("./$rootNamespace/models/$outputShapeName.swift")
+            .definitionFile("./$rootNamespace/models/Models.swift")
             .name(outputShapeName)
             .build()
 


### PR DESCRIPTION
Corresponding:
https://github.com/awslabs/aws-sdk-swift/pull/156

All unit tests will probably break, but pushing this up to demonstrate how to merge all generated model files into a single file


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
