### PR TITLE
fix: Use XMLCoder version 0.13.0

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -1,5 +1,4 @@
 
-
 {
   "name": "smithy-swift",
   "needs_compiler": false,


### PR DESCRIPTION
Note this will fail until XMLCoder 0.13.0 is released

corresponding: https://github.com/awslabs/aws-sdk-swift/pull/279

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
