### PR TITLE
chore: Convert idempotency token middleware from closure to reusable type

### DIFF
--- a/Sources/ClientRuntime/Idempotency/IdempotencyTokenMiddleware.swift
+++ b/Sources/ClientRuntime/Idempotency/IdempotencyTokenMiddleware.swift
@@ -1,0 +1,33 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public struct IdempotencyTokenMiddleware<OperationStackInput,
+                                         OperationStackOutput: HttpResponseBinding,
+                                         OperationStackError: HttpResponseErrorBinding>: ClientRuntime.Middleware {
+    public let id: Swift.String = "IdempotencyTokenMiddleware"
+    private let keyPath: WritableKeyPath<OperationStackInput, String?>
+
+    public init(keyPath: WritableKeyPath<OperationStackInput, String?>) {
+        self.keyPath = keyPath
+    }
+
+    public func handle<H>(context: Context,
+                          input: MInput,
+                          next: H) async throws -> MOutput
+    where H: Handler, Self.MInput == H.Input, Self.MOutput == H.Output, Self.Context == H.Context {
+        var copiedInput = input
+        if input[keyPath: keyPath] == nil {
+            let idempotencyTokenGenerator = context.getIdempotencyTokenGenerator()
+            copiedInput[keyPath: keyPath] = idempotencyTokenGenerator.generateToken()
+        }
+        return try await next.handle(context: context, input: copiedInput)
+    }
+
+    public typealias MInput = OperationStackInput
+    public typealias MOutput = OperationOutput<OperationStackOutput>
+    public typealias Context = HttpContext
+}

--- a/Tests/ClientRuntimeTests/Idempotency/IdempotencyTokenMiddlewareTests.swift
+++ b/Tests/ClientRuntimeTests/Idempotency/IdempotencyTokenMiddlewareTests.swift
@@ -1,0 +1,86 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import ClientRuntime
+import XCTest
+
+class IdempotencyTokenMiddlewareTests: XCTestCase {
+
+    private typealias Subject = IdempotencyTokenMiddleware<TestInputType, TestOutputType, TestOutputErrorType>
+
+    let token = "def"
+    let previousToken = "abc"
+    private var tokenGenerator: IdempotencyTokenGenerator!
+    private var context: HttpContext!
+    private var subject: Subject!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tokenGenerator = TestIdempotencyTokenGenerator(token: token)
+        context = HttpContextBuilder().withIdempotencyTokenGenerator(value: tokenGenerator).build()
+        subject = Subject(keyPath: \.tokenMember)
+    }
+
+    func test_handle_itSetsAnIdempotencyTokenIfNoneIsSet() async throws {
+        let input = TestInputType(tokenMember: nil)
+        let next = MockHandler<TestInputType, TestOutputType> { (context, input) in
+            XCTAssertEqual(input.tokenMember, self.token)
+        }
+        _ = try await subject.handle(context: context, input: input, next: next)
+    }
+
+    func test_handle_itDoesNotChangeTheIdempotencyTokenIfAlreadySet() async throws {
+        let input = TestInputType(tokenMember: previousToken)
+        let next = MockHandler<TestInputType, TestOutputType> { (context, input) in
+            XCTAssertEqual(input.tokenMember, self.previousToken)
+        }
+        _ = try await subject.handle(context: context, input: input, next: next)
+    }
+}
+
+// MARK: - Test fixtures & types
+
+private struct TestIdempotencyTokenGenerator: IdempotencyTokenGenerator {
+    let token: String
+    func generateToken() -> String { token }
+}
+
+private struct TestInputType {
+    var tokenMember: String?
+}
+
+private struct TestOutputType: HttpResponseBinding {
+    init(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder?) async throws {
+        // no-op
+    }
+}
+
+private enum TestOutputErrorType: HttpResponseErrorBinding {
+    static func makeError(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder?) async throws -> Error {
+        return TestError()
+    }
+}
+
+private struct TestError: Error {}
+
+private struct MockHandler<I, O: HttpResponseBinding>: Handler {
+    typealias Output = OperationOutput<O>
+    typealias Context = HttpContext
+    typealias MockHandlerCallback = (Context, I) async throws -> Void
+
+    private let handleCallback: MockHandlerCallback
+
+    init(handleCallback: @escaping MockHandlerCallback) {
+        self.handleCallback = handleCallback
+    }
+
+    func handle(context: Context, input: I) async throws -> Output {
+        try await handleCallback(context, input)
+        return OperationOutput(httpResponse: HttpResponse())
+    }
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ClientRuntimeTypes.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ClientRuntimeTypes.kt
@@ -75,6 +75,7 @@ object ClientRuntimeTypes {
         val HeaderMiddleware = runtimeSymbol("HeaderMiddleware")
         val SerializableBodyMiddleware = runtimeSymbol("SerializableBodyMiddleware")
         val RetryMiddleware = runtimeSymbol("RetryMiddleware")
+        val IdempotencyTokenMiddleware = runtimeSymbol("IdempotencyTokenMiddleware")
         val NoopHandler = runtimeSymbol("NoopHandler")
 
         object Providers {

--- a/smithy-swift-codegen/src/test/kotlin/ContentMd5MiddlewareTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ContentMd5MiddlewareTests.kt
@@ -27,14 +27,7 @@ class ContentMd5MiddlewareTests {
                                   .withPartitionID(value: config.partitionID)
                                   .build()
                     var operation = ClientRuntime.OperationStack<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>(id: "idempotencyTokenWithStructure")
-                    operation.initializeStep.intercept(position: .after, id: "IdempotencyTokenMiddleware") { (context, input, next) -> ClientRuntime.OperationOutput<IdempotencyTokenWithStructureOutput> in
-                        let idempotencyTokenGenerator = context.getIdempotencyTokenGenerator()
-                        var copiedInput = input
-                        if input.token == nil {
-                            copiedInput.token = idempotencyTokenGenerator.generateToken()
-                        }
-                        return try await next.handle(context: context, input: copiedInput)
-                    }
+                    operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.IdempotencyTokenMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>(keyPath: \.token))
                     operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>())
                     operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput>())
                     operation.buildStep.intercept(position: .before, middleware: ClientRuntime.ContentMD5Middleware<IdempotencyTokenWithStructureOutput>())

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
@@ -125,14 +125,7 @@ class HttpProtocolClientGeneratorTests {
                               .withPartitionID(value: config.partitionID)
                               .build()
                 var operation = ClientRuntime.OperationStack<AllocateWidgetInput, AllocateWidgetOutput, AllocateWidgetOutputError>(id: "allocateWidget")
-                operation.initializeStep.intercept(position: .after, id: "IdempotencyTokenMiddleware") { (context, input, next) -> ClientRuntime.OperationOutput<AllocateWidgetOutput> in
-                    let idempotencyTokenGenerator = context.getIdempotencyTokenGenerator()
-                    var copiedInput = input
-                    if input.clientToken == nil {
-                        copiedInput.clientToken = idempotencyTokenGenerator.generateToken()
-                    }
-                    return try await next.handle(context: context, input: copiedInput)
-                }
+                operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.IdempotencyTokenMiddleware<AllocateWidgetInput, AllocateWidgetOutput, AllocateWidgetOutputError>(keyPath: \.clientToken))
                 operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<AllocateWidgetInput, AllocateWidgetOutput, AllocateWidgetOutputError>())
                 operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<AllocateWidgetInput, AllocateWidgetOutput>())
                 operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<AllocateWidgetInput, AllocateWidgetOutput>(contentType: "application/json"))

