### PR TITLE
fix: streaming response

### DIFF
--- a/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
@@ -143,15 +143,16 @@ public class CRTClientEngine: HttpClientEngine {
             streamReader.write(buffer: byteBuffer)
         } onStreamComplete: { [self] (_, error) in
             logger.debug("stream completed")
+            streamReader.hasFinishedWriting = true
             if case let CRTError.crtError(unwrappedError) = error {
                 if unwrappedError.errorCode != 0 {
                     logger.error("Response encountered an error: \(error)")
                     streamReader.onError(error: ClientError.crtError(error))
                     future.fail(error)
+                    return
                 }
             }
 
-            streamReader.hasFinishedWriting = true
             response.body = .stream(.reader(streamReader))
             future.fulfill(response)
         }

--- a/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
@@ -86,18 +86,10 @@ public class CRTClientEngine: HttpClientEngine {
     }
     
     public func execute(request: SdkHttpRequest) -> Future<HttpResponse> {
-//        let isStreaming = { () -> Bool in
-//            switch request.body {
-//            case .stream: return true
-//            default: return false
-//            }
-//        }()
         let connectionMgr = getOrCreateConnectionPool(endpoint: request.endpoint)
         let httpResponseFuture: Future<HttpResponse> = connectionMgr.acquireConnection()
             .chained { (connectionResult) -> Future<HttpResponse> in
                 self.logger.debug("Connection was acquired to: \(String(describing: request.endpoint.url?.absoluteString))")
-               // let (requestOptions, future) = isStreaming ?
-                  //  self.makeHttpRequestStreamOptions(request): self.makeHttpRequestOptions(request)
                 let (requestOptions, future) = self.makeHttpRequestStreamOptions(request)
                 switch connectionResult {
                 case .failure(let error):
@@ -147,65 +139,25 @@ public class CRTClientEngine: HttpClientEngine {
         } onIncomingBody: { [self] (_, data) in
             logger.debug("incoming data")
             
-           // if let streamReader = streamReader {
-                let byteBuffer = ByteBuffer(data: data)
-                streamReader.write(buffer: byteBuffer)
-           // }
+            let byteBuffer = ByteBuffer(data: data)
+            streamReader.write(buffer: byteBuffer)
         } onStreamComplete: { [self] (_, error) in
             logger.debug("stream completed")
             if case let CRTError.crtError(unwrappedError) = error {
                 if unwrappedError.errorCode != 0 {
                     logger.error("Response encountered an error: \(error)")
-                   // if let streamReader = streamReader {
-                        streamReader.onError(error: ClientError.crtError(error))
-                   // }
+                    streamReader.onError(error: ClientError.crtError(error))
                     future.fail(error)
                 }
             }
-           // if let streamReader = streamReader {
-                streamReader.hasFinishedWriting = true
-                response.body = .stream(.reader(streamReader))
-          //  }
+
+            streamReader.hasFinishedWriting = true
+            response.body = .stream(.reader(streamReader))
             future.fulfill(response)
         }
         
         return (requestOptions, future)
     }
-    
-//    public func makeHttpRequestOptions(_ request: SdkHttpRequest) -> (HttpRequestOptions, Future<HttpResponse>) {
-//        let future = Future<HttpResponse>()
-//        let crtRequest = request.toHttpRequest(bufferSize: windowSize)
-//
-//        let response = HttpResponse()
-//        var incomingData = Data()
-//
-//        let requestOptions = HttpRequestOptions(request: crtRequest) { [self] (stream, _, httpHeaders) in
-//            logger.debug("headers were received")
-//            response.statusCode = HttpStatusCode(rawValue: Int(stream.getResponseStatusCode()))
-//                ?? HttpStatusCode.notFound
-//            response.headers.addAll(httpHeaders: httpHeaders)
-//        } onIncomingHeadersBlockDone: { [self] (stream, _) in
-//            logger.debug("header block is done")
-//            response.statusCode = HttpStatusCode(rawValue: Int(stream.getResponseStatusCode()))
-//                ?? HttpStatusCode.notFound
-//        } onIncomingBody: { [self] (_, data) in
-//            logger.debug("incoming data: \(data.count) bytes")
-//            incomingData.append(data)
-//        } onStreamComplete: { [self] (_, error) in
-//            logger.debug("stream completed")
-//            if case let CRTError.crtError(unwrappedError) = error {
-//                if unwrappedError.errorCode != 0 {
-//                    logger.error("Response encountered an error: \(error)")
-//                    future.fail(error)
-//                }
-//            }
-//
-//            response.body = HttpBody.data(incomingData)
-//            future.fulfill(response)
-//        }
-//
-//        return (requestOptions, future)
-//    }
     
     deinit {
         AwsCommonRuntimeKit.cleanUp()

--- a/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
@@ -86,18 +86,19 @@ public class CRTClientEngine: HttpClientEngine {
     }
     
     public func execute(request: SdkHttpRequest) -> Future<HttpResponse> {
-        let isStreaming = { () -> Bool in
-            switch request.body {
-            case .stream: return true
-            default: return false
-            }
-        }()
+//        let isStreaming = { () -> Bool in
+//            switch request.body {
+//            case .stream: return true
+//            default: return false
+//            }
+//        }()
         let connectionMgr = getOrCreateConnectionPool(endpoint: request.endpoint)
         let httpResponseFuture: Future<HttpResponse> = connectionMgr.acquireConnection()
             .chained { (connectionResult) -> Future<HttpResponse> in
                 self.logger.debug("Connection was acquired to: \(String(describing: request.endpoint.url?.absoluteString))")
-                let (requestOptions, future) = isStreaming ?
-                    self.makeHttpRequestStreamOptions(request): self.makeHttpRequestOptions(request)
+               // let (requestOptions, future) = isStreaming ?
+                  //  self.makeHttpRequestStreamOptions(request): self.makeHttpRequestOptions(request)
+                let (requestOptions, future) = self.makeHttpRequestStreamOptions(request)
                 switch connectionResult {
                 case .failure(let error):
                     future.fail(error)
@@ -132,11 +133,7 @@ public class CRTClientEngine: HttpClientEngine {
         let crtRequest = request.toHttpRequest(bufferSize: windowSize)
         let response = HttpResponse()
         
-        var streamReader: StreamReader?
-        if case let HttpBody.stream(unwrappedStream) = request.body,
-           case let ByteStream.reader(reader) = unwrappedStream {
-            streamReader = reader
-        }
+        let streamReader: StreamReader = DataStreamReader()
         
         let requestOptions = HttpRequestOptions(request: crtRequest) { [self] (stream, _, httpHeaders) in
             logger.debug("headers were received")
@@ -150,65 +147,65 @@ public class CRTClientEngine: HttpClientEngine {
         } onIncomingBody: { [self] (_, data) in
             logger.debug("incoming data")
             
-            if let streamReader = streamReader {
+           // if let streamReader = streamReader {
                 let byteBuffer = ByteBuffer(data: data)
                 streamReader.write(buffer: byteBuffer)
-            }
+           // }
         } onStreamComplete: { [self] (_, error) in
             logger.debug("stream completed")
             if case let CRTError.crtError(unwrappedError) = error {
                 if unwrappedError.errorCode != 0 {
                     logger.error("Response encountered an error: \(error)")
-                    if let streamReader = streamReader {
+                   // if let streamReader = streamReader {
                         streamReader.onError(error: ClientError.crtError(error))
-                    }
+                   // }
                     future.fail(error)
                 }
             }
-            if let streamReader = streamReader {
+           // if let streamReader = streamReader {
                 streamReader.hasFinishedWriting = true
                 response.body = .stream(.reader(streamReader))
-            }
+          //  }
             future.fulfill(response)
         }
         
         return (requestOptions, future)
     }
     
-    public func makeHttpRequestOptions(_ request: SdkHttpRequest) -> (HttpRequestOptions, Future<HttpResponse>) {
-        let future = Future<HttpResponse>()
-        let crtRequest = request.toHttpRequest(bufferSize: windowSize)
-        
-        let response = HttpResponse()
-        var incomingData = Data()
-        
-        let requestOptions = HttpRequestOptions(request: crtRequest) { [self] (stream, _, httpHeaders) in
-            logger.debug("headers were received")
-            response.statusCode = HttpStatusCode(rawValue: Int(stream.getResponseStatusCode()))
-                ?? HttpStatusCode.notFound
-            response.headers.addAll(httpHeaders: httpHeaders)
-        } onIncomingHeadersBlockDone: { [self] (stream, _) in
-            logger.debug("header block is done")
-            response.statusCode = HttpStatusCode(rawValue: Int(stream.getResponseStatusCode()))
-                ?? HttpStatusCode.notFound
-        } onIncomingBody: { [self] (_, data) in
-            logger.debug("incoming data: \(data.count) bytes")
-            incomingData.append(data)
-        } onStreamComplete: { [self] (_, error) in
-            logger.debug("stream completed")
-            if case let CRTError.crtError(unwrappedError) = error {
-                if unwrappedError.errorCode != 0 {
-                    logger.error("Response encountered an error: \(error)")
-                    future.fail(error)
-                }
-            }
-            
-            response.body = HttpBody.data(incomingData)
-            future.fulfill(response)
-        }
-        
-        return (requestOptions, future)
-    }
+//    public func makeHttpRequestOptions(_ request: SdkHttpRequest) -> (HttpRequestOptions, Future<HttpResponse>) {
+//        let future = Future<HttpResponse>()
+//        let crtRequest = request.toHttpRequest(bufferSize: windowSize)
+//
+//        let response = HttpResponse()
+//        var incomingData = Data()
+//
+//        let requestOptions = HttpRequestOptions(request: crtRequest) { [self] (stream, _, httpHeaders) in
+//            logger.debug("headers were received")
+//            response.statusCode = HttpStatusCode(rawValue: Int(stream.getResponseStatusCode()))
+//                ?? HttpStatusCode.notFound
+//            response.headers.addAll(httpHeaders: httpHeaders)
+//        } onIncomingHeadersBlockDone: { [self] (stream, _) in
+//            logger.debug("header block is done")
+//            response.statusCode = HttpStatusCode(rawValue: Int(stream.getResponseStatusCode()))
+//                ?? HttpStatusCode.notFound
+//        } onIncomingBody: { [self] (_, data) in
+//            logger.debug("incoming data: \(data.count) bytes")
+//            incomingData.append(data)
+//        } onStreamComplete: { [self] (_, error) in
+//            logger.debug("stream completed")
+//            if case let CRTError.crtError(unwrappedError) = error {
+//                if unwrappedError.errorCode != 0 {
+//                    logger.error("Response encountered an error: \(error)")
+//                    future.fail(error)
+//                }
+//            }
+//
+//            response.body = HttpBody.data(incomingData)
+//            future.fulfill(response)
+//        }
+//
+//        return (requestOptions, future)
+//    }
     
     deinit {
         AwsCommonRuntimeKit.cleanUp()

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpHeaderMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpHeaderMiddleware.kt
@@ -74,8 +74,7 @@ class HttpHeaderMiddleware(
             renderDoCatch(memberNameWithExtension, paramName)
         } else {
             if (member.needsDefaultValueCheck(ctx.model, ctx.symbolProvider) && !inCollection) {
-                writer.write("let needsToBeSentAcrossTheWire = $memberName != ${member.defaultValue(ctx.symbolProvider)}")
-                writer.openBlock("if needsToBeSentAcrossTheWire {", "}") {
+                writer.openBlock("if $memberName != ${member.defaultValue(ctx.symbolProvider)} {", "}") {
                     writer.write("input.builder.withHeader(name: \"$paramName\", value: String($memberNameWithExtension))")
                 }
             } else {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
@@ -67,8 +67,6 @@ open class HttpProtocolUnitTestRequestGenerator protected constructor(builder: B
             decoderProperty?.renderInstantiation(writer)
             decoderProperty?.renderConfiguration(writer)
 
-            // TODO:: handle streaming inputs
-            // isStreamingRequest = inputShape.asStructureShape().get().hasStreamingMember(model)
             writer.writeInline("\nlet input = ")
                 .call {
                     ShapeValueGenerator(model, symbolProvider).writeShapeValueInline(writer, inputShape, test.params)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
@@ -15,7 +15,6 @@ import software.amazon.smithy.swift.codegen.RecursiveShapeBoxer
 import software.amazon.smithy.swift.codegen.ShapeValueGenerator
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.getOrNull
-import software.amazon.smithy.swift.codegen.hasStreamingMember
 import software.amazon.smithy.swift.codegen.isBoxed
 
 /**
@@ -53,21 +52,10 @@ open class HttpProtocolUnitTestResponseGenerator protected constructor(builder: 
             renderHeadersInHttpResponse(test)
             test.body.ifPresent { body ->
                 if (body.isNotBlank() && body.isNotEmpty()) {
-                    val isStreamingResponse = operation.output.map {
-                        val outputShape = model.expectShape(it)
-                        outputShape.asStructureShape().get().hasStreamingMember(model)
-                    }.orElse(false)
-                    if (isStreamingResponse) {
-                        writer.write(
-                            "content: HttpBody.stream(ByteStream.from(data: \"\"\"\n\$L\n\"\"\".data(using: .utf8)!)),",
-                            body.replace(".000", "")
-                        )
-                    } else {
-                        writer.write(
-                            "content: HttpBody.data(\"\"\"\n\$L\n\"\"\".data(using: .utf8)),",
-                            body.replace(".000", "")
-                        )
-                    }
+                    writer.write(
+                        "content: HttpBody.stream(ByteStream.from(data: \"\"\"\n\$L\n\"\"\".data(using: .utf8)!)),",
+                        body.replace(".000", "")
+                    )
                 }
             }
             writer.write("host: host")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpQueryItemMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpQueryItemMiddleware.kt
@@ -126,8 +126,7 @@ class HttpQueryItemMiddleware(
             renderDoCatch(memberName, paramName)
         } else {
             if (member.needsDefaultValueCheck(ctx.model, ctx.symbolProvider)) {
-                writer.write("let needsToBeSentAcrossTheWire = $memberName != ${member.defaultValue(ctx.symbolProvider)}")
-                writer.openBlock("if needsToBeSentAcrossTheWire {", "}") {
+                writer.openBlock("if $memberName != ${member.defaultValue(ctx.symbolProvider)} {", "}") {
                     val queryItemName = "${ctx.symbolProvider.toMemberNames(member).second}QueryItem"
                     writer.write("let $queryItemName = URLQueryItem(name: \"$paramName\".urlPercentEncoding(), value: String($memberName).urlPercentEncoding())")
                     writer.write("input.builder.withQueryItem($queryItemName)")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HttpResponseTraitWithHttpPayload.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HttpResponseTraitWithHttpPayload.kt
@@ -22,9 +22,9 @@ class HttpResponseTraitWithHttpPayload(
         // TODO: properly support event streams and other binary stream types besides blob
         val isBinaryStream =
             ctx.model.getShape(binding.member.target).get().hasTrait<StreamingTrait>() && target.type == ShapeType.BLOB
-        val bodyType = if (isBinaryStream) ".stream" else ".data"
-        val additionalUnwrap = if (!isBinaryStream) ",\n    let data = data" else ""
-        writer.openBlock("if case $bodyType(let data) = httpResponse.body$additionalUnwrap {", "} else {") {
+        writer.openBlock("if case .stream(let reader) = httpResponse.body {", "} else {") {
+            val extension = if(!isBinaryStream) ".toBytes().toData()" else ""
+            writer.write("let data = reader$extension")
             when (target.type) {
                 ShapeType.DOCUMENT -> {
                     writer.openBlock("if let responseDecoder = decoder {", "} else {") {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HttpResponseTraitWithHttpPayload.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HttpResponseTraitWithHttpPayload.kt
@@ -23,7 +23,7 @@ class HttpResponseTraitWithHttpPayload(
         val isBinaryStream =
             ctx.model.getShape(binding.member.target).get().hasTrait<StreamingTrait>() && target.type == ShapeType.BLOB
         writer.openBlock("if case .stream(let reader) = httpResponse.body {", "} else {") {
-            val extension = if(!isBinaryStream) ".toBytes().toData()" else ""
+            val extension = if (!isBinaryStream) ".toBytes().toData()" else ""
             writer.write("let data = reader$extension")
             when (target.type) {
                 ShapeType.DOCUMENT -> {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HttpResponseTraitWithoutHttpPayload.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HttpResponseTraitWithoutHttpPayload.kt
@@ -40,11 +40,11 @@ class HttpResponseTraitWithoutHttpPayload(
         val bodyMembersWithoutQueryTraitMemberNames = bodyMembersWithoutQueryTrait.map { ctx.symbolProvider.toMemberName(it.member) }
 
         if (bodyMembersWithoutQueryTrait.isNotEmpty()) {
-            writer.write("if case .data(let data) = httpResponse.body,")
+            writer.write("if case .stream(let reader) = httpResponse.body,")
             writer.indent()
-            writer.write("let unwrappedData = data,")
             writer.write("let responseDecoder = decoder {")
-            writer.write("let output: ${outputShapeName}Body = try responseDecoder.decode(responseBody: unwrappedData)")
+            writer.write("let data = reader.toBytes().toData()")
+            writer.write("let output: ${outputShapeName}Body = try responseDecoder.decode(responseBody: data)")
             bodyMembersWithoutQueryTraitMemberNames.sorted().forEach {
                 writer.write("self.$it = output.$it")
             }

--- a/smithy-swift-codegen/src/test/kotlin/HttpBindingProtocolGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpBindingProtocolGeneratorTests.kt
@@ -71,8 +71,8 @@ class HttpBindingProtocolGeneratorTests {
             """
 extension ExplicitStructOutputResponse: HttpResponseBinding {
     public init (httpResponse: HttpResponse, decoder: ResponseDecoder? = nil) throws {
-        if case .data(let data) = httpResponse.body,
-            let data = data {
+        if case .stream(let reader) = httpResponse.body {
+            let data = reader.toBytes().toData()
             if let responseDecoder = decoder {
                 let output: Nested2 = try responseDecoder.decode(responseBody: data)
                 self.payload1 = output
@@ -118,8 +118,8 @@ extension HttpResponseCodeOutputResponse: HttpResponseBinding {
             """
 extension InlineDocumentAsPayloadOutputResponse: HttpResponseBinding {
     public init (httpResponse: HttpResponse, decoder: ResponseDecoder? = nil) throws {
-        if case .data(let data) = httpResponse.body,
-            let data = data {
+        if case .stream(let reader) = httpResponse.body {
+            let data = reader.toBytes().toData()
             if let responseDecoder = decoder {
                 let output: Document = try responseDecoder.decode(responseBody: data)
                 self.documentValue = output

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolUnitTestErrorGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolUnitTestErrorGeneratorTests.kt
@@ -27,14 +27,14 @@ class GreetingWithErrorsComplexErrorTest: HttpResponseTestBase {
                     "X-Amzn-Errortype": "ComplexError",
                     "X-Header": "Header"
                 ],
-                content: HttpBody.data(""${'"'}
+                content: HttpBody.stream(ByteStream.from(data: ""${'"'}
                 {
                     "TopLevel": "Top level",
                     "Nested": {
                         "Fooooo": "bar"
                     }
                 }
-                ""${'"'}.data(using: .utf8)),
+                ""${'"'}.data(using: .utf8)!)),
                 host: host
             ) else {
                 XCTFail("Something is wrong with the created http response")
@@ -91,14 +91,14 @@ class GreetingWithErrorsComplexErrorTest: HttpResponseTestBase {
                     "X-Amzn-Errortype": "ComplexError",
                     "X-Header": "Header"
                 ],
-                content: HttpBody.data(""${'"'}
+                content: HttpBody.stream(ByteStream.from(data: ""${'"'}
                 {
                     "TopLevel": "Top level",
                     "Nested": {
                         "Fooooo": "bar"
                     }
                 }
-                ""${'"'}.data(using: .utf8)),
+                ""${'"'}.data(using: .utf8)!)),
                 host: host
             ) else {
                 XCTFail("Something is wrong with the created http response")

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolUnitTestResponseGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolUnitTestResponseGeneratorTests.kt
@@ -37,7 +37,7 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
                 "X-Int": "1",
                 "X-String": "Hello"
             ],
-            content: HttpBody.data(""${'"'}
+            content: HttpBody.stream(ByteStream.from(data: ""${'"'}
             {
               "payload1": "explicit string",
               "payload2": 1,
@@ -47,7 +47,7 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
               }
             }
 
-            ""${'"'}.data(using: .utf8)),
+            ""${'"'}.data(using: .utf8)!)),
             host: host
         ) else {
             XCTFail("Something is wrong with the created http response")
@@ -165,13 +165,13 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
             headers: [
                 "Content-Type": "application/json"
             ],
-            content: HttpBody.data(""${'"'}
+            content: HttpBody.stream(ByteStream.from(data: ""${'"'}
             {
                 "contents": {
                     "stringValue": "foo"
                 }
             }
-            ""${'"'}.data(using: .utf8)),
+            ""${'"'}.data(using: .utf8)!)),
             host: host
         ) else {
             XCTFail("Something is wrong with the created http response")
@@ -208,7 +208,7 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
             headers: [
                 "Content-Type": "application/json"
             ],
-            content: HttpBody.data(""${'"'}
+            content: HttpBody.stream(ByteStream.from(data: ""${'"'}
             {
                 "nested": {
                     "foo": "Foo1",
@@ -223,7 +223,7 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
                     }
                 }
             }
-            ""${'"'}.data(using: .utf8)),
+            ""${'"'}.data(using: .utf8)!)),
             host: host
         ) else {
             XCTFail("Something is wrong with the created http response")
@@ -276,14 +276,14 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
                         headers: [
                             "Content-Type": "application/json"
                         ],
-                        content: HttpBody.data(""${'"'}
+                        content: HttpBody.stream(ByteStream.from(data: ""${'"'}
                         {
                             "stringValue": "string",
                             "documentValue": {
                                 "foo": "bar"
                             }
                         }
-                        ""${'"'}.data(using: .utf8)),
+                        ""${'"'}.data(using: .utf8)!)),
                         host: host
                     ) else {
                         XCTFail("Something is wrong with the created http response")
@@ -330,11 +330,11 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
                         headers: [
                             "Content-Type": "application/json"
                         ],
-                        content: HttpBody.data(""${'"'}
+                        content: HttpBody.stream(ByteStream.from(data: ""${'"'}
                         {
                             "foo": "bar"
                         }
-                        ""${'"'}.data(using: .utf8)),
+                        ""${'"'}.data(using: .utf8)!)),
                         host: host
                     ) else {
                         XCTFail("Something is wrong with the created http response")


### PR DESCRIPTION
*Description of changes:* This PR fixes a series of bugs:
1. receiving a stream was broken. We now make no determination on the receiving end of the http engine whether or not something is a stream and everything is a stream and we convert it appropriately to Data for a customer or just return the streaming interface allowing them to receive it dynamically.
2. removes a compiler bug introduced by #292 due to a variable name showing up multiple times in a closure.

Corresponding PR: https://github.com/awslabs/aws-sdk-swift/pull/273
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
