### PR TITLE
fix: when passing in arguments, compare by lowercase

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ShapeValueGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ShapeValueGenerator.kt
@@ -221,7 +221,7 @@ class ShapeValueGenerator(
             // this is important because when a struct is generated in swift it is generated with its members sorted by name.
             // when you instantiate that struct you have to call params in order with their param names. if you don't it won't compile
             // so we sort here before we write any of the members with their values
-            val sortedMembers = node.members.toSortedMap(compareBy<StringNode> { it.value })
+            val sortedMembers = node.members.toSortedMap(compareBy<StringNode> { it.value.lowercase() })
             sortedMembers.forEach { (keyNode, valueNode) ->
                 val memberShape: Shape
                 when (currShape) {


### PR DESCRIPTION
corresponding:
https://github.com/awslabs/aws-sdk-swift/pull/304

this allows restxml-namespace protocol codegen tests to compile properly.. hopefully it doesn't break anything else.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
