### PR TITLE
fix!: Add no-op behavior for initialize methods of logging system.

### DIFF
--- a/Sources/ClientRuntime/Logging/SDKLoggingSystem.swift
+++ b/Sources/ClientRuntime/Logging/SDKLoggingSystem.swift
@@ -8,6 +8,7 @@
 import Logging
 
 public class SDKLoggingSystem {
+    private static var isInitialized = false
     private static var factories: [String: SDKLogHandlerFactory] = [:]
 
     public class func add(logHandlerFactory: SDKLogHandlerFactory) {
@@ -16,6 +17,7 @@ public class SDKLoggingSystem {
     }
 
     public class func initialize(defaultLogLevel: SDKLogLevel = .info) {
+        if isInitialized { return } else { isInitialized = true }
         LoggingSystem.bootstrap { label in
             if let factory = factories[label] {
                 return factory.construct(label: label)
@@ -27,6 +29,7 @@ public class SDKLoggingSystem {
     }
 
     public class func initialize(logLevel: SDKLogLevel) {
+        if isInitialized { return } else { isInitialized = true }
         LoggingSystem.bootstrap { label in
             var handler = StreamLogHandler.standardOutput(label: label)
             handler.logLevel = logLevel.toLoggerType()

--- a/Sources/ClientRuntime/Logging/SDKLoggingSystem.swift
+++ b/Sources/ClientRuntime/Logging/SDKLoggingSystem.swift
@@ -7,16 +7,16 @@
 
 import Logging
 
-public class SDKLoggingSystem {
+public actor SDKLoggingSystem {
     private static var isInitialized = false
     private static var factories: [String: SDKLogHandlerFactory] = [:]
 
-    public class func add(logHandlerFactory: SDKLogHandlerFactory) {
+    public static func add(logHandlerFactory: SDKLogHandlerFactory) {
         let label = logHandlerFactory.label
         factories[label] = logHandlerFactory
     }
 
-    public class func initialize(defaultLogLevel: SDKLogLevel = .info) {
+    public static func initialize(defaultLogLevel: SDKLogLevel = .info) {
         if isInitialized { return } else { isInitialized = true }
         LoggingSystem.bootstrap { label in
             if let factory = factories[label] {
@@ -28,7 +28,7 @@ public class SDKLoggingSystem {
         }
     }
 
-    public class func initialize(logLevel: SDKLogLevel) {
+    public static func initialize(logLevel: SDKLogLevel) {
         if isInitialized { return } else { isInitialized = true }
         LoggingSystem.bootstrap { label in
             var handler = StreamLogHandler.standardOutput(label: label)

--- a/Sources/ClientRuntime/Logging/SDKLoggingSystem.swift
+++ b/Sources/ClientRuntime/Logging/SDKLoggingSystem.swift
@@ -16,7 +16,7 @@ public actor SDKLoggingSystem {
         factories[label] = logHandlerFactory
     }
 
-    public static func initialize(defaultLogLevel: SDKLogLevel = .info) {
+    public static func initialize(defaultLogLevel: SDKLogLevel = .info) async {
         if isInitialized { return } else { isInitialized = true }
         LoggingSystem.bootstrap { label in
             if let factory = factories[label] {
@@ -28,7 +28,7 @@ public actor SDKLoggingSystem {
         }
     }
 
-    public static func initialize(logLevel: SDKLogLevel) {
+    public static func initialize(logLevel: SDKLogLevel) async {
         if isInitialized { return } else { isInitialized = true }
         LoggingSystem.bootstrap { label in
             var handler = StreamLogHandler.standardOutput(label: label)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/903

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Calling `bootstrap` method of `swift-log`'s `LoggingSystem` more than once per program execution results in unexpected behavior ([swift-log spec](https://github.com/apple/swift-log/blob/e97a6fcb1ab07462881ac165fdbb37f067e205d5/Sources/Logging/Logging.swift#L672-L674)), most likely a crash.

To avoid this crash, no-op behavior is added to `SDKLoggingSystem` which wraps `LoggingSystem`. Whether the `initialize` methods have been already called or not is internally recorded to `isInitialized` variable. If yes, methods return with no-op done.

To make it thread-safe, `SDKLoggingSystem` is made an actor, and methods made async. This change is a breaking change. 

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.