### PR TITLE
fix: Correct serde for errors in event streams

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeDecodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/MemberShapeDecodeGenerator.kt
@@ -34,7 +34,8 @@ Includes functions to help render conformance to Decodable protocol for shapes
 abstract class MemberShapeDecodeGenerator(
     private val ctx: ProtocolGenerator.GenerationContext,
     private val writer: SwiftWriter,
-    private val defaultTimestampFormat: TimestampFormatTrait.Format
+    private val defaultTimestampFormat: TimestampFormatTrait.Format,
+    private val path: String
 ) : MemberShapeDecodeGeneratable {
     fun renderDecodeForTimestamp(ctx: ProtocolGenerator.GenerationContext, target: Shape, member: MemberShape, containerName: String) {
         val memberName = ctx.symbolProvider.toMemberName(member)
@@ -154,7 +155,7 @@ abstract class MemberShapeDecodeGenerator(
      */
     open fun renderAssigningDecodedMember(topLevelMember: MemberShape, decodedMemberName: String) {
         val topLevelMemberName = ctx.symbolProvider.toMemberName(topLevelMember)
-        writer.write("\$L = \$L", topLevelMemberName, decodedMemberName)
+        writer.write("\$L\$L = \$L", path, topLevelMemberName, decodedMemberName)
     }
 
     private fun renderDecodeListTarget(shape: Shape, decodedMemberName: String, collectionName: String, insertMethod: String, topLevelMember: MemberShape, parentMember: Shape, level: Int = 0) {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/StructDecodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/StructDecodeGenerator.kt
@@ -46,8 +46,9 @@ class StructDecodeGenerator(
     private val ctx: ProtocolGenerator.GenerationContext,
     private val members: List<MemberShape>,
     private val writer: SwiftWriter,
-    private val defaultTimestampFormat: TimestampFormatTrait.Format
-) : MemberShapeDecodeGenerator(ctx, writer, defaultTimestampFormat) {
+    private val defaultTimestampFormat: TimestampFormatTrait.Format,
+    private val path: String
+) : MemberShapeDecodeGenerator(ctx, writer, defaultTimestampFormat, path) {
     override fun render() {
         val containerName = "containerValues"
         writer.openBlock("public init(from decoder: \$N) throws {", "}", SwiftTypes.Decoder) {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/UnionDecodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/json/UnionDecodeGenerator.kt
@@ -18,7 +18,7 @@ class UnionDecodeGenerator(
     private val members: List<MemberShape>,
     private val writer: SwiftWriter,
     private val defaultTimestampFormat: TimestampFormatTrait.Format
-) : MemberShapeDecodeGenerator(ctx, writer, defaultTimestampFormat) {
+) : MemberShapeDecodeGenerator(ctx, writer, defaultTimestampFormat, "") {
     override fun render() {
         val containerName = "values"
         writer.openBlock("public init(from decoder: \$N) throws {", "}", SwiftTypes.Decoder) {

--- a/smithy-swift-codegen/src/test/kotlin/mocks/MockHttpAWSJson11ProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/mocks/MockHttpAWSJson11ProtocolGenerator.kt
@@ -96,6 +96,7 @@ class MockHttpAWSJson11ProtocolGenerator : HttpBindingProtocolGenerator() {
         members: List<MemberShape>,
         writer: SwiftWriter,
         defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
         val encodeGenerator = StructEncodeGenerator(ctx, members, writer, defaultTimestampFormat)
         encodeGenerator.render()
@@ -106,8 +107,9 @@ class MockHttpAWSJson11ProtocolGenerator : HttpBindingProtocolGenerator() {
         members: List<MemberShape>,
         writer: SwiftWriter,
         defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
-        val decodeGenerator = StructDecodeGenerator(ctx, members, writer, defaultTimestampFormat)
+        val decodeGenerator = StructDecodeGenerator(ctx, members, writer, defaultTimestampFormat, path)
         decodeGenerator.render()
     }
 

--- a/smithy-swift-codegen/src/test/kotlin/mocks/MockHttpEC2QueryProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/mocks/MockHttpEC2QueryProtocolGenerator.kt
@@ -88,6 +88,7 @@ class MockHttpEC2QueryProtocolGenerator : HttpBindingProtocolGenerator() {
         members: List<MemberShape>,
         writer: SwiftWriter,
         defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
         val customizations = MockEc2QueryFormURLEncodeCustomizations()
         val encodeGenerator = StructEncodeFormURLGenerator(ctx, customizations, shapeContainingMembers, shapeMetadata, members, writer, defaultTimestampFormat)
@@ -99,6 +100,7 @@ class MockHttpEC2QueryProtocolGenerator : HttpBindingProtocolGenerator() {
         members: List<MemberShape>,
         writer: SwiftWriter,
         defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
         val decodeGenerator = StructDecodeXMLGenerator(ctx, members, mapOf(), writer, defaultTimestampFormat)
         decodeGenerator.render()

--- a/smithy-swift-codegen/src/test/kotlin/mocks/MockHttpRestJsonProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/mocks/MockHttpRestJsonProtocolGenerator.kt
@@ -77,6 +77,7 @@ class MockHttpRestJsonProtocolGenerator : HttpBindingProtocolGenerator() {
         members: List<MemberShape>,
         writer: SwiftWriter,
         defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
         val encodeGenerator = StructEncodeGenerator(ctx, members, writer, defaultTimestampFormat)
         encodeGenerator.render()
@@ -87,8 +88,9 @@ class MockHttpRestJsonProtocolGenerator : HttpBindingProtocolGenerator() {
         members: List<MemberShape>,
         writer: SwiftWriter,
         defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
-        val decodeGenerator = StructDecodeGenerator(ctx, members, writer, defaultTimestampFormat)
+        val decodeGenerator = StructDecodeGenerator(ctx, members, writer, defaultTimestampFormat, path)
         decodeGenerator.render()
     }
 

--- a/smithy-swift-codegen/src/test/kotlin/mocks/MockHttpRestXMLProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/mocks/MockHttpRestXMLProtocolGenerator.kt
@@ -54,6 +54,7 @@ class MockHttpRestXMLProtocolGenerator : HttpBindingProtocolGenerator() {
         members: List<MemberShape>,
         writer: SwiftWriter,
         defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
         val encoder = StructEncodeXMLGenerator(ctx, shapeContainingMembers, members, writer, defaultTimestampFormat)
         encoder.render()
@@ -66,6 +67,7 @@ class MockHttpRestXMLProtocolGenerator : HttpBindingProtocolGenerator() {
         members: List<MemberShape>,
         writer: SwiftWriter,
         defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
         val decodeGenerator = StructDecodeXMLGenerator(ctx, members, shapeMetadata, writer, defaultTimestampFormat)
         decodeGenerator.render()


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1100

## Description of changes
Fixes serializers / deserializers for errors that are embedded in event streams, by accounting for the custom error properties being namespaced under `properties`.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.