### PR TITLE
fix: add back from method with fileHandle

### DIFF
--- a/Sources/ClientRuntime/Networking/Streaming/ByteStream.swift
+++ b/Sources/ClientRuntime/Networking/Streaming/ByteStream.swift
@@ -116,3 +116,13 @@ extension ByteStream: CustomDebugStringConvertible {
         }
     }
 }
+
+extension ByteStream {
+
+    /// Returns ByteStream from a FileHandle object.
+    /// - Parameter fileHandle: FileHandle object to be converted to ByteStream.
+    /// - Returns: ByteStream representation of the FileHandle object.
+    public static func from(fileHandle: FileHandle) -> ByteStream {
+        return .stream(FileStream(fileHandle: fileHandle))
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
#634 

## Description of changes
Add back helper method from 0.36.0 to create a Bytestream .stream from FileStream(filehandle)

Usage: `let fileByteStream = ByteStream.from(fileHandle: fileHandle)`


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.