### PR TITLE
fix: content-length middleware should not error on event streams

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/Middlewares/ContentLengthMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/ContentLengthMiddleware.swift
@@ -12,8 +12,10 @@ public struct ContentLengthMiddleware<OperationStackOutput: HttpResponseBinding>
 
     /// Creates a new `ContentLengthMiddleware` with the supplied parameters
     /// - Parameters:
-    ///   - requiresLength: Trait requires the length of a blob stream to be known. Defaults to `nil`.
-    ///   - unsignedPayload: Trait signifies that the length of a stream may not be known. Defaults to `nil`.
+    ///   - requiresLength: Trait requires the length of a blob stream to be known. 
+    ///     When the request body is not a streaming blob, `nil` should be passed. Defaults to `nil`.
+    ///   - unsignedPayload: Trait signifies that the length of a stream in payload does not need to be known.
+    ///     When the request body is not a streaming blob, `nil` should be passed. Defaults to `nil`.
     public init(requiresLength: Bool? = nil, unsignedPayload: Bool? = nil) {
         self.requiresLength = requiresLength
         self.unsignedPayload = unsignedPayload

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/ContentLengthMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/ContentLengthMiddleware.swift
@@ -10,8 +10,10 @@ public struct ContentLengthMiddleware<OperationStackOutput: HttpResponseBinding>
 
     private var unsignedPayload: Bool?
 
-    // Blob streams will explicitly set requiresLength and unsignedPayload to true or false
-    // All other streams requiresLength and unsignedPayload will default to nil
+    /// Creates a new `ContentLengthMiddleware` with the supplied parameters
+    /// - Parameters:
+    ///   - requiresLength: Trait requires the length of a blob stream to be known. Defaults to `nil`.
+    ///   - unsignedPayload: Trait signifies that the length of a stream may not be known. Defaults to `nil`.
     public init(requiresLength: Bool? = nil, unsignedPayload: Bool? = nil) {
         self.requiresLength = requiresLength
         self.unsignedPayload = unsignedPayload

--- a/Sources/ClientRuntime/Util/PlatformOperatingSystem.swift
+++ b/Sources/ClientRuntime/Util/PlatformOperatingSystem.swift
@@ -14,7 +14,6 @@ public enum PlatformOperatingSystem: String {
     case tvOS
     case visionOS
     case unknown
-    case visionOS
 }
 
 public var currentOS: PlatformOperatingSystem {

--- a/Sources/ClientRuntime/Util/PlatformOperatingSystem.swift
+++ b/Sources/ClientRuntime/Util/PlatformOperatingSystem.swift
@@ -14,6 +14,7 @@ public enum PlatformOperatingSystem: String {
     case tvOS
     case visionOS
     case unknown
+    case visionOS
 }
 
 public var currentOS: PlatformOperatingSystem {

--- a/Tests/ClientRuntimeTests/NetworkingTests/ContentLengthMiddlewareTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/ContentLengthMiddlewareTests.swift
@@ -27,7 +27,7 @@ class ContentLengthMiddlewareTests: XCTestCase {
         try await AssertHeadersArePresent(expectedHeaders: ["Transfer-Encoding": "Chunked"])
     }
 
-    func testRequiresLengthSetWithNilStreamShouldThrowError() async throws {
+    func testTransferEncodingChunkedSetWithNilTraits() async throws {
         // default constructor
         addContentLengthMiddlewareWith(requiresLength: nil, unsignedPayload: nil)
         forceEmptyStream()
@@ -61,7 +61,7 @@ class ContentLengthMiddlewareTests: XCTestCase {
         }
     }
 
-    private func addContentLengthMiddlewareWith(requiresLength: Bool, unsignedPayload: Bool) {
+    private func addContentLengthMiddlewareWith(requiresLength: Bool?, unsignedPayload: Bool?) {
         stack.finalizeStep.intercept(
             position: .before,
             middleware: ContentLengthMiddleware(requiresLength: requiresLength, unsignedPayload: unsignedPayload)

--- a/Tests/ClientRuntimeTests/NetworkingTests/ContentLengthMiddlewareTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/ContentLengthMiddlewareTests.swift
@@ -27,6 +27,13 @@ class ContentLengthMiddlewareTests: XCTestCase {
         try await AssertHeadersArePresent(expectedHeaders: ["Transfer-Encoding": "Chunked"])
     }
 
+    func testRequiresLengthSetWithNilStreamShouldThrowError() async throws {
+        // default constructor
+        addContentLengthMiddlewareWith(requiresLength: nil, unsignedPayload: nil)
+        forceEmptyStream()
+        try await AssertHeadersArePresent(expectedHeaders: ["Transfer-Encoding": "Chunked"])
+    }
+
     func testContentLengthSetWhenStreamLengthAvailableAndRequiresLengthSet() async throws {
         addContentLengthMiddlewareWith(requiresLength: true, unsignedPayload: false)
         try await AssertHeadersArePresent(expectedHeaders: ["Content-Length": "0"])


### PR DESCRIPTION
Event streams should not be subject to logic that applies only to data streams

## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1177

## Description of changes
- Add back default behavior of adding `Transfer-Encoding: Chunked` header on any event streams where length cannot be calculated
- Have `ContentLengthMiddleware()` default behavior used by non-blob streams set requiresLength and unsignedPayload to nil since these traits are only relevant for determining failure condition on blob stream
- Add test for this scenario
- Confirmed that structure of AWS Transcribe (failing integration test) would code-generate `ContentLengthMiddleware()`

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.