### PR TITLE
fix: allow isTruncated to be optional bool

### DIFF
--- a/Sources/ClientRuntime/Pagination/PaginatorSequence.swift
+++ b/Sources/ClientRuntime/Pagination/PaginatorSequence.swift
@@ -12,13 +12,13 @@ public struct PaginatorSequence<OperationStackInput: PaginateToken, OperationSta
     let input: OperationStackInput
     let inputKey: KeyPath<OperationStackInput, OperationStackInput.Token?>?
     let outputKey: KeyPath<OperationStackOutput, OperationStackInput.Token?>
-    var isTruncatedKey: KeyPath<OperationStackOutput, Bool>?
+    var isTruncatedKey: KeyPath<OperationStackOutput, Bool?>?
     let paginationFunction: (OperationStackInput) async throws -> OperationStackOutput
 
     public init(input: OperationStackInput,
                 inputKey: KeyPath<OperationStackInput, OperationStackInput.Token?>? = nil,
                 outputKey: KeyPath<OperationStackOutput, OperationStackInput.Token?>,
-                isTruncatedKey: KeyPath<OperationStackOutput, Bool>? = nil,
+                isTruncatedKey: KeyPath<OperationStackOutput, Bool?>? = nil,
                 paginationFunction: @escaping (OperationStackInput) async throws -> OperationStackOutput) {
         self.input = input
         self.inputKey = inputKey
@@ -51,7 +51,7 @@ public struct PaginatorSequence<OperationStackInput: PaginateToken, OperationSta
 
                 // Use isTruncatedKey from the sequence to check if pagination should continue
                 if let isTruncatedKey = sequence.isTruncatedKey {
-                    let isTruncated = output[keyPath: isTruncatedKey]
+                    let isTruncated = output[keyPath: isTruncatedKey] ?? false
                     if !isTruncated {
                         // set token to nil to break out of the next iteration
                         token = nil


### PR DESCRIPTION
S3's ListParts had a nullability change for `isTruncated`

## Issue \#
[#1021](https://github.com/awslabs/aws-sdk-swift/issues/1021)

## Description of changes
Change type of `isTruncated` and `isTruncatedKey` to accept an optional bool and default to false

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.