--- a/smithy-swift-codegen/src/test/kotlin/IdempotencyTokenTraitTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/IdempotencyTokenTraitTests.kt
@@ -27,14 +27,7 @@ class IdempotencyTokenTraitTests {
                                   .withPartitionID(value: config.partitionID)
                                   .build()
                     var operation = ClientRuntime.OperationStack<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>(id: "idempotencyTokenWithStructure")
-                    operation.initializeStep.intercept(position: .after, id: "IdempotencyTokenMiddleware") { (context, input, next) -> ClientRuntime.OperationOutput<IdempotencyTokenWithStructureOutput> in
-                        let idempotencyTokenGenerator = context.getIdempotencyTokenGenerator()
-                        var copiedInput = input
-                        if input.token == nil {
-                            copiedInput.token = idempotencyTokenGenerator.generateToken()
-                        }
-                        return try await next.handle(context: context, input: copiedInput)
-                    }
+                    operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.IdempotencyTokenMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>(keyPath: \.token))
                     operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput, IdempotencyTokenWithStructureOutputError>())
                     operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput>())
                     operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<IdempotencyTokenWithStructureInput, IdempotencyTokenWithStructureOutput>(contentType: "application/xml"))


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1202

## Description of changes
Changes the idempotency token middleware from an anonymous closure that is rendered inline at every point of use to a reusable Swift type that is placed under unit test.

The reusable middleware uses Swift key paths to specify the idempotency token member on the input structure; the input structure type and the key path are passed as initialization parameters to the reusable middleware.

We currently have ~710 operations that use idempotency tokens throughout the SDK, and this change reduces generated SDK size by about 5000 lines by not duplicating the idempotency token code at every point of use.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.