### PR TITLE
fix!: Remove suffix 'Response' from operation output type names

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/AddOperationShapes.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/AddOperationShapes.kt
@@ -54,10 +54,10 @@ class AddOperationShapes {
                     .map { shapeId ->
                         cloneOperationShape(
                             operationId, (model.expectShape(shapeId) as StructureShape),
-                            "OutputResponse"
+                            "Output"
                         )
                     }
-                    .orElseGet { emptyOperationStructure(operationId, "OutputResponse", moduleName) }
+                    .orElseGet { emptyOperationStructure(operationId, "Output", moduleName) }
 
                 // Add new input/output to model
                 modelBuilder.addShape(inputShape)

--- a/smithy-swift-codegen/src/test/kotlin/ContentMd5MiddlewareTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ContentMd5MiddlewareTests.kt
@@ -13,8 +13,8 @@ class ContentMd5MiddlewareTests {
                 ///
                 /// - Parameter IdempotencyTokenWithStructureInput : [no documentation found]
                 ///
-                /// - Returns: `IdempotencyTokenWithStructureOutputResponse` : [no documentation found]
-                public func idempotencyTokenWithStructure(input: IdempotencyTokenWithStructureInput) async throws -> IdempotencyTokenWithStructureOutputResponse
+                /// - Returns: `IdempotencyTokenWithStructureOutput` : [no documentation found]
+                public func idempotencyTokenWithStructure(input: IdempotencyTokenWithStructureInput) async throws -> IdempotencyTokenWithStructureOutput
                 {
                     let context = ClientRuntime.HttpContextBuilder()
                                   .withEncoder(value: encoder)
@@ -26,8 +26,8 @@ class ContentMd5MiddlewareTests {
                                   .withLogger(value: config.logger)
                                   .withPartitionID(value: config.partitionID)
                                   .build()
-                    var operation = ClientRuntime.OperationStack<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>(id: "idempotencyTokenWithStructure")
-                    operation.initializeStep.intercept(position: .after, id: "IdempotencyTokenMiddleware") { (context, input, next) -> ClientRuntime.OperationOutput<IdempotencyTokenWithStructureOutputResponse> in
+                    var operation = ClientRuntime.OperationStack<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>(id: "idempotencyTokenWithStructure")
+                    operation.initializeStep.intercept(position: .after, id: "IdempotencyTokenMiddleware") { (context, input, next) -> ClientRuntime.OperationOutput<IdempotencyTokenWithStructureOutput> in
                         let idempotencyTokenGenerator = context.getIdempotencyTokenGenerator()
                         var copiedInput = input
                         if input.token == nil {
@@ -35,15 +35,15 @@ class ContentMd5MiddlewareTests {
                         }
                         return try await next.handle(context: context, input: copiedInput)
                     }
-                    operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>())
-                    operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>())
-                    operation.buildStep.intercept(position: .before, middleware: ClientRuntime.ContentMD5Middleware<IdempotencyTokenWithStructureOutputResponse>())
-                    operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>(contentType: "application/xml"))
-                    operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>(xmlName: "IdempotencyToken"))
+                    operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>())
+                    operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput>())
+                    operation.buildStep.intercept(position: .before, middleware: ClientRuntime.ContentMD5Middleware<IdempotencyTokenWithStructureOutput>())
+                    operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput>(contentType: "application/xml"))
+                    operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput>(xmlName: "IdempotencyToken"))
                     operation.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
-                    operation.finalizeStep.intercept(position: .after, middleware: ClientRuntime.RetryMiddleware<ClientRuntime.DefaultRetryStrategy, ClientRuntime.DefaultRetryErrorInfoProvider, IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>(options: config.retryStrategyOptions))
-                    operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware<IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>())
-                    operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.LoggerMiddleware<IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>(clientLogMode: config.clientLogMode))
+                    operation.finalizeStep.intercept(position: .after, middleware: ClientRuntime.RetryMiddleware<ClientRuntime.DefaultRetryStrategy, ClientRuntime.DefaultRetryErrorInfoProvider, IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>(options: config.retryStrategyOptions))
+                    operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware<IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>())
+                    operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.LoggerMiddleware<IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>(clientLogMode: config.clientLogMode))
                     let result = try await operation.handleMiddleware(context: context, input: input, next: client.getHandler())
                     return result
                 }

