### PR TITLE
feat: proposed interface for exposing logging

### DIFF
--- a/Packages/ClientRuntime/Sources/Config/Configuration.swift
+++ b/Packages/ClientRuntime/Sources/Config/Configuration.swift
@@ -14,25 +14,20 @@ open class Configuration {
     public let httpClientConfiguration: HttpClientConfiguration
     public let idempotencyTokenGenerator: IdempotencyTokenGenerator
     public let retrier: Retrier
-    public var clientLogMode: ClientLogMode
-    public let logger: LogAgent
     
     public init(encoder: RequestEncoder? = nil,
                 decoder: ResponseDecoder? = nil,
                 httpClientEngine: HttpClientEngine? = nil,
                 httpClientConfiguration: HttpClientConfiguration = HttpClientConfiguration(),
                 retrier: Retrier? = nil,
-                clientLogMode: ClientLogMode = .request,
-                logger: LogAgent? = nil,
                 idempotencyTokenGenerator: IdempotencyTokenGenerator = DefaultIdempotencyTokenGenerator()) throws {
         self.encoder = encoder
         self.decoder = decoder
         let engine = try httpClientEngine ?? CRTClientEngine()
         self.httpClientEngine = engine
         self.retrier = try retrier ?? SDKRetrier(clientEngine: engine)
-        self.clientLogMode = clientLogMode
-        self.logger = logger ?? SwiftLogger(label: "Swift SDK Logger")
         self.httpClientConfiguration = httpClientConfiguration
         self.idempotencyTokenGenerator = idempotencyTokenGenerator
     }
+
 }

--- a/Packages/ClientRuntime/Sources/Logging/CRLogHandlerFactory.swift
+++ b/Packages/ClientRuntime/Sources/Logging/CRLogHandlerFactory.swift
@@ -1,0 +1,13 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+	
+import Logging
+
+public protocol CRLogHandlerFactory {
+    var label: String { get }
+    func constructLogHandler(label: String) -> LogHandler
+}

--- a/Packages/ClientRuntime/Sources/Logging/CRLogLevel.swift
+++ b/Packages/ClientRuntime/Sources/Logging/CRLogLevel.swift
@@ -1,0 +1,38 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+	
+import Logging
+
+public enum CRLogLevel: String, Codable, CaseIterable {
+    case trace
+    case debug
+    case info
+    case notice
+    case warning
+    case error
+    case critical
+
+    public func toLoggerType() -> Logger.Level {
+        switch(self) {
+        case .trace:
+            return .trace
+        case .debug:
+            return .debug
+        case .info:
+            return .info
+        case .notice:
+            return .notice
+        case .warning:
+            return .warning
+        case .error:
+            return .error
+        case .critical:
+            return .critical
+        }
+    }
+}
+

--- a/Packages/ClientRuntime/Sources/Logging/CRLoggingSystem.swift
+++ b/Packages/ClientRuntime/Sources/Logging/CRLoggingSystem.swift
@@ -1,0 +1,36 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+	
+import Logging
+
+public class CRLoggingSystem {
+    private static var handlerFactories: [String:CRLogHandlerFactory] = [:]
+
+    public class func add(logHandlerFactory: CRLogHandlerFactory) {
+        let label = logHandlerFactory.label
+        handlerFactories[label] = logHandlerFactory
+    }
+
+    public class func initialize() {
+        LoggingSystem.bootstrap { label in
+            if let factory = handlerFactories[label] {
+                return factory.constructLogHandler(label: label)
+            }
+            var handler = StreamLogHandler.standardOutput(label: label)
+            handler.logLevel = .info
+            return handler
+        }
+    }
+
+    public class func initialize(logLevel: CRLogLevel) {
+        LoggingSystem.bootstrap { label in
+            var handler = StreamLogHandler.standardOutput(label: label)
+            handler.logLevel = logLevel.toLoggerType()
+            return handler
+        }
+    }
+}

--- a/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngineLogHandlerFactory.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngineLogHandlerFactory.swift
@@ -1,0 +1,23 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+	
+import Logging
+
+public struct CRTClientEngineLogHandlerFactory: CRLogHandlerFactory {
+    public var label = "CRTClientEngine"
+    let logLevel: CRLogLevel
+
+    public func constructLogHandler(label: String) -> LogHandler {
+        var handler = StreamLogHandler.standardOutput(label: label)
+        handler.logLevel = logLevel.toLoggerType()
+        return handler
+    }
+    
+    public init(logLevel: CRLogLevel) {
+        self.logLevel = logLevel
+    }
+}


### PR DESCRIPTION
This is a proposal for exposing a logging interface to customers allowing them to adjust the log level for any instance of LogLevel in our system.  See internal design doc for a full description of a full design/strategy for this component.


Customer facing code would look like this:
```
CRLoggingSystem.add(logHandlerFactory: S3ClientLogHandlerFactory(logLevel: .debug))
CRLoggingSystem.add(logHandlerFactory: CRTClientEngineLogHandlerFactory(logLevel: .debug))
CRLoggingSystem.initialize()
```

Or, if they want to set the log level across all instances:
```
CRLoggingSystem.initialize(logLevel: .debug)
```

Not in love with the "CR" in the name, but LogLevel was already taken.. Doh!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
