### PR TITLE
fix: remove Service postfix from some service names

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftSettings.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftSettings.kt
@@ -68,10 +68,14 @@ class SwiftSettings(
             val author = config.expectStringMember(AUTHOR).value
             val gitRepo = config.expectStringMember(GIT_REPO).value
             val swiftVersion = config.expectStringMember(SWIFT_VERSION).value
-            val sdkId = config.getStringMemberOrDefault(SDK_ID, serviceId.name)
+            val sdkId = sanitizeSdkId(config.getStringMemberOrDefault(SDK_ID, serviceId.name))
             val shouldGenerateUnitTestTarget = config.getBooleanMemberOrDefault(SHOULD_GENERATE_UNIT_TEST_TARGET, false)
 
             return SwiftSettings(serviceId, moduleName, version, desc, author, homepage, sdkId, gitRepo, swiftVersion, shouldGenerateUnitTestTarget)
+        }
+
+        private fun sanitizeSdkId(sdkId: String): String {
+            return sdkId.removeSuffix(" Service")
         }
 
         // infer the service to generate from a model


### PR DESCRIPTION
Original:
https://github.com/awslabs/smithy-swift/pull/282/files


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
