### PR TITLE
fix: make headers mutable

### DIFF
--- a/Sources/ClientRuntime/Networking/Endpoint.swift
+++ b/Sources/ClientRuntime/Networking/Endpoint.swift
@@ -11,7 +11,7 @@ public struct Endpoint: Hashable {
     public let protocolType: ProtocolType?
     public let host: String
     public let port: Int16
-    public let headers: Headers?
+    public internal(set) var headers: Headers?
     public let properties: [String: AnyHashable]
 
     public init(urlString: String,

--- a/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
+++ b/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
@@ -11,9 +11,12 @@ import AwsCommonRuntimeKit
 // in the CRT engine so that is why it's a class
 public class SdkHttpRequest {
     public let body: HttpBody
-    public let endpoint: Endpoint
+    public internal(set) var endpoint: Endpoint
     public let method: HttpMethodType
-    public var headers: Headers { endpoint.headers ?? Headers() }
+    public var headers: Headers {
+        get { endpoint.headers ?? Headers() }
+        set { endpoint.headers = newValue }
+    }
     public var path: String { endpoint.path }
     public var host: String { endpoint.host }
     public var queryItems: [URLQueryItem]? { endpoint.queryItems }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
- https://github.com/smithy-lang/smithy-swift/issues/583

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
I really don't love this change, ideally we'd have a more official way of setting headers. But the change making headers immutable in 0.20.0 is currently blocking us from upgrading.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.