### PR TITLE
chore: Add whitespace to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ This project is licensed under the Apache-2.0 License.
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md) for more information.
+


### PR DESCRIPTION
## Description of changes
Adds trivial whitespace change to README.  Needed to prevent release from failing since there have been no changes to `smithy-swift` since the last Swift SDK release.  See https://github.com/awslabs/aws-sdk-swift/issues/1060

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.