--- a/smithy-swift-codegen/src/test/kotlin/HttpBindingProtocolGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpBindingProtocolGeneratorTests.kt
@@ -66,11 +66,11 @@ class HttpBindingProtocolGeneratorTests {
 
     @Test
     fun `it creates correct init for explicit struct payloads`() {
-        val contents = getModelFileContents("example", "ExplicitStructOutputResponse+HttpResponseBinding.swift", newTestContext.manifest)
+        val contents = getModelFileContents("example", "ExplicitStructOutput+HttpResponseBinding.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-extension ExplicitStructOutputResponse: ClientRuntime.HttpResponseBinding {
+extension ExplicitStructOutput: ClientRuntime.HttpResponseBinding {
     public init(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws {
         if let data = try await httpResponse.body.readData(), let responseDecoder = decoder {
             let output: Nested2 = try responseDecoder.decode(responseBody: data)
@@ -92,12 +92,12 @@ extension ExplicitStructOutputResponse: ClientRuntime.HttpResponseBinding {
     }
 
     @Test
-    fun `httpResponseCodeOutputResponse response init content`() {
-        val contents = getModelFileContents("example", "HttpResponseCodeOutputResponse+HttpResponseBinding.swift", newTestContext.manifest)
+    fun `httpResponseCodeOutput response init content`() {
+        val contents = getModelFileContents("example", "HttpResponseCodeOutput+HttpResponseBinding.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-extension HttpResponseCodeOutputResponse: ClientRuntime.HttpResponseBinding {
+extension HttpResponseCodeOutput: ClientRuntime.HttpResponseBinding {
     public init(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws {
         self.status = httpResponse.statusCode.rawValue
     }
@@ -108,11 +108,11 @@ extension HttpResponseCodeOutputResponse: ClientRuntime.HttpResponseBinding {
 
     @Test
     fun `decode the document type in HttpResponseBinding`() {
-        val contents = getModelFileContents("example", "InlineDocumentAsPayloadOutputResponse+HttpResponseBinding.swift", newTestContext.manifest)
+        val contents = getModelFileContents("example", "InlineDocumentAsPayloadOutput+HttpResponseBinding.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-extension InlineDocumentAsPayloadOutputResponse: ClientRuntime.HttpResponseBinding {
+extension InlineDocumentAsPayloadOutput: ClientRuntime.HttpResponseBinding {
     public init(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws {
         if let data = try await httpResponse.body.readData(), let responseDecoder = decoder {
             let output: ClientRuntime.Document = try responseDecoder.decode(responseBody: data)
@@ -127,10 +127,10 @@ extension InlineDocumentAsPayloadOutputResponse: ClientRuntime.HttpResponseBindi
     }
     @Test
     fun `default fooMap to an empty map if keysForFooMap is empty`() {
-        val contents = getModelFileContents("example", "HttpPrefixHeadersOutputResponse+HttpResponseBinding.swift", newTestContext.manifest)
+        val contents = getModelFileContents("example", "HttpPrefixHeadersOutput+HttpResponseBinding.swift", newTestContext.manifest)
         val expectedContents =
             """
-            extension HttpPrefixHeadersOutputResponse: ClientRuntime.HttpResponseBinding {
+            extension HttpPrefixHeadersOutput: ClientRuntime.HttpResponseBinding {
                 public init(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws {
                     if let fooHeaderValue = httpResponse.headers.value(for: "X-Foo") {
                         self.foo = fooHeaderValue

--- a/smithy-swift-codegen/src/test/kotlin/HttpBodyMiddlewareTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpBodyMiddlewareTests.kt
@@ -37,7 +37,7 @@ class HttpBodyMiddlewareTests {
             
                 public func handle<H>(context: Context,
                               input: ClientRuntime.SerializeStepInput<ExplicitStringInput>,
-                              next: H) async throws -> ClientRuntime.OperationOutput<ExplicitStringOutputResponse>
+                              next: H) async throws -> ClientRuntime.OperationOutput<ExplicitStringOutput>
                 where H: Handler,
                 Self.MInput == H.Input,
                 Self.MOutput == H.Output,
@@ -52,7 +52,7 @@ class HttpBodyMiddlewareTests {
                 }
             
                 public typealias MInput = ClientRuntime.SerializeStepInput<ExplicitStringInput>
-                public typealias MOutput = ClientRuntime.OperationOutput<ExplicitStringOutputResponse>
+                public typealias MOutput = ClientRuntime.OperationOutput<ExplicitStringOutput>
                 public typealias Context = ClientRuntime.HttpContext
             }
             """.trimIndent()
@@ -72,7 +72,7 @@ class HttpBodyMiddlewareTests {
             
                 public func handle<H>(context: Context,
                               input: ClientRuntime.SerializeStepInput<ExplicitBlobInput>,
-                              next: H) async throws -> ClientRuntime.OperationOutput<ExplicitBlobOutputResponse>
+                              next: H) async throws -> ClientRuntime.OperationOutput<ExplicitBlobOutput>
                 where H: Handler,
                 Self.MInput == H.Input,
                 Self.MOutput == H.Output,
@@ -87,7 +87,7 @@ class HttpBodyMiddlewareTests {
                 }
             
                 public typealias MInput = ClientRuntime.SerializeStepInput<ExplicitBlobInput>
-                public typealias MOutput = ClientRuntime.OperationOutput<ExplicitBlobOutputResponse>
+                public typealias MOutput = ClientRuntime.OperationOutput<ExplicitBlobOutput>
                 public typealias Context = ClientRuntime.HttpContext
             }
             """.trimIndent()
@@ -107,7 +107,7 @@ class HttpBodyMiddlewareTests {
             
                 public func handle<H>(context: Context,
                               input: ClientRuntime.SerializeStepInput<ExplicitBlobStreamInput>,
-                              next: H) async throws -> ClientRuntime.OperationOutput<ExplicitBlobStreamOutputResponse>
+                              next: H) async throws -> ClientRuntime.OperationOutput<ExplicitBlobStreamOutput>
                 where H: Handler,
                 Self.MInput == H.Input,
                 Self.MOutput == H.Output,
@@ -121,7 +121,7 @@ class HttpBodyMiddlewareTests {
                 }
             
                 public typealias MInput = ClientRuntime.SerializeStepInput<ExplicitBlobStreamInput>
-                public typealias MOutput = ClientRuntime.OperationOutput<ExplicitBlobStreamOutputResponse>
+                public typealias MOutput = ClientRuntime.OperationOutput<ExplicitBlobStreamOutput>
                 public typealias Context = ClientRuntime.HttpContext
             }
             """.trimIndent()
@@ -141,7 +141,7 @@ class HttpBodyMiddlewareTests {
             
                 public func handle<H>(context: Context,
                               input: ClientRuntime.SerializeStepInput<ExplicitStructInput>,
-                              next: H) async throws -> ClientRuntime.OperationOutput<ExplicitStructOutputResponse>
+                              next: H) async throws -> ClientRuntime.OperationOutput<ExplicitStructOutput>
                 where H: Handler,
                 Self.MInput == H.Input,
                 Self.MOutput == H.Output,
@@ -168,7 +168,7 @@ class HttpBodyMiddlewareTests {
                 }
             
                 public typealias MInput = ClientRuntime.SerializeStepInput<ExplicitStructInput>
-                public typealias MOutput = ClientRuntime.OperationOutput<ExplicitStructOutputResponse>
+                public typealias MOutput = ClientRuntime.OperationOutput<ExplicitStructOutput>
                 public typealias Context = ClientRuntime.HttpContext
             }
             """.trimIndent()

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
@@ -111,8 +111,8 @@ class HttpProtocolClientGeneratorTests {
             ///
             /// - Parameter AllocateWidgetInput : [no documentation found]
             ///
-            /// - Returns: `AllocateWidgetOutputResponse` : [no documentation found]
-            public func allocateWidget(input: AllocateWidgetInput) async throws -> AllocateWidgetOutputResponse
+            /// - Returns: `AllocateWidgetOutput` : [no documentation found]
+            public func allocateWidget(input: AllocateWidgetInput) async throws -> AllocateWidgetOutput
             {
                 let context = ClientRuntime.HttpContextBuilder()
                               .withEncoder(value: encoder)
@@ -124,8 +124,8 @@ class HttpProtocolClientGeneratorTests {
                               .withLogger(value: config.logger)
                               .withPartitionID(value: config.partitionID)
                               .build()
-                var operation = ClientRuntime.OperationStack<AllocateWidgetInput, AllocateWidgetOutputResponse, AllocateWidgetOutputError>(id: "allocateWidget")
-                operation.initializeStep.intercept(position: .after, id: "IdempotencyTokenMiddleware") { (context, input, next) -> ClientRuntime.OperationOutput<AllocateWidgetOutputResponse> in
+                var operation = ClientRuntime.OperationStack<AllocateWidgetInput, AllocateWidgetOutput, AllocateWidgetOutputError>(id: "allocateWidget")
+                operation.initializeStep.intercept(position: .after, id: "IdempotencyTokenMiddleware") { (context, input, next) -> ClientRuntime.OperationOutput<AllocateWidgetOutput> in
                     let idempotencyTokenGenerator = context.getIdempotencyTokenGenerator()
                     var copiedInput = input
                     if input.clientToken == nil {
@@ -133,14 +133,14 @@ class HttpProtocolClientGeneratorTests {
                     }
                     return try await next.handle(context: context, input: copiedInput)
                 }
-                operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<AllocateWidgetInput, AllocateWidgetOutputResponse, AllocateWidgetOutputError>())
-                operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<AllocateWidgetInput, AllocateWidgetOutputResponse>())
-                operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<AllocateWidgetInput, AllocateWidgetOutputResponse>(contentType: "application/json"))
-                operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<AllocateWidgetInput, AllocateWidgetOutputResponse>(xmlName: "AllocateWidgetInput"))
+                operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<AllocateWidgetInput, AllocateWidgetOutput, AllocateWidgetOutputError>())
+                operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<AllocateWidgetInput, AllocateWidgetOutput>())
+                operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<AllocateWidgetInput, AllocateWidgetOutput>(contentType: "application/json"))
+                operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<AllocateWidgetInput, AllocateWidgetOutput>(xmlName: "AllocateWidgetInput"))
                 operation.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
-                operation.finalizeStep.intercept(position: .after, middleware: ClientRuntime.RetryMiddleware<ClientRuntime.DefaultRetryStrategy, ClientRuntime.DefaultRetryErrorInfoProvider, AllocateWidgetOutputResponse, AllocateWidgetOutputError>(options: config.retryStrategyOptions))
-                operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware<AllocateWidgetOutputResponse, AllocateWidgetOutputError>())
-                operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.LoggerMiddleware<AllocateWidgetOutputResponse, AllocateWidgetOutputError>(clientLogMode: config.clientLogMode))
+                operation.finalizeStep.intercept(position: .after, middleware: ClientRuntime.RetryMiddleware<ClientRuntime.DefaultRetryStrategy, ClientRuntime.DefaultRetryErrorInfoProvider, AllocateWidgetOutput, AllocateWidgetOutputError>(options: config.retryStrategyOptions))
+                operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware<AllocateWidgetOutput, AllocateWidgetOutputError>())
+                operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.LoggerMiddleware<AllocateWidgetOutput, AllocateWidgetOutputError>(clientLogMode: config.clientLogMode))
                 let result = try await operation.handleMiddleware(context: context, input: input, next: client.getHandler())
                 return result
             }

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolUnitTestRequestGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolUnitTestRequestGeneratorTests.kt
@@ -82,23 +82,23 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                       .withEncoder(value: encoder)
                       .withMethod(value: .post)
                       .build()
-        var operationStack = OperationStack<SmokeTestInput, SmokeTestOutputResponse, SmokeTestOutputError>(id: "SmokeTest")
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<SmokeTestInput, SmokeTestOutputResponse, SmokeTestOutputError>(urlPrefix: urlPrefix))
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<SmokeTestInput, SmokeTestOutputResponse>(host: hostOnly))
-        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<SmokeTestOutputResponse> in
+        var operationStack = OperationStack<SmokeTestInput, SmokeTestOutput, SmokeTestOutputError>(id: "SmokeTest")
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<SmokeTestInput, SmokeTestOutput, SmokeTestOutputError>(urlPrefix: urlPrefix))
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<SmokeTestInput, SmokeTestOutput>(host: hostOnly))
+        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<SmokeTestOutput> in
             input.withMethod(context.getMethod())
             input.withPath(context.getPath())
             let host = "\(context.getHostPrefix() ?? "")\(context.getHost() ?? "")"
             input.withHost(host)
             return try await next.handle(context: context, input: input)
         }
-        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.HeaderMiddleware<SmokeTestInput, SmokeTestOutputResponse>())
-        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.QueryItemMiddleware<SmokeTestInput, SmokeTestOutputResponse>())
-        operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<SmokeTestInput, SmokeTestOutputResponse>(contentType: "application/json"))
-        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<SmokeTestInput, SmokeTestOutputResponse>(xmlName: "SmokeTestRequest"))
+        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.HeaderMiddleware<SmokeTestInput, SmokeTestOutput>())
+        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.QueryItemMiddleware<SmokeTestInput, SmokeTestOutput>())
+        operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<SmokeTestInput, SmokeTestOutput>(contentType: "application/json"))
+        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<SmokeTestInput, SmokeTestOutput>(xmlName: "SmokeTestRequest"))
         operationStack.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
         operationStack.deserializeStep.intercept(position: .after,
-                     middleware: MockDeserializeMiddleware<SmokeTestOutputResponse, SmokeTestOutputError>(
+                     middleware: MockDeserializeMiddleware<SmokeTestOutput, SmokeTestOutputError>(
                              id: "TestDeserializeMiddleware"){ context, actual in
             try await self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
@@ -117,8 +117,8 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                 }
             })
             let response = HttpResponse(body: HttpBody.none, statusCode: .ok)
-            let mockOutput = try await SmokeTestOutputResponse(httpResponse: response, decoder: nil)
-            let output = OperationOutput<SmokeTestOutputResponse>(httpResponse: response, output: mockOutput)
+            let mockOutput = try await SmokeTestOutput(httpResponse: response, decoder: nil)
+            let output = OperationOutput<SmokeTestOutput>(httpResponse: response, output: mockOutput)
             return output
         })
         _ = try await operationStack.handleMiddleware(context: context, input: input, next: MockHandler(){ (context, request) in
@@ -170,21 +170,21 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                       .withEncoder(value: encoder)
                       .withMethod(value: .post)
                       .build()
-        var operationStack = OperationStack<ExplicitStringInput, ExplicitStringOutputResponse, ExplicitStringOutputError>(id: "ExplicitString")
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<ExplicitStringInput, ExplicitStringOutputResponse, ExplicitStringOutputError>(urlPrefix: urlPrefix))
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<ExplicitStringInput, ExplicitStringOutputResponse>(host: hostOnly))
-        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<ExplicitStringOutputResponse> in
+        var operationStack = OperationStack<ExplicitStringInput, ExplicitStringOutput, ExplicitStringOutputError>(id: "ExplicitString")
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<ExplicitStringInput, ExplicitStringOutput, ExplicitStringOutputError>(urlPrefix: urlPrefix))
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<ExplicitStringInput, ExplicitStringOutput>(host: hostOnly))
+        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<ExplicitStringOutput> in
             input.withMethod(context.getMethod())
             input.withPath(context.getPath())
             let host = "\(context.getHostPrefix() ?? "")\(context.getHost() ?? "")"
             input.withHost(host)
             return try await next.handle(context: context, input: input)
         }
-        operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<ExplicitStringInput, ExplicitStringOutputResponse>(contentType: "text/plain"))
+        operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<ExplicitStringInput, ExplicitStringOutput>(contentType: "text/plain"))
         operationStack.serializeStep.intercept(position: .after, middleware: ExplicitStringInputBodyMiddleware())
         operationStack.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
         operationStack.deserializeStep.intercept(position: .after,
-                     middleware: MockDeserializeMiddleware<ExplicitStringOutputResponse, ExplicitStringOutputError>(
+                     middleware: MockDeserializeMiddleware<ExplicitStringOutput, ExplicitStringOutputError>(
                              id: "TestDeserializeMiddleware"){ context, actual in
             try await self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
@@ -194,8 +194,8 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                 }
             })
             let response = HttpResponse(body: HttpBody.none, statusCode: .ok)
-            let mockOutput = try await ExplicitStringOutputResponse(httpResponse: response, decoder: nil)
-            let output = OperationOutput<ExplicitStringOutputResponse>(httpResponse: response, output: mockOutput)
+            let mockOutput = try await ExplicitStringOutput(httpResponse: response, decoder: nil)
+            let output = OperationOutput<ExplicitStringOutput>(httpResponse: response, output: mockOutput)
             return output
         })
         _ = try await operationStack.handleMiddleware(context: context, input: input, next: MockHandler(){ (context, request) in
@@ -239,10 +239,10 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                       .withEncoder(value: encoder)
                       .withMethod(value: .post)
                       .build()
-        var operationStack = OperationStack<EmptyInputAndEmptyOutputInput, EmptyInputAndEmptyOutputOutputResponse, EmptyInputAndEmptyOutputOutputError>(id: "RestJsonEmptyInputAndEmptyOutput")
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<EmptyInputAndEmptyOutputInput, EmptyInputAndEmptyOutputOutputResponse, EmptyInputAndEmptyOutputOutputError>(urlPrefix: urlPrefix))
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<EmptyInputAndEmptyOutputInput, EmptyInputAndEmptyOutputOutputResponse>(host: hostOnly))
-        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<EmptyInputAndEmptyOutputOutputResponse> in
+        var operationStack = OperationStack<EmptyInputAndEmptyOutputInput, EmptyInputAndEmptyOutputOutput, EmptyInputAndEmptyOutputOutputError>(id: "RestJsonEmptyInputAndEmptyOutput")
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<EmptyInputAndEmptyOutputInput, EmptyInputAndEmptyOutputOutput, EmptyInputAndEmptyOutputOutputError>(urlPrefix: urlPrefix))
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<EmptyInputAndEmptyOutputInput, EmptyInputAndEmptyOutputOutput>(host: hostOnly))
+        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<EmptyInputAndEmptyOutputOutput> in
             input.withMethod(context.getMethod())
             input.withPath(context.getPath())
             let host = "\(context.getHostPrefix() ?? "")\(context.getHost() ?? "")"
@@ -250,12 +250,12 @@ class HttpProtocolUnitTestRequestGeneratorTests {
             return try await next.handle(context: context, input: input)
         }
         operationStack.deserializeStep.intercept(position: .after,
-                     middleware: MockDeserializeMiddleware<EmptyInputAndEmptyOutputOutputResponse, EmptyInputAndEmptyOutputOutputError>(
+                     middleware: MockDeserializeMiddleware<EmptyInputAndEmptyOutputOutput, EmptyInputAndEmptyOutputOutputError>(
                              id: "TestDeserializeMiddleware"){ context, actual in
             try await self.assertEqual(expected, actual)
             let response = HttpResponse(body: HttpBody.none, statusCode: .ok)
-            let mockOutput = try await EmptyInputAndEmptyOutputOutputResponse(httpResponse: response, decoder: nil)
-            let output = OperationOutput<EmptyInputAndEmptyOutputOutputResponse>(httpResponse: response, output: mockOutput)
+            let mockOutput = try await EmptyInputAndEmptyOutputOutput(httpResponse: response, decoder: nil)
+            let output = OperationOutput<EmptyInputAndEmptyOutputOutput>(httpResponse: response, output: mockOutput)
             return output
         })
         _ = try await operationStack.handleMiddleware(context: context, input: input, next: MockHandler(){ (context, request) in
@@ -305,22 +305,22 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                       .withEncoder(value: encoder)
                       .withMethod(value: .put)
                       .build()
-        var operationStack = OperationStack<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutputResponse, SimpleScalarPropertiesOutputError>(id: "RestJsonDoesntSerializeNullStructureValues")
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutputResponse, SimpleScalarPropertiesOutputError>(urlPrefix: urlPrefix))
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutputResponse>(host: hostOnly))
-        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<SimpleScalarPropertiesOutputResponse> in
+        var operationStack = OperationStack<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutput, SimpleScalarPropertiesOutputError>(id: "RestJsonDoesntSerializeNullStructureValues")
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutput, SimpleScalarPropertiesOutputError>(urlPrefix: urlPrefix))
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutput>(host: hostOnly))
+        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<SimpleScalarPropertiesOutput> in
             input.withMethod(context.getMethod())
             input.withPath(context.getPath())
             let host = "\(context.getHostPrefix() ?? "")\(context.getHost() ?? "")"
             input.withHost(host)
             return try await next.handle(context: context, input: input)
         }
-        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.HeaderMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutputResponse>())
-        operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutputResponse>(contentType: "application/json"))
-        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutputResponse>(xmlName: "SimpleScalarPropertiesInputOutput"))
+        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.HeaderMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutput>())
+        operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutput>(contentType: "application/json"))
+        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<SimpleScalarPropertiesInput, SimpleScalarPropertiesOutput>(xmlName: "SimpleScalarPropertiesInputOutput"))
         operationStack.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
         operationStack.deserializeStep.intercept(position: .after,
-                     middleware: MockDeserializeMiddleware<SimpleScalarPropertiesOutputResponse, SimpleScalarPropertiesOutputError>(
+                     middleware: MockDeserializeMiddleware<SimpleScalarPropertiesOutput, SimpleScalarPropertiesOutputError>(
                              id: "TestDeserializeMiddleware"){ context, actual in
             try await self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
@@ -344,8 +344,8 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                 }
             })
             let response = HttpResponse(body: HttpBody.none, statusCode: .ok)
-            let mockOutput = try await SimpleScalarPropertiesOutputResponse(httpResponse: response, decoder: nil)
-            let output = OperationOutput<SimpleScalarPropertiesOutputResponse>(httpResponse: response, output: mockOutput)
+            let mockOutput = try await SimpleScalarPropertiesOutput(httpResponse: response, decoder: nil)
+            let output = OperationOutput<SimpleScalarPropertiesOutput>(httpResponse: response, output: mockOutput)
             return output
         })
         _ = try await operationStack.handleMiddleware(context: context, input: input, next: MockHandler(){ (context, request) in
@@ -397,22 +397,22 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                       .withEncoder(value: encoder)
                       .withMethod(value: .post)
                       .build()
-        var operationStack = OperationStack<StreamingTraitsInput, StreamingTraitsOutputResponse, StreamingTraitsOutputError>(id: "RestJsonStreamingTraitsWithBlob")
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<StreamingTraitsInput, StreamingTraitsOutputResponse, StreamingTraitsOutputError>(urlPrefix: urlPrefix))
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<StreamingTraitsInput, StreamingTraitsOutputResponse>(host: hostOnly))
-        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<StreamingTraitsOutputResponse> in
+        var operationStack = OperationStack<StreamingTraitsInput, StreamingTraitsOutput, StreamingTraitsOutputError>(id: "RestJsonStreamingTraitsWithBlob")
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<StreamingTraitsInput, StreamingTraitsOutput, StreamingTraitsOutputError>(urlPrefix: urlPrefix))
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<StreamingTraitsInput, StreamingTraitsOutput>(host: hostOnly))
+        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<StreamingTraitsOutput> in
             input.withMethod(context.getMethod())
             input.withPath(context.getPath())
             let host = "\(context.getHostPrefix() ?? "")\(context.getHost() ?? "")"
             input.withHost(host)
             return try await next.handle(context: context, input: input)
         }
-        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.HeaderMiddleware<StreamingTraitsInput, StreamingTraitsOutputResponse>())
-        operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<StreamingTraitsInput, StreamingTraitsOutputResponse>(contentType: "application/octet-stream"))
+        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.HeaderMiddleware<StreamingTraitsInput, StreamingTraitsOutput>())
+        operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<StreamingTraitsInput, StreamingTraitsOutput>(contentType: "application/octet-stream"))
         operationStack.serializeStep.intercept(position: .after, middleware: StreamingTraitsInputBodyMiddleware())
         operationStack.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
         operationStack.deserializeStep.intercept(position: .after,
-                     middleware: MockDeserializeMiddleware<StreamingTraitsOutputResponse, StreamingTraitsOutputError>(
+                     middleware: MockDeserializeMiddleware<StreamingTraitsOutput, StreamingTraitsOutputError>(
                              id: "TestDeserializeMiddleware"){ context, actual in
             try await self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
@@ -422,8 +422,8 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                 }
             })
             let response = HttpResponse(body: HttpBody.none, statusCode: .ok)
-            let mockOutput = try await StreamingTraitsOutputResponse(httpResponse: response, decoder: nil)
-            let output = OperationOutput<StreamingTraitsOutputResponse>(httpResponse: response, output: mockOutput)
+            let mockOutput = try await StreamingTraitsOutput(httpResponse: response, decoder: nil)
+            let output = OperationOutput<StreamingTraitsOutput>(httpResponse: response, output: mockOutput)
             return output
         })
         _ = try await operationStack.handleMiddleware(context: context, input: input, next: MockHandler(){ (context, request) in
@@ -473,24 +473,24 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                       .withEncoder(value: encoder)
                       .withMethod(value: .get)
                       .build()
-        var operationStack = OperationStack<HttpPrefixHeadersInput, HttpPrefixHeadersOutputResponse, HttpPrefixHeadersOutputError>(id: "RestJsonHttpPrefixHeadersAreNotPresent")
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<HttpPrefixHeadersInput, HttpPrefixHeadersOutputResponse, HttpPrefixHeadersOutputError>(urlPrefix: urlPrefix))
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<HttpPrefixHeadersInput, HttpPrefixHeadersOutputResponse>(host: hostOnly))
-        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<HttpPrefixHeadersOutputResponse> in
+        var operationStack = OperationStack<HttpPrefixHeadersInput, HttpPrefixHeadersOutput, HttpPrefixHeadersOutputError>(id: "RestJsonHttpPrefixHeadersAreNotPresent")
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<HttpPrefixHeadersInput, HttpPrefixHeadersOutput, HttpPrefixHeadersOutputError>(urlPrefix: urlPrefix))
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<HttpPrefixHeadersInput, HttpPrefixHeadersOutput>(host: hostOnly))
+        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<HttpPrefixHeadersOutput> in
             input.withMethod(context.getMethod())
             input.withPath(context.getPath())
             let host = "\(context.getHostPrefix() ?? "")\(context.getHost() ?? "")"
             input.withHost(host)
             return try await next.handle(context: context, input: input)
         }
-        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.HeaderMiddleware<HttpPrefixHeadersInput, HttpPrefixHeadersOutputResponse>())
+        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.HeaderMiddleware<HttpPrefixHeadersInput, HttpPrefixHeadersOutput>())
         operationStack.deserializeStep.intercept(position: .after,
-                     middleware: MockDeserializeMiddleware<HttpPrefixHeadersOutputResponse, HttpPrefixHeadersOutputError>(
+                     middleware: MockDeserializeMiddleware<HttpPrefixHeadersOutput, HttpPrefixHeadersOutputError>(
                              id: "TestDeserializeMiddleware"){ context, actual in
             try await self.assertEqual(expected, actual)
             let response = HttpResponse(body: HttpBody.none, statusCode: .ok)
-            let mockOutput = try await HttpPrefixHeadersOutputResponse(httpResponse: response, decoder: nil)
-            let output = OperationOutput<HttpPrefixHeadersOutputResponse>(httpResponse: response, output: mockOutput)
+            let mockOutput = try await HttpPrefixHeadersOutput(httpResponse: response, decoder: nil)
+            let output = OperationOutput<HttpPrefixHeadersOutput>(httpResponse: response, output: mockOutput)
             return output
         })
         _ = try await operationStack.handleMiddleware(context: context, input: input, next: MockHandler(){ (context, request) in
@@ -545,21 +545,21 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                       .withEncoder(value: encoder)
                       .withMethod(value: .put)
                       .build()
-        var operationStack = OperationStack<JsonUnionsInput, JsonUnionsOutputResponse, JsonUnionsOutputError>(id: "RestJsonSerializeStringUnionValue")
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<JsonUnionsInput, JsonUnionsOutputResponse, JsonUnionsOutputError>(urlPrefix: urlPrefix))
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<JsonUnionsInput, JsonUnionsOutputResponse>(host: hostOnly))
-        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<JsonUnionsOutputResponse> in
+        var operationStack = OperationStack<JsonUnionsInput, JsonUnionsOutput, JsonUnionsOutputError>(id: "RestJsonSerializeStringUnionValue")
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<JsonUnionsInput, JsonUnionsOutput, JsonUnionsOutputError>(urlPrefix: urlPrefix))
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<JsonUnionsInput, JsonUnionsOutput>(host: hostOnly))
+        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<JsonUnionsOutput> in
             input.withMethod(context.getMethod())
             input.withPath(context.getPath())
             let host = "\(context.getHostPrefix() ?? "")\(context.getHost() ?? "")"
             input.withHost(host)
             return try await next.handle(context: context, input: input)
         }
-        operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<JsonUnionsInput, JsonUnionsOutputResponse>(contentType: "application/json"))
-        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<JsonUnionsInput, JsonUnionsOutputResponse>(xmlName: "UnionInputOutput"))
+        operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<JsonUnionsInput, JsonUnionsOutput>(contentType: "application/json"))
+        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<JsonUnionsInput, JsonUnionsOutput>(xmlName: "UnionInputOutput"))
         operationStack.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
         operationStack.deserializeStep.intercept(position: .after,
-                     middleware: MockDeserializeMiddleware<JsonUnionsOutputResponse, JsonUnionsOutputError>(
+                     middleware: MockDeserializeMiddleware<JsonUnionsOutput, JsonUnionsOutputError>(
                              id: "TestDeserializeMiddleware"){ context, actual in
             try await self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
@@ -575,8 +575,8 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                 }
             })
             let response = HttpResponse(body: HttpBody.none, statusCode: .ok)
-            let mockOutput = try await JsonUnionsOutputResponse(httpResponse: response, decoder: nil)
-            let output = OperationOutput<JsonUnionsOutputResponse>(httpResponse: response, output: mockOutput)
+            let mockOutput = try await JsonUnionsOutput(httpResponse: response, decoder: nil)
+            let output = OperationOutput<JsonUnionsOutput>(httpResponse: response, output: mockOutput)
             return output
         })
         _ = try await operationStack.handleMiddleware(context: context, input: input, next: MockHandler(){ (context, request) in
@@ -654,21 +654,21 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                       .withEncoder(value: encoder)
                       .withMethod(value: .put)
                       .build()
-        var operationStack = OperationStack<RecursiveShapesInput, RecursiveShapesOutputResponse, RecursiveShapesOutputError>(id: "RestJsonRecursiveShapes")
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<RecursiveShapesInput, RecursiveShapesOutputResponse, RecursiveShapesOutputError>(urlPrefix: urlPrefix))
-        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<RecursiveShapesInput, RecursiveShapesOutputResponse>(host: hostOnly))
-        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<RecursiveShapesOutputResponse> in
+        var operationStack = OperationStack<RecursiveShapesInput, RecursiveShapesOutput, RecursiveShapesOutputError>(id: "RestJsonRecursiveShapes")
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<RecursiveShapesInput, RecursiveShapesOutput, RecursiveShapesOutputError>(urlPrefix: urlPrefix))
+        operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<RecursiveShapesInput, RecursiveShapesOutput>(host: hostOnly))
+        operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<RecursiveShapesOutput> in
             input.withMethod(context.getMethod())
             input.withPath(context.getPath())
             let host = "\(context.getHostPrefix() ?? "")\(context.getHost() ?? "")"
             input.withHost(host)
             return try await next.handle(context: context, input: input)
         }
-        operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<RecursiveShapesInput, RecursiveShapesOutputResponse>(contentType: "application/json"))
-        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<RecursiveShapesInput, RecursiveShapesOutputResponse>(xmlName: "RecursiveShapesInputOutput"))
+        operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<RecursiveShapesInput, RecursiveShapesOutput>(contentType: "application/json"))
+        operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<RecursiveShapesInput, RecursiveShapesOutput>(xmlName: "RecursiveShapesInputOutput"))
         operationStack.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
         operationStack.deserializeStep.intercept(position: .after,
-                     middleware: MockDeserializeMiddleware<RecursiveShapesOutputResponse, RecursiveShapesOutputError>(
+                     middleware: MockDeserializeMiddleware<RecursiveShapesOutput, RecursiveShapesOutputError>(
                              id: "TestDeserializeMiddleware"){ context, actual in
             try await self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                 XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
@@ -684,8 +684,8 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                 }
             })
             let response = HttpResponse(body: HttpBody.none, statusCode: .ok)
-            let mockOutput = try await RecursiveShapesOutputResponse(httpResponse: response, decoder: nil)
-            let output = OperationOutput<RecursiveShapesOutputResponse>(httpResponse: response, output: mockOutput)
+            let mockOutput = try await RecursiveShapesOutput(httpResponse: response, decoder: nil)
+            let output = OperationOutput<RecursiveShapesOutput>(httpResponse: response, output: mockOutput)
             return output
         })
         _ = try await operationStack.handleMiddleware(context: context, input: input, next: MockHandler(){ (context, request) in
@@ -747,21 +747,21 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                           .withEncoder(value: encoder)
                           .withMethod(value: .put)
                           .build()
-            var operationStack = OperationStack<InlineDocumentInput, InlineDocumentOutputResponse, InlineDocumentOutputError>(id: "InlineDocumentInput")
-            operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<InlineDocumentInput, InlineDocumentOutputResponse, InlineDocumentOutputError>(urlPrefix: urlPrefix))
-            operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<InlineDocumentInput, InlineDocumentOutputResponse>(host: hostOnly))
-            operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<InlineDocumentOutputResponse> in
+            var operationStack = OperationStack<InlineDocumentInput, InlineDocumentOutput, InlineDocumentOutputError>(id: "InlineDocumentInput")
+            operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<InlineDocumentInput, InlineDocumentOutput, InlineDocumentOutputError>(urlPrefix: urlPrefix))
+            operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<InlineDocumentInput, InlineDocumentOutput>(host: hostOnly))
+            operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<InlineDocumentOutput> in
                 input.withMethod(context.getMethod())
                 input.withPath(context.getPath())
                 let host = "\(context.getHostPrefix() ?? "")\(context.getHost() ?? "")"
                 input.withHost(host)
                 return try await next.handle(context: context, input: input)
             }
-            operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<InlineDocumentInput, InlineDocumentOutputResponse>(contentType: "application/json"))
-            operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<InlineDocumentInput, InlineDocumentOutputResponse>(xmlName: "InlineDocumentInputOutput"))
+            operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<InlineDocumentInput, InlineDocumentOutput>(contentType: "application/json"))
+            operationStack.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<InlineDocumentInput, InlineDocumentOutput>(xmlName: "InlineDocumentInputOutput"))
             operationStack.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
             operationStack.deserializeStep.intercept(position: .after,
-                         middleware: MockDeserializeMiddleware<InlineDocumentOutputResponse, InlineDocumentOutputError>(
+                         middleware: MockDeserializeMiddleware<InlineDocumentOutput, InlineDocumentOutputError>(
                                  id: "TestDeserializeMiddleware"){ context, actual in
                 try await self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                     XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
@@ -778,8 +778,8 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                     }
                 })
                 let response = HttpResponse(body: HttpBody.none, statusCode: .ok)
-                let mockOutput = try await InlineDocumentOutputResponse(httpResponse: response, decoder: nil)
-                let output = OperationOutput<InlineDocumentOutputResponse>(httpResponse: response, output: mockOutput)
+                let mockOutput = try await InlineDocumentOutput(httpResponse: response, decoder: nil)
+                let output = OperationOutput<InlineDocumentOutput>(httpResponse: response, output: mockOutput)
                 return output
             })
             _ = try await operationStack.handleMiddleware(context: context, input: input, next: MockHandler(){ (context, request) in
@@ -837,21 +837,21 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                           .withEncoder(value: encoder)
                           .withMethod(value: .put)
                           .build()
-            var operationStack = OperationStack<InlineDocumentAsPayloadInput, InlineDocumentAsPayloadOutputResponse, InlineDocumentAsPayloadOutputError>(id: "InlineDocumentAsPayloadInput")
-            operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<InlineDocumentAsPayloadInput, InlineDocumentAsPayloadOutputResponse, InlineDocumentAsPayloadOutputError>(urlPrefix: urlPrefix))
-            operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<InlineDocumentAsPayloadInput, InlineDocumentAsPayloadOutputResponse>(host: hostOnly))
-            operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<InlineDocumentAsPayloadOutputResponse> in
+            var operationStack = OperationStack<InlineDocumentAsPayloadInput, InlineDocumentAsPayloadOutput, InlineDocumentAsPayloadOutputError>(id: "InlineDocumentAsPayloadInput")
+            operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<InlineDocumentAsPayloadInput, InlineDocumentAsPayloadOutput, InlineDocumentAsPayloadOutputError>(urlPrefix: urlPrefix))
+            operationStack.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<InlineDocumentAsPayloadInput, InlineDocumentAsPayloadOutput>(host: hostOnly))
+            operationStack.buildStep.intercept(position: .after, id: "RequestTestEndpointResolver") { (context, input, next) -> ClientRuntime.OperationOutput<InlineDocumentAsPayloadOutput> in
                 input.withMethod(context.getMethod())
                 input.withPath(context.getPath())
                 let host = "\(context.getHostPrefix() ?? "")\(context.getHost() ?? "")"
                 input.withHost(host)
                 return try await next.handle(context: context, input: input)
             }
-            operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<InlineDocumentAsPayloadInput, InlineDocumentAsPayloadOutputResponse>(contentType: "application/json"))
+            operationStack.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<InlineDocumentAsPayloadInput, InlineDocumentAsPayloadOutput>(contentType: "application/json"))
             operationStack.serializeStep.intercept(position: .after, middleware: InlineDocumentAsPayloadInputBodyMiddleware())
             operationStack.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
             operationStack.deserializeStep.intercept(position: .after,
-                         middleware: MockDeserializeMiddleware<InlineDocumentAsPayloadOutputResponse, InlineDocumentAsPayloadOutputError>(
+                         middleware: MockDeserializeMiddleware<InlineDocumentAsPayloadOutput, InlineDocumentAsPayloadOutputError>(
                                  id: "TestDeserializeMiddleware"){ context, actual in
                 try await self.assertEqual(expected, actual, { (expectedHttpBody, actualHttpBody) -> Void in
                     XCTAssertNotNil(actualHttpBody, "The actual HttpBody is nil")
@@ -867,8 +867,8 @@ class HttpProtocolUnitTestRequestGeneratorTests {
                     }
                 })
                 let response = HttpResponse(body: HttpBody.none, statusCode: .ok)
-                let mockOutput = try await InlineDocumentAsPayloadOutputResponse(httpResponse: response, decoder: nil)
-                let output = OperationOutput<InlineDocumentAsPayloadOutputResponse>(httpResponse: response, output: mockOutput)
+                let mockOutput = try await InlineDocumentAsPayloadOutput(httpResponse: response, decoder: nil)
+                let output = OperationOutput<InlineDocumentAsPayloadOutput>(httpResponse: response, output: mockOutput)
                 return output
             })
             _ = try await operationStack.handleMiddleware(context: context, input: input, next: MockHandler(){ (context, request) in

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolUnitTestResponseGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolUnitTestResponseGeneratorTests.kt
@@ -56,9 +56,9 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
         let decoder = ClientRuntime.JSONDecoder()
         decoder.dateDecodingStrategy = .secondsSince1970
         decoder.nonConformingFloatDecodingStrategy = .convertFromString(positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
-        let actual = try await SmokeTestOutputResponse(httpResponse: httpResponse, decoder: decoder)
+        let actual = try await SmokeTestOutput(httpResponse: httpResponse, decoder: decoder)
 
-        let expected = SmokeTestOutputResponse(
+        let expected = SmokeTestOutput(
             boolHeader: false,
             intHeader: 1,
             payload1: "explicit string",
@@ -102,9 +102,9 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
             return
         }
 
-        let actual = try await HttpPrefixHeadersOutputResponse(httpResponse: httpResponse)
+        let actual = try await HttpPrefixHeadersOutput(httpResponse: httpResponse)
 
-        let expected = HttpPrefixHeadersOutputResponse(
+        let expected = HttpPrefixHeadersOutput(
             foo: "Foo",
             fooMap: [
                 "abc": "ABC",
@@ -138,9 +138,9 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
             return
         }
 
-        let actual = try await HttpPrefixHeadersOutputResponse(httpResponse: httpResponse)
+        let actual = try await HttpPrefixHeadersOutput(httpResponse: httpResponse)
 
-        let expected = HttpPrefixHeadersOutputResponse(
+        let expected = HttpPrefixHeadersOutput(
             foo: "Foo"
         )
 
@@ -179,9 +179,9 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
         let decoder = ClientRuntime.JSONDecoder()
         decoder.dateDecodingStrategy = .secondsSince1970
         decoder.nonConformingFloatDecodingStrategy = .convertFromString(positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
-        let actual = try await JsonUnionsOutputResponse(httpResponse: httpResponse, decoder: decoder)
+        let actual = try await JsonUnionsOutput(httpResponse: httpResponse, decoder: decoder)
 
-        let expected = JsonUnionsOutputResponse(
+        let expected = JsonUnionsOutput(
             contents: MyUnion.stringvalue("foo")
 
         )
@@ -230,9 +230,9 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
         let decoder = ClientRuntime.JSONDecoder()
         decoder.dateDecodingStrategy = .secondsSince1970
         decoder.nonConformingFloatDecodingStrategy = .convertFromString(positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
-        let actual = try await RecursiveShapesOutputResponse(httpResponse: httpResponse, decoder: decoder)
+        let actual = try await RecursiveShapesOutput(httpResponse: httpResponse, decoder: decoder)
 
-        let expected = RecursiveShapesOutputResponse(
+        let expected = RecursiveShapesOutput(
             nested: RecursiveShapesInputOutputNested1(
                 foo: "Foo1",
                 nested: Box<RecursiveShapesInputOutputNested2>(
@@ -288,9 +288,9 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
                     let decoder = ClientRuntime.JSONDecoder()
                     decoder.dateDecodingStrategy = .secondsSince1970
                     decoder.nonConformingFloatDecodingStrategy = .convertFromString(positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
-                    let actual = try await InlineDocumentOutputResponse(httpResponse: httpResponse, decoder: decoder)
+                    let actual = try await InlineDocumentOutput(httpResponse: httpResponse, decoder: decoder)
             
-                    let expected = InlineDocumentOutputResponse(
+                    let expected = InlineDocumentOutput(
                         documentValue: try decoder.decode(Document.self, from:
                             ""${'"'}
                             {
@@ -337,9 +337,9 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
                     let decoder = ClientRuntime.JSONDecoder()
                     decoder.dateDecodingStrategy = .secondsSince1970
                     decoder.nonConformingFloatDecodingStrategy = .convertFromString(positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
-                    let actual = try await InlineDocumentAsPayloadOutputResponse(httpResponse: httpResponse, decoder: decoder)
+                    let actual = try await InlineDocumentAsPayloadOutput(httpResponse: httpResponse, decoder: decoder)
             
-                    let expected = InlineDocumentAsPayloadOutputResponse(
+                    let expected = InlineDocumentAsPayloadOutput(
                         documentValue: try decoder.decode(Document.self, from:
                             ""${'"'}
                             {

--- a/smithy-swift-codegen/src/test/kotlin/IdempotencyTokenTraitTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/IdempotencyTokenTraitTests.kt
@@ -13,8 +13,8 @@ class IdempotencyTokenTraitTests {
                 ///
                 /// - Parameter IdempotencyTokenWithStructureInput : [no documentation found]
                 ///
-                /// - Returns: `IdempotencyTokenWithStructureOutputResponse` : [no documentation found]
-                public func idempotencyTokenWithStructure(input: IdempotencyTokenWithStructureInput) async throws -> IdempotencyTokenWithStructureOutputResponse
+                /// - Returns: `IdempotencyTokenWithStructureOutput` : [no documentation found]
+                public func idempotencyTokenWithStructure(input: IdempotencyTokenWithStructureInput) async throws -> IdempotencyTokenWithStructureOutput
                 {
                     let context = ClientRuntime.HttpContextBuilder()
                                   .withEncoder(value: encoder)
@@ -26,8 +26,8 @@ class IdempotencyTokenTraitTests {
                                   .withLogger(value: config.logger)
                                   .withPartitionID(value: config.partitionID)
                                   .build()
-                    var operation = ClientRuntime.OperationStack<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>(id: "idempotencyTokenWithStructure")
-                    operation.initializeStep.intercept(position: .after, id: "IdempotencyTokenMiddleware") { (context, input, next) -> ClientRuntime.OperationOutput<IdempotencyTokenWithStructureOutputResponse> in
+                    var operation = ClientRuntime.OperationStack<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>(id: "idempotencyTokenWithStructure")
+                    operation.initializeStep.intercept(position: .after, id: "IdempotencyTokenMiddleware") { (context, input, next) -> ClientRuntime.OperationOutput<IdempotencyTokenWithStructureOutput> in
                         let idempotencyTokenGenerator = context.getIdempotencyTokenGenerator()
                         var copiedInput = input
                         if input.token == nil {
@@ -35,14 +35,14 @@ class IdempotencyTokenTraitTests {
                         }
                         return try await next.handle(context: context, input: copiedInput)
                     }
-                    operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>())
-                    operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>())
-                    operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>(contentType: "application/xml"))
-                    operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutputResponse>(xmlName: "IdempotencyToken"))
+                    operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>())
+                    operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput>())
+                    operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput>(contentType: "application/xml"))
+                    operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput>(xmlName: "IdempotencyToken"))
                     operation.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
-                    operation.finalizeStep.intercept(position: .after, middleware: ClientRuntime.RetryMiddleware<ClientRuntime.DefaultRetryStrategy, ClientRuntime.DefaultRetryErrorInfoProvider, IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>(options: config.retryStrategyOptions))
-                    operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware<IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>())
-                    operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.LoggerMiddleware<IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>(clientLogMode: config.clientLogMode))
+                    operation.finalizeStep.intercept(position: .after, middleware: ClientRuntime.RetryMiddleware<ClientRuntime.DefaultRetryStrategy, ClientRuntime.DefaultRetryErrorInfoProvider, IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>(options: config.retryStrategyOptions))
+                    operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware<IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>())
+                    operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.LoggerMiddleware<IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>(clientLogMode: config.clientLogMode))
                     let result = try await operation.handleMiddleware(context: context, input: input, next: client.getHandler())
                     return result
                 }

--- a/smithy-swift-codegen/src/test/kotlin/IsolatedHttpProtocolUnitTestRequestGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/IsolatedHttpProtocolUnitTestRequestGeneratorTests.kt
@@ -121,9 +121,9 @@ class InputAndOutputWithHeadersResponseTest: HttpResponseTestBase {
             return
         }
 
-        let actual = try await InputAndOutputWithHeadersOutputResponse(httpResponse: httpResponse)
+        let actual = try await InputAndOutputWithHeadersOutput(httpResponse: httpResponse)
 
-        let expected = InputAndOutputWithHeadersOutputResponse(
+        let expected = InputAndOutputWithHeadersOutput(
             headerDouble: Swift.Double.nan,
             headerFloat: Swift.Float.nan
         )

--- a/smithy-swift-codegen/src/test/kotlin/PaginatorGeneratorTest.kt
+++ b/smithy-swift-codegen/src/test/kotlin/PaginatorGeneratorTest.kt
@@ -16,16 +16,16 @@ class PaginatorGeneratorTest {
         val contents = getFileContents(context.manifest, "/Test/Paginators.swift")
         val expected = """
         extension TestClient {
-            /// Paginate over `[ListFunctionsOutputResponse]` results.
+            /// Paginate over `[ListFunctionsOutput]` results.
             ///
             /// When this operation is called, an `AsyncSequence` is created. AsyncSequences are lazy so no service
             /// calls are made until the sequence is iterated over. This also means there is no guarantee that the request is valid
             /// until then. If there are errors in your request, you will see the failures only after you start iterating.
             /// - Parameters:
             ///     - input: A `[ListFunctionsInput]` to start pagination
-            /// - Returns: An `AsyncSequence` that can iterate over `ListFunctionsOutputResponse`
-            public func listFunctionsPaginated(input: ListFunctionsInput) -> ClientRuntime.PaginatorSequence<ListFunctionsInput, ListFunctionsOutputResponse> {
-                return ClientRuntime.PaginatorSequence<ListFunctionsInput, ListFunctionsOutputResponse>(input: input, inputKey: \ListFunctionsInput.marker, outputKey: \ListFunctionsOutputResponse.nextMarker, paginationFunction: self.listFunctions(input:))
+            /// - Returns: An `AsyncSequence` that can iterate over `ListFunctionsOutput`
+            public func listFunctionsPaginated(input: ListFunctionsInput) -> ClientRuntime.PaginatorSequence<ListFunctionsInput, ListFunctionsOutput> {
+                return ClientRuntime.PaginatorSequence<ListFunctionsInput, ListFunctionsOutput>(input: input, inputKey: \ListFunctionsInput.marker, outputKey: \ListFunctionsOutput.nextMarker, paginationFunction: self.listFunctions(input:))
             }
         }
 
@@ -49,16 +49,16 @@ class PaginatorGeneratorTest {
         val contents = getFileContents(context.manifest, "/Test/Paginators.swift")
         val expectedCode = """
         extension TestClient {
-            /// Paginate over `[ListFunctionsOutputResponse]` results.
+            /// Paginate over `[ListFunctionsOutput]` results.
             ///
             /// When this operation is called, an `AsyncSequence` is created. AsyncSequences are lazy so no service
             /// calls are made until the sequence is iterated over. This also means there is no guarantee that the request is valid
             /// until then. If there are errors in your request, you will see the failures only after you start iterating.
             /// - Parameters:
             ///     - input: A `[ListFunctionsInput]` to start pagination
-            /// - Returns: An `AsyncSequence` that can iterate over `ListFunctionsOutputResponse`
-            public func listFunctionsPaginated(input: ListFunctionsInput) -> ClientRuntime.PaginatorSequence<ListFunctionsInput, ListFunctionsOutputResponse> {
-                return ClientRuntime.PaginatorSequence<ListFunctionsInput, ListFunctionsOutputResponse>(input: input, inputKey: \ListFunctionsInput.marker, outputKey: \ListFunctionsOutputResponse.nextMarker, paginationFunction: self.listFunctions(input:))
+            /// - Returns: An `AsyncSequence` that can iterate over `ListFunctionsOutput`
+            public func listFunctionsPaginated(input: ListFunctionsInput) -> ClientRuntime.PaginatorSequence<ListFunctionsInput, ListFunctionsOutput> {
+                return ClientRuntime.PaginatorSequence<ListFunctionsInput, ListFunctionsOutput>(input: input, inputKey: \ListFunctionsInput.marker, outputKey: \ListFunctionsOutput.nextMarker, paginationFunction: self.listFunctions(input:))
             }
         }
         
@@ -72,7 +72,7 @@ class PaginatorGeneratorTest {
                 )}
         }
         
-        extension PaginatorSequence where Input == ListFunctionsInput, Output == ListFunctionsOutputResponse {
+        extension PaginatorSequence where Input == ListFunctionsInput, Output == ListFunctionsOutput {
             /// This paginator transforms the `AsyncSequence` returned by `listFunctionsPaginated`
             /// to access the nested member `[TestClientTypes.FunctionConfiguration]`
             /// - Returns: `[TestClientTypes.FunctionConfiguration]`
@@ -91,16 +91,16 @@ class PaginatorGeneratorTest {
         val contents = getFileContents(context.manifest, "/Test/Paginators.swift")
         val expectedCode = """
         extension TestClient {
-            /// Paginate over `[PaginatedMapOutputResponse]` results.
+            /// Paginate over `[PaginatedMapOutput]` results.
             ///
             /// When this operation is called, an `AsyncSequence` is created. AsyncSequences are lazy so no service
             /// calls are made until the sequence is iterated over. This also means there is no guarantee that the request is valid
             /// until then. If there are errors in your request, you will see the failures only after you start iterating.
             /// - Parameters:
             ///     - input: A `[PaginatedMapInput]` to start pagination
-            /// - Returns: An `AsyncSequence` that can iterate over `PaginatedMapOutputResponse`
-            public func paginatedMapPaginated(input: PaginatedMapInput) -> ClientRuntime.PaginatorSequence<PaginatedMapInput, PaginatedMapOutputResponse> {
-                return ClientRuntime.PaginatorSequence<PaginatedMapInput, PaginatedMapOutputResponse>(input: input, inputKey: \PaginatedMapInput.nextToken, outputKey: \PaginatedMapOutputResponse.inner?.token, paginationFunction: self.paginatedMap(input:))
+            /// - Returns: An `AsyncSequence` that can iterate over `PaginatedMapOutput`
+            public func paginatedMapPaginated(input: PaginatedMapInput) -> ClientRuntime.PaginatorSequence<PaginatedMapInput, PaginatedMapOutput> {
+                return ClientRuntime.PaginatorSequence<PaginatedMapInput, PaginatedMapOutput>(input: input, inputKey: \PaginatedMapInput.nextToken, outputKey: \PaginatedMapOutput.inner?.token, paginationFunction: self.paginatedMap(input:))
             }
         }
         
@@ -112,7 +112,7 @@ class PaginatorGeneratorTest {
                 )}
         }
         
-        extension PaginatorSequence where Input == PaginatedMapInput, Output == PaginatedMapOutputResponse {
+        extension PaginatorSequence where Input == PaginatedMapInput, Output == PaginatedMapOutput {
             /// This paginator transforms the `AsyncSequence` returned by `paginatedMapPaginated`
             /// to access the nested member `[(String, Swift.Int)]`
             /// - Returns: `[(String, Swift.Int)]`

--- a/smithy-swift-codegen/src/test/kotlin/RecursiveShapeBoxerTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/RecursiveShapeBoxerTests.kt
@@ -64,11 +64,11 @@ internal class RecursiveShapeBoxerTests {
         recursiveShapesInput.shouldContain(expected)
 
         val recursiveShapesOutput = manifest
-            .getFileString("example/models/RecursiveShapesOutputResponse.swift").get()
+            .getFileString("example/models/RecursiveShapesOutput.swift").get()
         Assertions.assertNotNull(recursiveShapesOutput)
         val expected2 =
             """
-            public struct RecursiveShapesOutputResponse: Swift.Equatable {
+            public struct RecursiveShapesOutput: Swift.Equatable {
                 public var nested: ExampleClientTypes.RecursiveShapesInputOutputNested1?
             
                 public init(

--- a/smithy-swift-codegen/src/test/kotlin/RetryMiddlewareTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/RetryMiddlewareTests.kt
@@ -8,7 +8,7 @@ class RetryMiddlewareTests {
         val context = setupTests("Isolated/contentmd5checksum.smithy", "aws.protocoltests.restxml#RestXml")
         val contents = getFileContents(context.manifest, "/RestXml/RestXmlProtocolClient.swift")
         val expectedContents = """
-            operation.finalizeStep.intercept(position: .after, middleware: ClientRuntime.RetryMiddleware<ClientRuntime.DefaultRetryStrategy, ClientRuntime.DefaultRetryErrorInfoProvider, IdempotencyTokenWithStructureOutputResponse, IdempotencyTokenWithStructureOutputError>(options: config.retryStrategyOptions))
+            operation.finalizeStep.intercept(position: .after, middleware: ClientRuntime.RetryMiddleware<ClientRuntime.DefaultRetryStrategy, ClientRuntime.DefaultRetryErrorInfoProvider, IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>(options: config.retryStrategyOptions))
         """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
     }

--- a/smithy-swift-codegen/src/test/kotlin/SensitiveTraitGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/SensitiveTraitGeneratorTests.kt
@@ -28,11 +28,11 @@ class SensitiveTraitGeneratorTests {
     fun `SensitiveTraitInRequestOutput+CustomDebugStringConvertible`() {
         val manifest = setupTest()
         var extensionWithSensitiveTrait = manifest
-            .getFileString("example/models/SensitiveTraitInRequestOutputResponse+CustomDebugStringConvertible.swift").get()
+            .getFileString("example/models/SensitiveTraitInRequestOutput+CustomDebugStringConvertible.swift").get()
         extensionWithSensitiveTrait.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            extension SensitiveTraitInRequestOutputResponse: Swift.CustomDebugStringConvertible {
+            extension SensitiveTraitInRequestOutput: Swift.CustomDebugStringConvertible {
                 public var debugDescription: Swift.String {
                     "CONTENT_REDACTED"
                 }
@@ -45,13 +45,13 @@ class SensitiveTraitGeneratorTests {
     fun `AllSensitiveMemberStruct+CustomDebugStringConvertible`() {
         val manifest = setupTest()
         var extensionWithSensitiveTrait = manifest
-            .getFileString("example/models/SensitiveTraitTestRequestOutputResponse+CustomDebugStringConvertible.swift").get()
+            .getFileString("example/models/SensitiveTraitTestRequestOutput+CustomDebugStringConvertible.swift").get()
         extensionWithSensitiveTrait.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            extension SensitiveTraitTestRequestOutputResponse: Swift.CustomDebugStringConvertible {
+            extension SensitiveTraitTestRequestOutput: Swift.CustomDebugStringConvertible {
                 public var debugDescription: Swift.String {
-                    "SensitiveTraitTestRequestOutputResponse(bar: \"CONTENT_REDACTED\", baz: \"CONTENT_REDACTED\", foo: \"CONTENT_REDACTED\")"}
+                    "SensitiveTraitTestRequestOutput(bar: \"CONTENT_REDACTED\", baz: \"CONTENT_REDACTED\", foo: \"CONTENT_REDACTED\")"}
             }
             """.trimIndent()
         extensionWithSensitiveTrait.shouldContainOnlyOnce(expectedContents)

--- a/smithy-swift-codegen/src/test/kotlin/ServiceGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ServiceGeneratorTests.kt
@@ -73,13 +73,13 @@ class ServiceGeneratorTests {
     @Test
     fun `it renders swift func signatures correctly`() {
         val expectedSignatures = listOf(
-            "func getFooStreamingInput(input: GetFooStreamingInputInput) async throws -> GetFooStreamingInputOutputResponse",
-            "func getFooNoOutput(input: GetFooNoOutputInput) async throws -> GetFooNoOutputOutputResponse",
-            "func getFooStreamingOutput(input: GetFooStreamingOutputInput) async throws -> GetFooStreamingOutputOutputResponse",
-            "func getFoo(input: GetFooInput) async throws -> GetFooOutputResponse",
-            "func getFooNoInput(input: GetFooNoInputInput) async throws -> GetFooNoInputOutputResponse",
-            "func getFooStreamingInputNoOutput(input: GetFooStreamingInputNoOutputInput) async throws -> GetFooStreamingInputNoOutputOutputResponse",
-            "func getFooStreamingOutputNoInput(input: GetFooStreamingOutputNoInputInput) async throws -> GetFooStreamingOutputNoInputOutputResponse"
+            "func getFooStreamingInput(input: GetFooStreamingInputInput) async throws -> GetFooStreamingInputOutput",
+            "func getFooNoOutput(input: GetFooNoOutputInput) async throws -> GetFooNoOutputOutput",
+            "func getFooStreamingOutput(input: GetFooStreamingOutputInput) async throws -> GetFooStreamingOutputOutput",
+            "func getFoo(input: GetFooInput) async throws -> GetFooOutput",
+            "func getFooNoInput(input: GetFooNoInputInput) async throws -> GetFooNoInputOutput",
+            "func getFooStreamingInputNoOutput(input: GetFooStreamingInputNoOutputInput) async throws -> GetFooStreamingInputNoOutputOutput",
+            "func getFooStreamingOutputNoInput(input: GetFooStreamingOutputNoInputInput) async throws -> GetFooStreamingOutputNoInputOutput"
         )
         expectedSignatures.forEach {
             commonTestContents.shouldContainOnlyOnce(it)

--- a/smithy-swift-codegen/src/test/kotlin/ServiceRenamesTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ServiceRenamesTests.kt
@@ -45,11 +45,11 @@ class ServiceRenamesTests {
             ),
             "aws.protocoltests.restjson#RestJson"
         )
-        val contents = getFileContents(context.manifest, "/RestJson/models/MyTestOperationOutputResponse.swift")
+        val contents = getFileContents(context.manifest, "/RestJson/models/MyTestOperationOutput.swift")
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            public struct MyTestOperationOutputResponse: Swift.Equatable {
+            public struct MyTestOperationOutput: Swift.Equatable {
                 public var baz: ExampleClientTypes.GreetingStruct?
             
                 public init(

--- a/smithy-swift-codegen/src/test/kotlin/StructDecodeGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructDecodeGenerationTests.kt
@@ -29,7 +29,7 @@ class StructDecodeGenerationTests {
 
     @Test
     fun `it creates decodable conformance in correct file`() {
-        Assertions.assertTrue(newTestContext.manifest.hasFile("/example/models/SmokeTestOutputResponseBody+Decodable.swift"))
+        Assertions.assertTrue(newTestContext.manifest.hasFile("/example/models/SmokeTestOutputBody+Decodable.swift"))
     }
 
     @Test
@@ -42,17 +42,17 @@ class StructDecodeGenerationTests {
 
     @Test
     fun `it creates smoke test request decodable conformance`() {
-        val contents = getModelFileContents("example", "SmokeTestOutputResponseBody+Decodable.swift", newTestContext.manifest)
+        val contents = getModelFileContents("example", "SmokeTestOutputBody+Decodable.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            struct SmokeTestOutputResponseBody: Swift.Equatable {
+            struct SmokeTestOutputBody: Swift.Equatable {
                 let payload1: Swift.String?
                 let payload2: Swift.Int?
                 let payload3: ExampleClientTypes.Nested?
             }
             
-            extension SmokeTestOutputResponseBody: Swift.Decodable {
+            extension SmokeTestOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case payload1
                     case payload2
@@ -167,11 +167,11 @@ class StructDecodeGenerationTests {
     @Test
     fun `it provides decodable conformance to operation outputs with timestamps`() {
         val contents =
-            getModelFileContents("example", "TimestampInputOutputResponseBody+Decodable.swift", newTestContext.manifest)
+            getModelFileContents("example", "TimestampInputOutputBody+Decodable.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-struct TimestampInputOutputResponseBody: Swift.Equatable {
+struct TimestampInputOutputBody: Swift.Equatable {
     let normal: ClientRuntime.Date?
     let dateTime: ClientRuntime.Date?
     let epochSeconds: ClientRuntime.Date?
@@ -181,7 +181,7 @@ struct TimestampInputOutputResponseBody: Swift.Equatable {
     let timestampList: [ClientRuntime.Date]?
 }
 
-extension TimestampInputOutputResponseBody: Swift.Decodable {
+extension TimestampInputOutputBody: Swift.Decodable {
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case dateTime
         case epochSeconds
@@ -241,11 +241,11 @@ extension TimestampInputOutputResponseBody: Swift.Decodable {
 
     @Test
     fun `it decodes maps correctly`() {
-        val contents = getModelFileContents("example", "MapInputOutputResponseBody+Decodable.swift", newTestContext.manifest)
+        val contents = getModelFileContents("example", "MapInputOutputBody+Decodable.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-struct MapInputOutputResponseBody: Swift.Equatable {
+struct MapInputOutputBody: Swift.Equatable {
     let intMap: [Swift.String:Swift.Int]?
     let structMap: [Swift.String:ExampleClientTypes.ReachableOnlyThroughMap]?
     let enumMap: [Swift.String:ExampleClientTypes.MyEnum]?
@@ -254,7 +254,7 @@ struct MapInputOutputResponseBody: Swift.Equatable {
     let dateMap: [Swift.String:ClientRuntime.Date]?
 }
 
-extension MapInputOutputResponseBody: Swift.Decodable {
+extension MapInputOutputBody: Swift.Decodable {
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case blobMap
         case dateMap
@@ -347,17 +347,17 @@ extension MapInputOutputResponseBody: Swift.Decodable {
     @Test
     fun `it decodes nested diverse shapes correctly`() {
         val contents =
-            getModelFileContents("example", "NestedShapesOutputResponseBody+Decodable.swift", newTestContext.manifest)
+            getModelFileContents("example", "NestedShapesOutputBody+Decodable.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-struct NestedShapesOutputResponseBody: Swift.Equatable {
+struct NestedShapesOutputBody: Swift.Equatable {
     let nestedListInDict: [Swift.String:[ClientRuntime.Date]]?
     let nestedDictInList: [[Swift.String:Swift.String]]?
     let nestedListOfListInDict: [Swift.String:[[Swift.Int]]]?
 }
 
-extension NestedShapesOutputResponseBody: Swift.Decodable {
+extension NestedShapesOutputBody: Swift.Decodable {
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case nestedDictInList
         case nestedListInDict

--- a/smithy-swift-codegen/src/test/kotlin/StructureGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructureGeneratorTests.kt
@@ -398,11 +398,11 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         jsonMapsInput.shouldContain(expectedJsonMapsInput)
 
         val jsonMapsOutput = manifest
-            .getFileString("example/models/JsonMapsOutputResponse.swift").get()
+            .getFileString("example/models/JsonMapsOutput.swift").get()
         Assertions.assertNotNull(jsonMapsOutput)
         val expectedJsonMapsOutput =
             """
-            public struct JsonMapsOutputResponse: Swift.Equatable {
+            public struct JsonMapsOutput: Swift.Equatable {
                 public var denseBooleanMap: [Swift.String:Swift.Bool]?
                 public var denseNumberMap: [Swift.String:Swift.Int]?
                 public var denseStringMap: [Swift.String:Swift.String]?

--- a/smithy-swift-codegen/src/test/kotlin/SwiftDelegatorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/SwiftDelegatorTests.kt
@@ -25,7 +25,7 @@ class SwiftDelegatorTests {
         SwiftCodegenPlugin().execute(context)
 
         assertTrue(manifest.hasFile("example/models/GetFooInput.swift"))
-        assertTrue(manifest.hasFile("example/models/GetFooOutputResponse.swift"))
+        assertTrue(manifest.hasFile("example/models/GetFooOutput.swift"))
         assertTrue(manifest.hasFile("example/models/GetFooError.swift"))
     }
 

--- a/smithy-swift-codegen/src/test/kotlin/UnionDecodeGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/UnionDecodeGeneratorTests.kt
@@ -27,7 +27,7 @@ class UnionDecodeGeneratorTests {
 
     @Test
     fun `it creates decodable conformance in correct file`() {
-        Assertions.assertTrue(newTestContext.manifest.hasFile("/example/models/JsonUnionsOutputResponseBody+Decodable.swift"))
+        Assertions.assertTrue(newTestContext.manifest.hasFile("/example/models/JsonUnionsOutputBody+Decodable.swift"))
     }
 
     @Test
@@ -37,15 +37,15 @@ class UnionDecodeGeneratorTests {
 
     @Test
     fun `it decodes a union member in an operation body`() {
-        val contents = getModelFileContents("example", "JsonUnionsOutputResponseBody+Decodable.swift", newTestContext.manifest)
+        val contents = getModelFileContents("example", "JsonUnionsOutputBody+Decodable.swift", newTestContext.manifest)
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            struct JsonUnionsOutputResponseBody: Swift.Equatable {
+            struct JsonUnionsOutputBody: Swift.Equatable {
                 let contents: ExampleClientTypes.MyUnion?
             }
             
-            extension JsonUnionsOutputResponseBody: Swift.Decodable {
+            extension JsonUnionsOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case contents
                 }

--- a/smithy-swift-codegen/src/test/kotlin/httpResponse/HttpResponseBindingIgnoreQuery.kt
+++ b/smithy-swift-codegen/src/test/kotlin/httpResponse/HttpResponseBindingIgnoreQuery.kt
@@ -18,11 +18,11 @@ class HttpResponseBindingIgnoreQuery {
     @Test
     fun `001 Output httpResponseBinding sets query to nil`() {
         val context = setupTests("http-query-payload.smithy", "aws.protocoltests.restjson#RestJson")
-        val contents = getFileContents(context.manifest, "/RestJson/models/IgnoreQueryParamsInResponseOutputResponse+HttpResponseBinding.swift")
+        val contents = getFileContents(context.manifest, "/RestJson/models/IgnoreQueryParamsInResponseOutput+HttpResponseBinding.swift")
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            extension IgnoreQueryParamsInResponseOutputResponse: ClientRuntime.HttpResponseBinding {
+            extension IgnoreQueryParamsInResponseOutput: ClientRuntime.HttpResponseBinding {
                 public init(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws {
                     self.baz = nil
                 }

--- a/smithy-swift-codegen/src/test/kotlin/serde/awsjson11/OutputResponseDeserializerTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/awsjson11/OutputResponseDeserializerTests.kt
@@ -11,7 +11,7 @@ import shouldSyntacticSanityCheck
 import software.amazon.smithy.swift.codegen.model.AddOperationShapes
 
 // NOTE: protocol conformance is mostly handled by the protocol tests suite
-class OutputResponseDeserializerTests {
+class OutputDeserializerTests {
     private var model = javaClass.getResource("awsjson-output-response-deserializer.smithy").asSmithy()
     private fun newTestContext(): TestContext {
         val settings = model.defaultSettings()
@@ -33,17 +33,17 @@ class OutputResponseDeserializerTests {
     fun `it creates correct init for simple structure payloads`() {
         val contents = getModelFileContents(
             "example",
-            "SimpleStructureOutputResponse+HttpResponseBinding.swift",
+            "SimpleStructureOutput+HttpResponseBinding.swift",
             newTestContext.manifest
         )
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            extension SimpleStructureOutputResponse: ClientRuntime.HttpResponseBinding {
+            extension SimpleStructureOutput: ClientRuntime.HttpResponseBinding {
                 public init(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws {
                     if let data = try await httpResponse.body.readData(),
                         let responseDecoder = decoder {
-                        let output: SimpleStructureOutputResponseBody = try responseDecoder.decode(responseBody: data)
+                        let output: SimpleStructureOutputBody = try responseDecoder.decode(responseBody: data)
                         self.name = output.name
                         self.number = output.number
                     } else {
@@ -60,13 +60,13 @@ class OutputResponseDeserializerTests {
     fun `it creates correct init for data streaming payloads`() {
         val contents = getModelFileContents(
             "example",
-            "DataStreamingOutputResponse+HttpResponseBinding.swift",
+            "DataStreamingOutput+HttpResponseBinding.swift",
             newTestContext.manifest
         )
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            extension DataStreamingOutputResponse: ClientRuntime.HttpResponseBinding {
+            extension DataStreamingOutput: ClientRuntime.HttpResponseBinding {
                 public init(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws {
                     switch httpResponse.body {
                     case .data(let data):
@@ -86,13 +86,13 @@ class OutputResponseDeserializerTests {
     fun `it creates correct init for event streaming payloads`() {
         val contents = getModelFileContents(
             "example",
-            "EventStreamingOutputResponse+HttpResponseBinding.swift",
+            "EventStreamingOutput+HttpResponseBinding.swift",
             newTestContext.manifest
         )
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            extension EventStreamingOutputResponse: ClientRuntime.HttpResponseBinding {
+            extension EventStreamingOutput: ClientRuntime.HttpResponseBinding {
                 public init(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws {
                     if case let .stream(stream) = httpResponse.body, let responseDecoder = decoder {
                         let messageDecoder: ClientRuntime.MessageDecoder? = nil

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/AttributeDecodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/AttributeDecodeXMLGenerationTests.kt
@@ -16,13 +16,13 @@ class AttributeDecodeXMLGenerationTests {
     @Test
     fun `001 xml attributes decode for input type`() {
         val context = setupTests("Isolated/Restxml/xml-attr.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlAttributesOutputResponseBody+DynamicNodeDecoding.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlAttributesOutputBody+DynamicNodeDecoding.swift")
         val expectedContents = """
-        extension XmlAttributesOutputResponseBody: ClientRuntime.DynamicNodeDecoding {
+        extension XmlAttributesOutputBody: ClientRuntime.DynamicNodeDecoding {
             public static func nodeDecoding(for key: Swift.CodingKey) -> ClientRuntime.NodeDecoding {
                 switch(key) {
-                    case XmlAttributesOutputResponseBody.CodingKeys.foo: return .element
-                    case XmlAttributesOutputResponseBody.CodingKeys.attr: return .attribute
+                    case XmlAttributesOutputBody.CodingKeys.foo: return .element
+                    case XmlAttributesOutputBody.CodingKeys.attr: return .attribute
                     default:
                         return .element
                 }

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/BlobDecodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/BlobDecodeXMLGenerationTests.kt
@@ -17,9 +17,9 @@ class BlobDecodeXMLGenerationTests {
     @Test
     fun `decode blob`() {
         val context = setupTests("Isolated/Restxml/xml-blobs.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlBlobsOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlBlobsOutputBody+Decodable.swift")
         val expectedContents = """
-        extension XmlBlobsOutputResponseBody: Swift.Decodable {
+        extension XmlBlobsOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case data
             }
@@ -46,9 +46,9 @@ class BlobDecodeXMLGenerationTests {
     @Test
     fun `decode blob nested`() {
         val context = setupTests("Isolated/Restxml/xml-blobs.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlBlobsNestedOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlBlobsNestedOutputBody+Decodable.swift")
         val expectedContents = """
-        extension XmlBlobsNestedOutputResponseBody: Swift.Decodable {
+        extension XmlBlobsNestedOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case nestedBlobList
             }

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/EnumDecodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/EnumDecodeXMLGenerationTests.kt
@@ -17,16 +17,16 @@ class EnumDecodeXMLGenerationTests {
     @Test
     fun `decode enum`() {
         val context = setupTests("Isolated/Restxml/xml-enums.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlEnumsOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlEnumsOutputBody+Decodable.swift")
         val expectedContents = """
-        struct XmlEnumsOutputResponseBody: Swift.Equatable {
+        struct XmlEnumsOutputBody: Swift.Equatable {
             let fooEnum1: RestXmlProtocolClientTypes.FooEnum?
             let fooEnum2: RestXmlProtocolClientTypes.FooEnum?
             let fooEnum3: RestXmlProtocolClientTypes.FooEnum?
             let fooEnumList: [RestXmlProtocolClientTypes.FooEnum]?
         }
         
-        extension XmlEnumsOutputResponseBody: Swift.Decodable {
+        extension XmlEnumsOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case fooEnum1
                 case fooEnum2
@@ -70,14 +70,14 @@ class EnumDecodeXMLGenerationTests {
     @Test
     fun `decode enum nested`() {
         val context = setupTests("Isolated/Restxml/xml-enums.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlEnumsNestedOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlEnumsNestedOutputBody+Decodable.swift")
         val expectedContents =
             """
-            struct XmlEnumsNestedOutputResponseBody: Swift.Equatable {
+            struct XmlEnumsNestedOutputBody: Swift.Equatable {
                 let nestedEnumsList: [[RestXmlProtocolClientTypes.FooEnum]]?
             }
             
-            extension XmlEnumsNestedOutputResponseBody: Swift.Decodable {
+            extension XmlEnumsNestedOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case nestedEnumsList
                 }

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/ListDecodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/ListDecodeXMLGenerationTests.kt
@@ -16,10 +16,10 @@ class ListDecodeXMLGenerationTests {
     @Test
     fun `001 wrapped list with xmlName`() {
         val context = setupTests("Isolated/Restxml/xml-lists-xmlname.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlListXmlNameOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlListXmlNameOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlListXmlNameOutputResponseBody: Swift.Decodable {
+            extension XmlListXmlNameOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case renamedListMembers = "renamed"
                 }
@@ -54,9 +54,9 @@ class ListDecodeXMLGenerationTests {
     @Test
     fun `002 wrapped nested list with xmlname`() {
         val context = setupTests("Isolated/Restxml/xml-lists-xmlname-nested.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlListXmlNameNestedOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlListXmlNameNestedOutputBody+Decodable.swift")
         val expectedContents = """
-        extension XmlListXmlNameNestedOutputResponseBody: Swift.Decodable {
+        extension XmlListXmlNameNestedOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case renamedListMembers = "renamed"
             }
@@ -99,9 +99,9 @@ class ListDecodeXMLGenerationTests {
     fun `003 decode flattened list`() {
         val context = setupTests("Isolated/Restxml/xml-lists-flattened.smithy", "aws.protocoltests.restxml#RestXml")
 
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlFlattenedListOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlFlattenedListOutputBody+Decodable.swift")
         val expectedContents = """
-        extension XmlFlattenedListOutputResponseBody: Swift.Decodable {
+        extension XmlFlattenedListOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case myGroceryList
             }
@@ -136,9 +136,9 @@ class ListDecodeXMLGenerationTests {
     @Test
     fun `004 decode flattened empty list`() {
         val context = setupTests("Isolated/Restxml/xml-lists-emptyFlattened.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlEmptyFlattenedListsOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlEmptyFlattenedListsOutputBody+Decodable.swift")
         val expectedContents = """
-        extension XmlEmptyFlattenedListsOutputResponseBody: Swift.Decodable {
+        extension XmlEmptyFlattenedListsOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case booleanList
                 case integerList
@@ -231,10 +231,10 @@ class ListDecodeXMLGenerationTests {
     @Test
     fun `005 decode nestednested flattened list serialization`() {
         val context = setupTests("Isolated/Restxml/xml-lists-nestednested-flattened.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlNestedNestedFlattenedListOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlNestedNestedFlattenedListOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlNestedNestedFlattenedListOutputResponseBody: Swift.Decodable {
+            extension XmlNestedNestedFlattenedListOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case nestedNestedStringList
                 }
@@ -282,10 +282,10 @@ class ListDecodeXMLGenerationTests {
     @Test
     fun `012 decode list containing map`() {
         val context = setupTests("Isolated/Restxml/xml-lists-contain-map.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlListContainMapOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlListContainMapOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlListContainMapOutputResponseBody: Swift.Decodable {
+            extension XmlListContainMapOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myList
                 }
@@ -331,10 +331,10 @@ class ListDecodeXMLGenerationTests {
     @Test
     fun `013 decode flattened list containing map`() {
         val context = setupTests("Isolated/Restxml/xml-lists-flattened-contain-map.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlListFlattenedContainMapOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlListFlattenedContainMapOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlListFlattenedContainMapOutputResponseBody: Swift.Decodable {
+            extension XmlListFlattenedContainMapOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myList
                 }

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/MapDecodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/MapDecodeXMLGenerationTests.kt
@@ -17,9 +17,9 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `001 decode wrapped map`() {
         val context = setupTests("Isolated/Restxml/xml-maps.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsOutputBody+Decodable.swift")
         val expectedContents = """
-        extension XmlMapsOutputResponseBody: Swift.Decodable {
+        extension XmlMapsOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case myMap
             }
@@ -54,9 +54,9 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `002 decode wrapped map with name protocol`() {
         val context = setupTests("Isolated/Restxml/xml-maps.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsWithNameProtocolOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsWithNameProtocolOutputBody+Decodable.swift")
         val expectedContents = """
-        extension XmlMapsWithNameProtocolOutputResponseBody: Swift.Decodable {
+        extension XmlMapsWithNameProtocolOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case `protocol` = "protocol"
             }
@@ -91,10 +91,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `003 decode nested wrapped map`() {
         val context = setupTests("Isolated/Restxml/xml-maps-nested.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsNestedOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsNestedOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsNestedOutputResponseBody: Swift.Decodable {
+            extension XmlMapsNestedOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -137,10 +137,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `004 decode nested nested wrapped map`() {
         val context = setupTests("Isolated/Restxml/xml-maps-nestednested.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsNestedNestedOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsNestedNestedOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsNestedNestedOutputResponseBody: Swift.Decodable {
+            extension XmlMapsNestedNestedOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -191,10 +191,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `005 decode flattened map`() {
         val context = setupTests("Isolated/Restxml/xml-maps-flattened.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlFlattenedMapsOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlFlattenedMapsOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlFlattenedMapsOutputResponseBody: Swift.Decodable {
+            extension XmlFlattenedMapsOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -229,10 +229,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `006 decode flattened nested map`() {
         val context = setupTests("Isolated/Restxml/xml-maps-flattened-nested.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsFlattenedNestedOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsFlattenedNestedOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsFlattenedNestedOutputResponseBody: Swift.Decodable {
+            extension XmlMapsFlattenedNestedOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -275,10 +275,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `007 decode map with xmlname`() {
         val context = setupTests("Isolated/Restxml/xml-maps-xmlname.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsXmlNameOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsXmlNameOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsXmlNameOutputResponseBody: Swift.Decodable {
+            extension XmlMapsXmlNameOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -313,10 +313,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `008 decode map with xmlname flattened`() {
         val context = setupTests("Isolated/Restxml/xml-maps-xmlname-flattened.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsXmlNameFlattenedOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsXmlNameFlattenedOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsXmlNameFlattenedOutputResponseBody: Swift.Decodable {
+            extension XmlMapsXmlNameFlattenedOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -351,10 +351,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `009 decode map with xmlname nested`() {
         val context = setupTests("Isolated/Restxml/xml-maps-xmlname-nested.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsXmlNameNestedOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsXmlNameNestedOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsXmlNameNestedOutputResponseBody: Swift.Decodable {
+            extension XmlMapsXmlNameNestedOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -396,10 +396,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `011 decode flattened nested map with xmlname`() {
         val context = setupTests("Isolated/Restxml/xml-maps-flattened-nested-xmlname.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsFlattenedNestedXmlNameOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsFlattenedNestedXmlNameOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsFlattenedNestedXmlNameOutputResponseBody: Swift.Decodable {
+            extension XmlMapsFlattenedNestedXmlNameOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -442,10 +442,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `011 decode map with xmlnamespace`() {
         val context = setupTests("Isolated/Restxml/xml-maps-namespace.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsXmlNamespaceOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsXmlNamespaceOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsXmlNamespaceOutputResponseBody: Swift.Decodable {
+            extension XmlMapsXmlNamespaceOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -480,10 +480,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `012 decode flattened map with xmlnamespace`() {
         val context = setupTests("Isolated/Restxml/xml-maps-flattened-namespace.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsFlattenedXmlNamespaceOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsFlattenedXmlNamespaceOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsFlattenedXmlNamespaceOutputResponseBody: Swift.Decodable {
+            extension XmlMapsFlattenedXmlNamespaceOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -518,10 +518,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `013 decode nested map with xmlnamespace`() {
         val context = setupTests("Isolated/Restxml/xml-maps-nested-namespace.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsNestedXmlNamespaceOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsNestedXmlNamespaceOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsNestedXmlNamespaceOutputResponseBody: Swift.Decodable {
+            extension XmlMapsNestedXmlNamespaceOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -564,10 +564,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `014 decode nested flattened map with xmlnamespace`() {
         val context = setupTests("Isolated/Restxml/xml-maps-flattened-nested-namespace.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsFlattenedNestedXmlNamespaceOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsFlattenedNestedXmlNamespaceOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsFlattenedNestedXmlNamespaceOutputResponseBody: Swift.Decodable {
+            extension XmlMapsFlattenedNestedXmlNamespaceOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -609,10 +609,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `015 decode map containing list`() {
         val context = setupTests("Isolated/Restxml/xml-maps-contain-list.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsContainListOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsContainListOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsContainListOutputResponseBody: Swift.Decodable {
+            extension XmlMapsContainListOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -652,10 +652,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `016 decode flattened map containing list`() {
         val context = setupTests("Isolated/Restxml/xml-maps-flattened-contain-list.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsFlattenedContainListOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsFlattenedContainListOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsFlattenedContainListOutputResponseBody: Swift.Decodable {
+            extension XmlMapsFlattenedContainListOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                 }
@@ -696,10 +696,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `017 decode map containing timestamp`() {
         val context = setupTests("Isolated/Restxml/xml-maps-timestamp.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsTimestampsOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsTimestampsOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsTimestampsOutputResponseBody: Swift.Decodable {
+            extension XmlMapsTimestampsOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case timestampMap
                 }
@@ -734,10 +734,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `018 decode flattened map containing timestamp`() {
         val context = setupTests("Isolated/Restxml/xml-maps-flattened-timestamp.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsFlattenedTimestampsOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsFlattenedTimestampsOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsFlattenedTimestampsOutputResponseBody: Swift.Decodable {
+            extension XmlMapsFlattenedTimestampsOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case timestampMap
                 }
@@ -771,10 +771,10 @@ class MapDecodeXMLGenerationTests {
     @Test
     fun `019 two maps that may conflict with KeyValue`() {
         val context = setupTests("Isolated/Restxml/xml-maps-2x.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsTwoOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlMapsTwoOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlMapsTwoOutputResponseBody: Swift.Decodable {
+            extension XmlMapsTwoOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case myMap
                     case mySecondMap

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/MemberShapeDecodeXMLGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/MemberShapeDecodeXMLGeneratorTests.kt
@@ -17,10 +17,10 @@ class MemberShapeDecodeXMLGeneratorTests {
     @Test
     fun `001 set default value for a missing value of a scalar member`() {
         val context = setupTests("Isolated/Restxml/xml-scalarmember-default-value.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/SimpleScalarPropertiesOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/SimpleScalarPropertiesOutputBody+Decodable.swift")
         val expectedContents =
             """
-        extension SimpleScalarPropertiesOutputResponseBody: Swift.Decodable {
+        extension SimpleScalarPropertiesOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case byteValue
                 case doubleValue = "DoubleDribble"

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/RecursiveShapesDecodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/RecursiveShapesDecodeXMLGenerationTests.kt
@@ -16,10 +16,10 @@ class RecursiveShapesDecodeXMLGenerationTests {
     @Test
     fun `decode recursive shape`() {
         val context = setupTests("Isolated/Restxml/xml-recursive.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlRecursiveShapesOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlRecursiveShapesOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlRecursiveShapesOutputResponseBody: Swift.Decodable {
+            extension XmlRecursiveShapesOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case nested
                 }
@@ -37,10 +37,10 @@ class RecursiveShapesDecodeXMLGenerationTests {
     @Test
     fun `decode recursive nested shape`() {
         val context = setupTests("Isolated/Restxml/xml-recursive-nested.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlNestedRecursiveShapesOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlNestedRecursiveShapesOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlNestedRecursiveShapesOutputResponseBody: Swift.Decodable {
+            extension XmlNestedRecursiveShapesOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case nestedRecursiveList
                 }

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/SetDecodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/SetDecodeXMLGenerationTests.kt
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.Test
 
 class SetDecodeXMLGenerationTests {
     @Test
-    fun `XmlEnumSetOutputResponseBody decodable`() {
+    fun `XmlEnumSetOutputBody decodable`() {
         val context = setupTests("Isolated/Restxml/xml-sets.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlEnumSetOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlEnumSetOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlEnumSetOutputResponseBody: Swift.Decodable {
+            extension XmlEnumSetOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case fooEnumSet
                 }
@@ -53,12 +53,12 @@ class SetDecodeXMLGenerationTests {
     }
 
     @Test
-    fun `XmlEnumNestedSetOutputResponseBody nested decodable`() {
+    fun `XmlEnumNestedSetOutputBody nested decodable`() {
         val context = setupTests("Isolated/Restxml/xml-sets-nested.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlEnumNestedSetOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlEnumNestedSetOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlEnumNestedSetOutputResponseBody: Swift.Decodable {
+            extension XmlEnumNestedSetOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case fooEnumSet
                 }

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/StructDecodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/StructDecodeXMLGenerationTests.kt
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.Test
 
 class StructDecodeXMLGenerationTests {
     @Test
-    fun `XmlWrappedListOutputResponseBody decodable`() {
+    fun `XmlWrappedListOutputBody decodable`() {
         val context = setupTests("Isolated/Restxml/xml-lists-wrapped.smithy", "aws.protocoltests.restxml#RestXml")
 
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlWrappedListOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlWrappedListOutputBody+Decodable.swift")
         val expectedContents = """
-        extension XmlWrappedListOutputResponseBody: Swift.Decodable {
+        extension XmlWrappedListOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case myGroceryList
             }
@@ -53,12 +53,12 @@ class StructDecodeXMLGenerationTests {
     }
 
     @Test
-    fun `SimpleScalarPropertiesOutputResponseBody decodable`() {
+    fun `SimpleScalarPropertiesOutputBody decodable`() {
         val context = setupTests("Isolated/Restxml/xml-scalar.smithy", "aws.protocoltests.restxml#RestXml")
 
-        val contents = getFileContents(context.manifest, "/RestXml/models/SimpleScalarPropertiesOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/SimpleScalarPropertiesOutputBody+Decodable.swift")
         val expectedContents = """
-        struct SimpleScalarPropertiesOutputResponseBody: Swift.Equatable {
+        struct SimpleScalarPropertiesOutputBody: Swift.Equatable {
             let stringValue: Swift.String?
             let trueBooleanValue: Swift.Bool?
             let falseBooleanValue: Swift.Bool?
@@ -71,7 +71,7 @@ class StructDecodeXMLGenerationTests {
             let doubleValue: Swift.Double?
         }
         
-        extension SimpleScalarPropertiesOutputResponseBody: Swift.Decodable {
+        extension SimpleScalarPropertiesOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case byteValue
                 case doubleValue = "DoubleDribble"
@@ -117,9 +117,9 @@ class StructDecodeXMLGenerationTests {
     @Test
     fun `nestednested wrapped list deserialization`() {
         val context = setupTests("Isolated/Restxml/xml-lists-nestednested-wrapped.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlNestedNestedWrappedListOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlNestedNestedWrappedListOutputBody+Decodable.swift")
         val expectedContents = """
-        extension XmlNestedNestedWrappedListOutputResponseBody: Swift.Decodable {
+        extension XmlNestedNestedWrappedListOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case nestedNestedStringList
             }
@@ -168,10 +168,10 @@ class StructDecodeXMLGenerationTests {
     @Test
     fun `empty lists decode`() {
         val context = setupTests("Isolated/Restxml/xml-lists-empty.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlEmptyListsOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlEmptyListsOutputBody+Decodable.swift")
         val expectedContents =
             """
-            extension XmlEmptyListsOutputResponseBody: Swift.Decodable {
+            extension XmlEmptyListsOutputBody: Swift.Decodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case booleanList
                     case integerList

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/TimeStampDecodeGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/TimeStampDecodeGenerationTests.kt
@@ -16,9 +16,9 @@ class TimeStampDecodeGenerationTests {
     @Test
     fun `001 decode all timestamps`() {
         val context = setupTests("Isolated/Restxml/xml-timestamp.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlTimestampsOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlTimestampsOutputBody+Decodable.swift")
         val expectedContents = """
-        extension XmlTimestampsOutputResponseBody: Swift.Decodable {
+        extension XmlTimestampsOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case dateTime
                 case epochSeconds
@@ -46,9 +46,9 @@ class TimeStampDecodeGenerationTests {
     @Test
     fun `002 decode nested timestamps`() {
         val context = setupTests("Isolated/Restxml/xml-timestamp-nested.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlTimestampsNestedOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlTimestampsNestedOutputBody+Decodable.swift")
         val expectedContents = """
-        extension XmlTimestampsNestedOutputResponseBody: Swift.Decodable {
+        extension XmlTimestampsNestedOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case nestedTimestampList
             }
@@ -91,9 +91,9 @@ class TimeStampDecodeGenerationTests {
     @Test
     fun `003 decode nested timestamps HttpDate`() {
         val context = setupTests("Isolated/Restxml/xml-timestamp-nested.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlTimestampsNestedHTTPDateOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlTimestampsNestedHTTPDateOutputBody+Decodable.swift")
         val expectedContents = """
-        extension XmlTimestampsNestedHTTPDateOutputResponseBody: Swift.Decodable {
+        extension XmlTimestampsNestedHTTPDateOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case nestedTimestampList
             }
@@ -135,9 +135,9 @@ class TimeStampDecodeGenerationTests {
     @Test
     fun `004 decode nested timestamps xmlName`() {
         val context = setupTests("Isolated/Restxml/xml-timestamp-nested-xmlname.smithy", "aws.protocoltests.restxml#RestXml")
-        val contents = getFileContents(context.manifest, "/RestXml/models/XmlTimestampsNestedXmlNameOutputResponseBody+Decodable.swift")
+        val contents = getFileContents(context.manifest, "/RestXml/models/XmlTimestampsNestedXmlNameOutputBody+Decodable.swift")
         val expectedContents = """
-        extension XmlTimestampsNestedXmlNameOutputResponseBody: Swift.Decodable {
+        extension XmlTimestampsNestedXmlNameOutputBody: Swift.Decodable {
             enum CodingKeys: Swift.String, Swift.CodingKey {
                 case nestedTimestampList
             }

--- a/smithy-swift-codegen/src/test/kotlin/waiters/WaiterAcceptorGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/waiters/WaiterAcceptorGeneratorTests.kt
@@ -30,7 +30,7 @@ class WaiterAcceptorGeneratorTests {
         val context = setupTests("waiters.smithy", "com.test#TestHasWaiters", 0)
         val contents = getFileContents(context.manifest, "/Test/Waiters.swift")
         val expected = """
-            .init(state: .success, matcher: { (input: HeadBucketInput, result: Result<HeadBucketOutputResponse, Error>) -> Bool in
+            .init(state: .success, matcher: { (input: HeadBucketInput, result: Result<HeadBucketOutput, Error>) -> Bool in
                 switch result {
                     case .success: return true
                     case .failure: return false
@@ -45,7 +45,7 @@ class WaiterAcceptorGeneratorTests {
         val context = setupTests("waiters.smithy", "com.test#TestHasWaiters", 1)
         val contents = getFileContents(context.manifest, "/Test/Waiters.swift")
         val expected = """
-            .init(state: .retry, matcher: { (input: HeadBucketInput, result: Result<HeadBucketOutputResponse, Error>) -> Bool in
+            .init(state: .retry, matcher: { (input: HeadBucketInput, result: Result<HeadBucketOutput, Error>) -> Bool in
                 guard case .failure(let error) = result else { return false }
                 return (error as? ServiceError)?.typeName == "NotFound"
             }),
@@ -58,7 +58,7 @@ class WaiterAcceptorGeneratorTests {
         val context = setupTests("waiters.smithy", "com.test#TestHasWaiters", 2)
         val contents = getFileContents(context.manifest, "/Test/Waiters.swift")
         val expected = """
-            .init(state: .success, matcher: { (input: HeadBucketInput, result: Result<HeadBucketOutputResponse, Error>) -> Bool in
+            .init(state: .success, matcher: { (input: HeadBucketInput, result: Result<HeadBucketOutput, Error>) -> Bool in
                 // JMESPath expression: "field1"
                 // JMESPath comparator: "stringEquals"
                 // JMESPath expected value: "abc"
@@ -75,12 +75,12 @@ class WaiterAcceptorGeneratorTests {
         val context = setupTests("waiters.smithy", "com.test#TestHasWaiters", 3)
         val contents = getFileContents(context.manifest, "/Test/Waiters.swift")
         val expected = """
-            .init(state: .success, matcher: { (input: HeadBucketInput, result: Result<HeadBucketOutputResponse, Error>) -> Bool in
+            .init(state: .success, matcher: { (input: HeadBucketInput, result: Result<HeadBucketOutput, Error>) -> Bool in
                 // JMESPath expression: "input.bucketName == output.field1"
                 // JMESPath comparator: "booleanEquals"
                 // JMESPath expected value: "true"
                 guard case .success(let unwrappedOutput) = result else { return false }
-                let inputOutput = WaiterConfiguration<HeadBucketInput, HeadBucketOutputResponse>.Acceptor.InputOutput(input: input, output: unwrappedOutput)
+                let inputOutput = WaiterConfiguration<HeadBucketInput, HeadBucketOutput>.Acceptor.InputOutput(input: input, output: unwrappedOutput)
                 let input = inputOutput.input
                 let bucketName = input?.bucketName
                 let output = inputOutput.output

--- a/smithy-swift-codegen/src/test/kotlin/waiters/WaiterConfigGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/waiters/WaiterConfigGeneratorTests.kt
@@ -30,7 +30,7 @@ class WaiterConfigGeneratorTests {
         val context = setupTests("waiters.smithy", "com.test#TestHasWaiters")
         val contents = getFileContents(context.manifest, "/Test/Waiters.swift")
         val expected = """
-            static func bucketExistsWaiterConfig() throws -> WaiterConfiguration<HeadBucketInput, HeadBucketOutputResponse> {
+            static func bucketExistsWaiterConfig() throws -> WaiterConfiguration<HeadBucketInput, HeadBucketOutput> {
         """.trimIndent()
         contents.shouldContainOnlyOnce(expected)
     }
@@ -40,7 +40,7 @@ class WaiterConfigGeneratorTests {
         val context = setupTests("waiters.smithy", "com.test#TestHasWaiters")
         val contents = getFileContents(context.manifest, "/Test/Waiters.swift")
         val expected = """
-            return try WaiterConfiguration<HeadBucketInput, HeadBucketOutputResponse>(acceptors: acceptors, minDelay: 7.0, maxDelay: 22.0)
+            return try WaiterConfiguration<HeadBucketInput, HeadBucketOutput>(acceptors: acceptors, minDelay: 7.0, maxDelay: 22.0)
         """.trimIndent()
         contents.shouldContainOnlyOnce(expected)
     }
@@ -50,7 +50,7 @@ class WaiterConfigGeneratorTests {
         val context = setupTests("waiters.smithy", "com.test#TestHasWaiters")
         val contents = getFileContents(context.manifest, "/Test/Waiters.swift")
         val expected = """
-            let acceptors: [WaiterConfiguration<HeadBucketInput, HeadBucketOutputResponse>.Acceptor] = [
+            let acceptors: [WaiterConfiguration<HeadBucketInput, HeadBucketOutput>.Acceptor] = [
         """.trimIndent()
         contents.shouldContainOnlyOnce(expected)
     }

--- a/smithy-swift-codegen/src/test/kotlin/waiters/WaiterGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/waiters/WaiterGeneratorTests.kt
@@ -36,7 +36,7 @@ class WaiterGeneratorTests {
         val context = setupTests("waiters.smithy", "com.test#TestHasWaiters")
         val contents = getFileContents(context.manifest, "/Test/Waiters.swift")
         val expected = """
-            return try WaiterConfiguration<HeadBucketInput, HeadBucketOutputResponse>(acceptors: acceptors, minDelay: 7.0, maxDelay: 22.0)
+            return try WaiterConfiguration<HeadBucketInput, HeadBucketOutput>(acceptors: acceptors, minDelay: 7.0, maxDelay: 22.0)
         """.trimIndent()
         contents.shouldContainOnlyOnce(expected)
     }
@@ -46,7 +46,7 @@ class WaiterGeneratorTests {
         val context = setupTests("waiters.smithy", "com.test#TestHasWaiters")
         val contents = getFileContents(context.manifest, "/Test/Waiters.swift")
         val expected = """
-            public func waitUntilBucketExists(options: WaiterOptions, input: HeadBucketInput) async throws -> WaiterOutcome<HeadBucketOutputResponse> {
+            public func waitUntilBucketExists(options: WaiterOptions, input: HeadBucketInput) async throws -> WaiterOutcome<HeadBucketOutput> {
         """.trimIndent()
         contents.shouldContainOnlyOnce(expected)
     }

--- a/smithy-swift-codegen/src/test/kotlin/waiters/WaiterMethodGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/waiters/WaiterMethodGeneratorTests.kt
@@ -41,7 +41,7 @@ class WaiterMethodGeneratorTests {
             /// - Throws: `WaiterFailureError` if the waiter fails due to matching an `Acceptor` with state `failure`
             /// or there is an error not handled by any `Acceptor.`
             /// `WaiterTimeoutError` if the waiter times out.
-            public func waitUntilBucketExists(options: WaiterOptions, input: HeadBucketInput) async throws -> WaiterOutcome<HeadBucketOutputResponse> {
+            public func waitUntilBucketExists(options: WaiterOptions, input: HeadBucketInput) async throws -> WaiterOutcome<HeadBucketOutput> {
                 let waiter = Waiter(config: try Self.bucketExistsWaiterConfig(), operation: self.headBucket(input:))
                 return try await waiter.waitUntil(options: options, input: input)
             }


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1169

## Description of changes
In the past, operations could return either an `OutputResponse` or an `OutputError`.  SDK error handling was refactored to eliminate the `OutputError` enumeration, but the `OutputResponse` suffix remains on operation output structures.

To provide for more concise & intuitive naming, and to be consistent with both operation input structures and with the practice in other AWS SDKs, output structures will have the `Response` suffix removed from their name.

This is a breaking change because references to operation output structures will have to ba changed to refer to the new name.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.