### PR TITLE
feat: make connectTimeoutMs configurable

### DIFF
--- a/Sources/ClientRuntime/Config/DefaultSDKRuntimeConfiguration.swift
+++ b/Sources/ClientRuntime/Config/DefaultSDKRuntimeConfiguration.swift
@@ -90,6 +90,13 @@ public extension DefaultSDKRuntimeConfiguration {
     /// Is the CRT HTTP client.
     static var defaultHttpClientEngine: HttpClientEngine { CRTClientEngine() }
 
+    /// The default HTTP client with a specified timeout
+    ///
+    /// Is the CRT HTTP client.
+    static func httpClientEngineWithTimeout(timeoutMs: UInt32) -> HttpClientEngine {
+        return CRTClientEngine(config: CRTClientEngineConfig(connectTimeoutMs: timeoutMs))
+    }
+
     /// The HTTP client configuration to use when none is provided.
     ///
     /// Is the CRT HTTP client's configuration.

--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngineConfig.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngineConfig.swift
@@ -17,13 +17,18 @@ struct CRTClientEngineConfig {
     /// If you set this in server mode, it enforces client authentication.
     let verifyPeer: Bool
 
+    /// Timeout in MS for connections
+    let connectTimeoutMs: UInt32?
+
     public init(
         maxConnectionsPerEndpoint: Int = 50,
         windowSize: Int = 16 * 1024 * 1024,
-        verifyPeer: Bool = true
+        verifyPeer: Bool = true,
+        connectTimeoutMs: UInt32? = nil
     ) {
         self.maxConnectionsPerEndpoint = maxConnectionsPerEndpoint
         self.windowSize = windowSize
         self.verifyPeer = verifyPeer
+        self.connectTimeoutMs = connectTimeoutMs
     }
 }


### PR DESCRIPTION
Expose connectTimeoutMs so that it is configurable on the client.

## Issue \#
[#1065](https://github.com/awslabs/aws-sdk-swift/issues/1065)
[#1152](https://github.com/awslabs/aws-sdk-swift/pull/1152)

## Description of changes

Ex. Usage
```
// I set timeout to 15_000 as an example but this could be any UInt32 number
let httpClientConfiguration = HttpClientConfiguration()
let crtEngine = CRTClientEngine(CRTClientEngineConfig(connectTimeoutMs: 15_000))
let httpClient = SdkHttpClient(engine: crtEngine, config: httpClientConfiguration)
```

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.