### PR TITLE
fix: Use original member name for serialization of URL-encoded forms

### DIFF
--- a/Sources/SmithyTestUtil/RequestTestUtil/HttpRequestTestBase.swift
+++ b/Sources/SmithyTestUtil/RequestTestUtil/HttpRequestTestBase.swift
@@ -369,7 +369,7 @@ open class HttpRequestTestBase: XCTestCase {
             )
             XCTAssertTrue(values.contains(expectedQueryItem.value),
                           """
-                          expected query item not found.
+                          expected query item value not found for \"\(expectedQueryItem.name)\".
                           Expected Value: \(expectedQueryItem.value ?? "nil")
                           Actual Values: \(values)
                           """,

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/formurl/MemberShapeEncodeFormURLGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/formurl/MemberShapeEncodeFormURLGenerator.kt
@@ -353,7 +353,7 @@ abstract class MemberShapeEncodeFormURLGenerator(
     fun renderTimestampMember(member: MemberShape, memberTarget: TimestampShape, containerName: String) {
         val symbol = ctx.symbolProvider.toSymbol(memberTarget)
         val memberName = ctx.symbolProvider.toMemberName(member)
-        val resolvedMemberName = customizations.customNameTraitGenerator(member, memberName)
+        val resolvedMemberName = customizations.customNameTraitGenerator(member, member.memberName)
         val isBoxed = symbol.isBoxed()
         val codingKey = "${ClientRuntimeTypes.Serde.Key}(\"$resolvedMemberName\")"
         if (isBoxed) {


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1121

## Description of changes
When generating the serializer for `x-www-url-encoded` forms, the "lowerCamelCase" form of the member name is used when serializing timestamps.  This can cause errors at the server because the field name does not have the correct capitalization.
- This change uses the original member name to construct the form, so that URL-encoded forms containing timestamps may be read.
- Protocol tests for proper request serialization are in the corresponding `aws-sdk-swift` PR: https://github.com/awslabs/aws-sdk-swift/pull/1137

Also: Improve the messaging when a protocol test fails with non-matching query string parameters.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.