### PR TITLE
fix: documentation fix

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/EndpointTraitConstructor.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/EndpointTraitConstructor.kt
@@ -16,7 +16,7 @@ class EndpointTraitConstructor(private val endpointTrait: EndpointTrait, private
                 // hostLabel can only target string shapes
                 // see: https://awslabs.github.io/smithy/1.0/spec/core/endpoint-traits.html#hostlabel-trait
                 val member = inputShape.members().first { it.memberName == segment.content }
-                "\\(String(describing: input.${member.memberName.toCamelCase()}))"
+                "\\(input.${member.memberName.toCamelCase()})"
             } else {
                 segment.content
             }


### PR DESCRIPTION
*Description of changes:* This temporarily fixes docuemntation in xcode until we do a more formal html to markdown conversion. As you can see you can now option click in xcode and you can also build full documentation if you wanted to.
<img width="706" alt="Screen Shot 2021-08-19 at 9 31 19 AM" src="https://user-images.githubusercontent.com/8533749/130107347-ec737529-13a3-445f-9246-eee87f6e2640.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
