### PR TITLE
chore: Support Swift 5.x versions past 5.9 in metadata

### DIFF
--- a/Sources/ClientRuntime/Util/SwiftVersion.swift
+++ b/Sources/ClientRuntime/Util/SwiftVersion.swift
@@ -8,7 +8,7 @@
 /// Returns the swift version of the compiler that is compiling this application.
 public var swiftVersion: String {
     /**
-     Unfortunately there isn't a way to grab the compiled swift programmatically and so we must resot to the compiler directives to produce a version string.
+     Unfortunately there isn't a way to grab the compiled swift programmatically and so we must resort to the compiler directives to produce a version string.
      We are checking for quite a few versions in the future, that may never exist, in order to future proof our current SDKs. Ideally, all current SDKs should compile
      on future Swift versions unless that Swift version introduces a breaking change.
      
@@ -23,6 +23,26 @@ public var swiftVersion: String {
 private func swift5Version() -> String? {
     #if swift(>=6.0)
     return nil
+    #elseif swift(>=5.19)
+    return "5.19"
+    #elseif swift(>=5.18)
+    return "5.18"
+    #elseif swift(>=5.17)
+    return "5.17"
+    #elseif swift(>=5.16)
+    return "5.16"
+    #elseif swift(>=5.15)
+    return "5.15"
+    #elseif swift(>=5.14)
+    return "5.14"
+    #elseif swift(>=5.13)
+    return "5.13"
+    #elseif swift(>=5.12)
+    return "5.12"
+    #elseif swift(>=5.11)
+    return "5.11"
+    #elseif swift(>=5.10)
+    return "5.10"
     #elseif swift(>=5.9)
     return "5.9"
     #elseif swift(>=5.8)


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1135

## Description of changes
Swift 5.9 was just released with Xcode 15.  The Swift core team has indicated that the release of Swift 6 is not imminent, so further Swift 5 minor releases are expected.

This PR extends the Swift metadata generation to handle Swift 5 minor versions up to Swift 5.19.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.