### PR TITLE
feat: add stored property for adding additional headers in SdkHttpRequest

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
+++ b/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
@@ -46,11 +46,11 @@ public class SdkHttpRequest {
         return builder
     }
 
-    public func withHeader(name: String, value: String) -> Void {
+    public func withHeader(name: String, value: String) {
         self.additionalHeaders.add(name: name, value: value)
     }
 
-    public func withoutHeader(name: String) -> Void {
+    public func withoutHeader(name: String) {
         self.additionalHeaders.remove(name: name)
     }
 }

--- a/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
+++ b/Sources/ClientRuntime/Networking/Http/SdkHttpRequest.swift
@@ -13,7 +13,12 @@ public class SdkHttpRequest {
     public let body: HttpBody
     public let endpoint: Endpoint
     public let method: HttpMethodType
-    public var headers: Headers { endpoint.headers ?? Headers() }
+    private var additionalHeaders: Headers = Headers()
+    public var headers: Headers {
+        var allHeaders = endpoint.headers ?? Headers()
+        allHeaders.addAll(headers: additionalHeaders)
+        return allHeaders
+    }
     public var path: String { endpoint.path }
     public var host: String { endpoint.host }
     public var queryItems: [URLQueryItem]? { endpoint.queryItems }
@@ -39,6 +44,14 @@ public class SdkHttpRequest {
             builder.withQueryItems(qItems)
         }
         return builder
+    }
+
+    public func withHeader(name: String, value: String) -> Void {
+        self.additionalHeaders.add(name: name, value: value)
+    }
+
+    public func withoutHeader(name: String) -> Void {
+        self.additionalHeaders.remove(name: name)
     }
 }
 

--- a/Tests/ClientRuntimeTests/NetworkingTests/HttpRequestTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/HttpRequestTests.swift
@@ -20,19 +20,30 @@ class HttpRequestTests: NetworkingTestUtils {
 
         let httpBody = HttpBody.data(expectedMockRequestData)
         let mockHttpRequest = SdkHttpRequest(method: .get, endpoint: endpoint, body: httpBody)
+        mockHttpRequest.withHeader(name: "foo", value: "bar")
         let httpRequest = try mockHttpRequest.toHttpRequest()
 
         XCTAssertNotNil(httpRequest)
         let headersFromRequest = httpRequest.getHeaders()
         XCTAssertNotNil(headers)
-        for index in 0...(httpRequest.headerCount - 1) {
 
+        // Check headers
+        var additionalHeaderFound = false
+        for index in 0...(httpRequest.headerCount - 1) {
             let header1 = headersFromRequest[index]
             let header2 = mockHttpRequest.headers.headers[index]
+
+            // Check for additional header
+            if header1.name == "foo" {
+                XCTAssertEqual(header1.value, "bar")
+                additionalHeaderFound = true
+            }
+
             XCTAssertEqual(header1.name, header2.name)
             XCTAssertEqual(header1.value, header2.value.joined(separator: ","))
         }
 
+        XCTAssertTrue(additionalHeaderFound, "Additional header 'foo' not found in httpRequest")
         XCTAssertEqual(httpRequest.method, "GET")
 
         if let bodyLength = try httpRequest.body?.length() {


### PR DESCRIPTION
Provide the ability to add additional headers to an existing request of type SdkHttpRequest.

## Issue \#
[#1130](https://github.com/awslabs/aws-sdk-swift/issues/1130)
#583 

## Description of changes
Cause: `headers` is already a mutable property but it is computed without any stored values. This means that a customer who attempts to modify headers will either have no effect (because computed properties are read-only) or because it points to an instance of `endpoint.headers` whose headers are immutable. 

Solution: Add `additionalHeaders` stored property which is mutable and provide add/removal methods.

Risk: Computed properties ensure that the request is never modified in-transit. In order to reduce any risk associated I have chosen to add a new property that is mutable, stores values, and provided my own setters rather than modify the existing property to no longer be computed. Additionally, we should remove this functionality once Swift SDK SRA-compliant with interceptors ([#307](https://github.com/awslabs/aws-sdk-swift/issues/307))

How to use:
```
class MyHTTPClientEngineProxy: HttpClientEngine {
    let base: HttpClientEngine

    init(base: HttpClientEngine) {
        self.base = base
    }

    func execute(request: SdkHttpRequest) async throws -> HttpResponse {
        request.withHeader(name: "foo", value: "bar")
        return try await base.execute(request: request)
    }
}
```

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.