### PR TITLE
fix: Endpoint url should be nil if host or scheme is missing

### DIFF
--- a/Sources/ClientRuntime/Networking/Endpoint.swift
+++ b/Sources/ClientRuntime/Networking/Endpoint.swift
@@ -63,10 +63,10 @@ extension Endpoint {
     public var url: URL? {
         var components = URLComponents()
         components.scheme = protocolType?.rawValue
-        components.host = host
+        components.host = host.isEmpty ? nil : host // If host is empty, URL is invalid
         components.percentEncodedPath = path
         components.percentEncodedQuery = queryItemString
-        return components.url
+        return (components.host == nil || components.scheme == nil) ? nil : components.url
     }
 
     var queryItemString: String? {

--- a/Tests/ClientRuntimeTests/NetworkingTests/HttpRequestTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/HttpRequestTests.swift
@@ -111,7 +111,9 @@ class HttpRequestTests: NetworkingTestUtils {
     }
 
     func testConversionToUrlRequestFailsWithInvalidEndpoint() {
-        // TODO:: When is the endpoint invalid or endpoint.url nil?
-        _ = Endpoint(host: "", path: "", protocolType: nil)
+        // Testing with an invalid endpoint where host is empty,
+        // path is empty, and protocolType is nil.
+        let endpoint = Endpoint(host: "", path: "", protocolType: nil)
+        XCTAssertNil(endpoint.url, "An invalid endpoint should result in a nil URL.")
     }
 }


### PR DESCRIPTION
URL extension was set to optional to account for nil properties, but nil was never returned. As a result there was a TODO in the test wondering when endpoint.url should be nil.

## Issue \#
[#710](https://github.com/awslabs/aws-sdk-swift/issues/710)

## Description of changes
- Update code logic to set url to nil if host or scheme is nil (invalid URL)
- Update test to check for nil URL
- Remove TODO

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.