### PR TITLE
feat: add limited support in smithy-swift for visionOS

### DIFF
--- a/Sources/ClientRuntime/Util/PlatformOperatingSystem.swift
+++ b/Sources/ClientRuntime/Util/PlatformOperatingSystem.swift
@@ -13,6 +13,7 @@ public enum PlatformOperatingSystem: String {
     case watchOS
     case tvOS
     case unknown
+    case visionOS
 }
 
 public var currentOS: PlatformOperatingSystem {
@@ -28,6 +29,8 @@ public var currentOS: PlatformOperatingSystem {
     return .windows
     #elseif os(tvOS)
     return .tvOS
+    #elseif os(visionOS)
+    return .visionOS
     #else
      #error("Cannot use a an operating system we do not support")
     #endif

--- a/Sources/ClientRuntime/Util/PlatformOperatingSystem.swift
+++ b/Sources/ClientRuntime/Util/PlatformOperatingSystem.swift
@@ -12,8 +12,8 @@ public enum PlatformOperatingSystem: String {
     case macOS
     case watchOS
     case tvOS
-    case unknown
     case visionOS
+    case unknown
 }
 
 public var currentOS: PlatformOperatingSystem {


### PR DESCRIPTION
Add limited support in smithy-swift for visionOS. Currently, we throw an error if a user tries to compile for visionOS. While we may not provide full support for it or put effort into testing related features, we should allow users to experiment with it and support the SDK compiling.

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
Add visionOS as a supported platform.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.