### PR TITLE
chore: Remove reference to xcode 12.5

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,8 +22,6 @@ env:
 jobs:
   downstream:
     runs-on: macos-11
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_12.5.app
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.