### PR TITLE
chore: Run tvOS old & new in CI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ let package = Package(
     name: "smithy-swift",
     platforms: [
         .macOS(.v10_15),
-        .iOS(.v13)
+        .iOS(.v13),
+        .tvOS(.v13)
     ],
     products: [
         .library(name: "ClientRuntime", targets: ["ClientRuntime"]),


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/376

## Description of changes
Sets tvOS minimum version of 13.0 to match minimum in `aws-crt-swift`, so that smithy-swift can build for tvOS.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.