### PR TITLE
add default log level to initialize method

### DIFF
--- a/Sources/ClientRuntime/Logging/SDKLoggingSystem.swift
+++ b/Sources/ClientRuntime/Logging/SDKLoggingSystem.swift
@@ -15,13 +15,13 @@ public class SDKLoggingSystem {
         factories[label] = logHandlerFactory
     }
 
-    public class func initialize() {
+    public class func initialize(defaultLogLevel: SDKLogLevel = .info) {
         LoggingSystem.bootstrap { label in
             if let factory = factories[label] {
                 return factory.construct(label: label)
             }
             var handler = StreamLogHandler.standardOutput(label: label)
-            handler.logLevel = .info
+            handler.logLevel = defaultLogLevel.toLoggerType()
             return handler
         }
     }


### PR DESCRIPTION
Make it possible to set specific log configuration to some items and then a default one for non-set ones.



## Description of changes
Adding default value as parameter to initialize method

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

Edit: Just noticed the commit should have a special [format](https://github.com/smithy-lang/smithy-swift/blob/main/CONTRIBUTING.md) sorry.. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.