### PR TITLE
chore: Require Swift 5.7, fix deprecation warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 
 import PackageDescription
 
@@ -13,9 +13,9 @@ let package = Package(
         .library(name: "SmithyTestUtil", targets: ["SmithyTestUtil"])
     ],
     dependencies: [
-        .package(url: "https://github.com/awslabs/aws-crt-swift.git", .exact("0.13.0")),
+        .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.13.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-        .package(url: "https://github.com/MaxDesiatov/XMLCoder.git", .exact("0.17.0"))
+        .package(url: "https://github.com/MaxDesiatov/XMLCoder.git", exact: "0.17.0")
     ],
     targets: [
         .target(

--- a/Sources/ClientRuntime/Retries/DefaultRetryStrategy/RetryQuota.swift
+++ b/Sources/ClientRuntime/Retries/DefaultRetryStrategy/RetryQuota.swift
@@ -55,7 +55,7 @@ final actor RetryQuota {
 
     /// Creates a new quota with settings from the passed options.
     /// - Parameter options: The retry strategy options from which to configure this retry quota
-    convenience init(options: RetryStrategyOptions) {
+    init(options: RetryStrategyOptions) {
         self.init(
             availableCapacity: options.availableCapacity,
             maxCapacity: options.maxCapacity,

--- a/Sources/ClientRuntime/Util/SwiftVersion.swift
+++ b/Sources/ClientRuntime/Util/SwiftVersion.swift
@@ -49,20 +49,6 @@ private func swift5Version() -> String? {
     return "5.8"
     #elseif swift(>=5.7)
     return "5.7"
-    #elseif swift(>=5.6)
-    return "5.6"
-    #elseif swift(>=5.5)
-    return "5.5"
-    #elseif swift(>=5.4)
-    return "5.4"
-    #elseif swift(>=5.3)
-    return "5.3"
-    #elseif swift(>=5.2)
-    return "5.2"
-    #elseif swift(>=5.1)
-    return "5.1"
-    #elseif swift(>=5.0)
-    return "5.0"
     #else
     return nil
     #endif


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1010

## Description of changes
- Sets minimum required Swift version to 5.7 or greater
- Fixes deprecation warnings for Swift code

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.