### PR TITLE
feat: implement ML endpoint customization

### DIFF
--- a/Packages/SmithyTestUtil/Sources/RequestTestUtil/HttpRequestTestBase.swift
+++ b/Packages/SmithyTestUtil/Sources/RequestTestUtil/HttpRequestTestBase.swift
@@ -207,6 +207,7 @@ open class HttpRequestTestBase: XCTestCase {
         assertQueryItems(expected.queryItems, actual.queryItems)
         
         XCTAssertEqual(expected.endpoint.path, actual.endpoint.path)
+        XCTAssertEqual(expected.endpoint.host, actual.endpoint.host)
         
         assertForbiddenQueryItems(expected.forbiddenQueryItems, actual.queryItems)
         

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/RequestTestEndpointResolverMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/RequestTestEndpointResolverMiddleware.kt
@@ -26,6 +26,9 @@ class RequestTestEndpointResolverMiddleware(private val model: Model, private va
             ClientRuntimeTypes.Core.SdkError
         ) {
             writer.write("input.withPath(context.getPath())")
+            writer.openBlock("if let host = context.getHost() {", "}") {
+                writer.write("input.withHost(host)")
+            }
             writer.write("return next.handle(context: context, input: input)")
         }
     }


### PR DESCRIPTION
Corresponding:
https://github.com/awslabs/aws-sdk-swift/pull/449


Draft PR:
Couple more things to do before we can push out a non-draft PR:
1.  ~~This get pushed in: https://github.com/awslabs/smithy/pull/944 (and then we pass the protocol codegen test)~~ Completed
2.  Ensure that when we use the actual call in the SDK - we figure out a way to take the value of teh host set in the context, so that it is applied to the actual request -- this is not happening currently as I have not yet figured out how we will replace(or modify) the endpoint resolver. -- TBD!
3.  Update any unit tests, etc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.