### PR TITLE
fix: add tls servername update for mac

### DIFF
--- a/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Packages/ClientRuntime/Sources/Networking/Http/CRT/CRTClientEngine.swift
@@ -31,14 +31,12 @@ public class CRTClientEngine: HttpClientEngine {
     
     private func createConnectionPool(endpoint: Endpoint) -> HttpClientConnectionManager {
         let tlsConnectionOptions = SDKDefaultIO.shared.tlsContext.newConnectionOptions()
-        #if os(Linux)
         do {
             try tlsConnectionOptions.setServerName(endpoint.host)
         } catch let err {
             logger.error("Server name was not able to be set in TLS Connection Options. TLS Negotiation will fail.")
             logger.error("Error: \(err.localizedDescription)")
         }
-        #endif
         let socketOptions = SocketOptions(socketType: .stream)
         let options = HttpClientConnectionOptions(clientBootstrap: SDKDefaultIO.shared.clientBootstrap,
                                                   hostName: endpoint.host,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This fixes an issue where TLS negotiation fails for some services because server name is not set i.e. Pinpoint. Previously this was only failing on Linux but it also fails on Mac now.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.