### PR TITLE
feat: add wrapper for checksums + unit tests

### DIFF
--- a/Sources/ClientRuntime/Networking/HashFunction.swift
+++ b/Sources/ClientRuntime/Networking/HashFunction.swift
@@ -10,6 +10,11 @@ enum HashResult {
     case integer(UInt32)
 }
 
+enum HashError: Error {
+    case invalidInput
+    case hashingFailed(reason: String)
+}
+
 enum HashFunction {
     case crc32, crc32c, sha1, sha256, md5
 
@@ -46,21 +51,21 @@ enum HashFunction {
                 let hashed = try data.computeSHA1()
                 return .data(hashed)
             } catch {
-                throw ClientRuntime.ClientError.unknownError("Error computing SHA1: \(error)")
+                throw HashError.hashingFailed(reason: "Error computing SHA1: \(error)")
             }
         case .sha256:
             do {
                 let hashed = try data.computeSHA256()
                 return .data(hashed)
             } catch {
-                throw ClientRuntime.ClientError.unknownError("Error computing SHA256: \(error)")
+                throw HashError.hashingFailed(reason: "Error computing SHA256: \(error)")
             }
         case .md5:
             do {
                 let hashed = try data.computeMD5()
                 return .data(hashed)
             } catch {
-                throw ClientRuntime.ClientError.unknownError("Error computing MD5: \(error)")
+                throw HashError.hashingFailed(reason: "Error computing MD5: \(error)")
             }
         }
     }

--- a/Sources/ClientRuntime/Networking/HashFunction.swift
+++ b/Sources/ClientRuntime/Networking/HashFunction.swift
@@ -1,0 +1,100 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+import AwsCommonRuntimeKit
+
+enum HashFunction {
+    case crc32, crc32c, sha1, sha256, md5
+
+    static func from(string: String) -> HashFunction? {
+        switch string.lowercased() {
+        case "crc32": return .crc32
+        case "crc32c": return .crc32c
+        case "sha1": return .sha1
+        case "sha256": return .sha256
+        case "md5": return .md5 // md5 is not a valid flexible checksum algorithm
+        default: return nil
+        }
+    }
+
+    var isSupported: Bool {
+        switch self {
+        case .crc32, .crc32c, .sha256, .sha1:
+            return true
+        default:
+            return false
+        }
+    }
+
+    func computeHash(of data: Data) throws -> Data? {
+        switch self {
+        case .crc32:
+            // Should turn this result back into a UInt32 using .toUInt32()
+            return Data(fromUInt32: data.computeCRC32())
+        case .crc32c:
+            // Should turn this result back into a UInt32 using .toUInt32()
+            return Data(fromUInt32: data.computeCRC32C())
+        case .sha1:
+            do {
+                let hashed = try data.computeSHA1()
+                return Data(hashed)
+            } catch {
+                throw ClientRuntime.ClientError.unknownError("Error computing SHA1: \(error)")
+            }
+        case .sha256:
+            do {
+                let hashed = try data.computeSHA256()
+                return Data(hashed)
+            } catch {
+                throw ClientRuntime.ClientError.unknownError("Error computing SHA256: \(error)")
+            }
+        case .md5:
+            do {
+                let hashed = try data.computeMD5()
+                return Data(hashed)
+            } catch {
+                throw ClientRuntime.ClientError.unknownError("Error computing MD5: \(error)")
+            }
+        }
+    }
+}
+
+protocol HexStringable {
+    func toHexString() -> String
+}
+
+extension Data {
+
+    // Create a Data type from a UInt32 value
+    init(fromUInt32 value: UInt32) {
+        var val = value // Create a mutable UInt32
+        self = Swift.withUnsafeBytes(of: &val) { Data($0) }
+    }
+
+    // Convert a Data type to UInt32
+    func toUInt32() -> UInt32? {
+        guard self.count == MemoryLayout<UInt32>.size else {
+            return nil // Ensures the data is of the correct size
+        }
+
+        return self.withUnsafeBytes { $0.load(as: UInt32.self) }
+    }
+}
+
+extension Data: HexStringable {
+
+    // Convert a Data type to a hexademical String
+    func toHexString() -> String {
+        return map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+extension UInt32: HexStringable {
+
+    // Convert a UInt32 type to a hexademical String
+    func toHexString() -> String {
+        return String(format: "%08x", self)
+    }
+}

--- a/Sources/ClientRuntime/Networking/HashFunction.swift
+++ b/Sources/ClientRuntime/Networking/HashFunction.swift
@@ -61,10 +61,6 @@ enum HashFunction {
     }
 }
 
-protocol HexStringable {
-    func toHexString() -> String
-}
-
 extension Data {
 
     // Create a Data type from a UInt32 value
@@ -81,6 +77,10 @@ extension Data {
 
         return self.withUnsafeBytes { $0.load(as: UInt32.self) }
     }
+}
+
+protocol HexStringable {
+    func toHexString() -> String
 }
 
 extension Data: HexStringable {

--- a/Sources/ClientRuntime/Networking/HashFunction.swift
+++ b/Sources/ClientRuntime/Networking/HashFunction.swift
@@ -38,13 +38,11 @@ enum HashFunction {
         }
     }
 
-    func computeHash(of data: Data) throws -> HashResult? {
+    func computeHash(of data: Data) throws -> HashResult {
         switch self {
         case .crc32:
-            // Should turn this result back into a UInt32 using .toUInt32()
             return .integer(data.computeCRC32())
         case .crc32c:
-            // Should turn this result back into a UInt32 using .toUInt32()
             return .integer(data.computeCRC32C())
         case .sha1:
             do {
@@ -71,35 +69,15 @@ enum HashFunction {
     }
 }
 
-protocol HexStringable {
-    func toHexString() -> String
-}
-
-extension Data: HexStringable {
-
-    // Convert a Data type to a hexademical String
-    func toHexString() -> String {
-        return map { String(format: "%02x", $0) }.joined()
-    }
-}
-
-extension UInt32: HexStringable {
-
-    // Convert a UInt32 type to a hexademical String
-    func toHexString() -> String {
-        return String(format: "%08x", self)
-    }
-}
-
-extension HashResult: HexStringable {
+extension HashResult {
 
     // Convert a HashResult to a hexadecimal String
     func toHexString() -> String {
         switch self {
         case .data(let data):
-            return data.toHexString()
+            return data.map { String(format: "%02x", $0) }.joined()
         case .integer(let integer):
-            return integer.toHexString()
+            return String(format: "%08x", integer)
         }
     }
 }

--- a/Tests/ClientRuntimeTests/NetworkingTests/HashFunctionTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/HashFunctionTests.swift
@@ -11,6 +11,11 @@ import AwsCommonRuntimeKit
 
 class HashFunctionTests: XCTestCase {
 
+    override func setUp() {
+        // Initialize function needs to be called before interacting with CRT
+        CommonRuntimeKit.initialize()
+    }
+
     func testCRC32() {
         guard let hashFunction = HashFunction.from(string: "crc32") else {
             XCTFail("CRC32 not found")
@@ -99,9 +104,6 @@ class HashFunctionTests: XCTestCase {
     }
 
     func testHashFunctionToHexString() {
-        // Must be called to work on linux
-        CommonRuntimeKit.initialize()
-
         let testData = Data("Hello, world!".utf8)
 
         // CRC32

--- a/Tests/ClientRuntimeTests/NetworkingTests/HashFunctionTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/HashFunctionTests.swift
@@ -1,0 +1,144 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import ClientRuntime
+
+class HashFunctionTests: XCTestCase {
+
+    func testCRC32() {
+        guard let hashFunction = HashFunction.from(string: "crc32") else {
+            XCTFail("CRC32 not found")
+            return
+        }
+
+        // Create test data
+        let testBytes: [UInt8] = [0xFF, 0xFE, 0xFD, 0xFC] // Bytes not valid in UTF-8
+        let testData = Data(testBytes)
+
+        let result = try? hashFunction.computeHash(of: testData)?.toUInt32()
+        let expected = testData.computeCRC32()
+        XCTAssertEqual(result, expected, "CRC32 hash does not match expected value")
+    }
+
+    func testCRC32C() {
+        guard let hashFunction = HashFunction.from(string: "crc32c") else {
+            XCTFail("CRC32C not found")
+            return
+        }
+
+        // Create test data
+        let testBytes: [UInt8] = [0xFF, 0xFE, 0xFD, 0xFC] // Bytes not valid in UTF-8
+        let testData = Data(testBytes)
+
+        let result = try? hashFunction.computeHash(of: testData)?.toUInt32()
+        let expected = testData.computeCRC32C()
+        XCTAssertEqual(result, expected, "CRC32C hash does not match expected value")
+    }
+
+    func testSHA1() {
+        guard let hashFunction = HashFunction.from(string: "sha1") else {
+            XCTFail("SHA1 not found")
+            return
+        }
+
+        // Create test data
+        let testBytes: [UInt8] = [0xFF, 0xFE, 0xFD, 0xFC] // Bytes not valid in UTF-8
+        let testData = Data(testBytes)
+
+        let result = try? hashFunction.computeHash(of: testData)
+        let expected = try? testData.computeSHA1()
+        XCTAssertEqual(result, expected, "SHA1 hash does not match expected value")
+    }
+
+    func testSHA256() {
+        guard let hashFunction = HashFunction.from(string: "sha256") else {
+            XCTFail("SHA256 not found")
+            return
+        }
+
+        // Create test data
+        let testBytes: [UInt8] = [0xFF, 0xFE, 0xFD, 0xFC] // Bytes not valid in UTF-8
+        let testData = Data(testBytes)
+
+        let result = try? hashFunction.computeHash(of: testData)
+        let expected = try? testData.computeSHA256()
+        XCTAssertEqual(result, expected, "SHA256 hash does not match expected value")
+    }
+
+    func testMD5() {
+        guard let hashFunction = HashFunction.from(string: "md5") else {
+            XCTFail("MD5 not found")
+            return
+        }
+
+        // Create test data
+        let testBytes: [UInt8] = [0xFF, 0xFE, 0xFD, 0xFC] // Bytes not valid in UTF-8
+        let testData = Data(testBytes)
+
+        let result = try? hashFunction.computeHash(of: testData)
+        let expected = try? testData.computeMD5()
+        XCTAssertEqual(result, expected, "MD5 hash does not match expected value")
+    }
+
+    func testInvalidHashFunction() {
+        let invalidHashFunction = HashFunction.from(string: "invalid")
+        XCTAssertNil(invalidHashFunction, "Invalid hash function should return nil")
+    }
+
+    func testDataConversionUInt32() {
+        let originalValue: UInt32 = 1234567890
+        let dataRepresentation = Data(fromUInt32: originalValue)
+        let convertedValue = dataRepresentation.toUInt32()
+        XCTAssertEqual(originalValue, convertedValue, "Conversion to and from UInt32 failed")
+    }
+
+    func testHashFunctionToHexString() {
+        let testData = Data("Hello, world!".utf8)
+
+        // CRC32
+        if let crc32Function = HashFunction.from(string: "crc32"),
+           let crc32Result = try? crc32Function.computeHash(of: testData)?.toUInt32() {
+            XCTAssertEqual(crc32Result.toHexString(), "ebe6c6e6", "CRC32 hexadecimal representation does not match expected value")
+        } else {
+            XCTFail("CRC32 hash function not found or computation failed")
+        }
+
+        // CRC32C
+        if let crc32cFunction = HashFunction.from(string: "crc32c"),
+           let crc32cResult = try? crc32cFunction.computeHash(of: testData)?.toUInt32() {
+            XCTAssertEqual(crc32cResult.toHexString(), "c8a106e5", "CRC32C hexadecimal representation does not match expected value")
+        } else {
+            XCTFail("CRC32C hash function not found or computation failed")
+        }
+
+        // SHA1
+        if let sha1Function = HashFunction.from(string: "sha1"),
+           let sha1Result = try? sha1Function.computeHash(of: testData) {
+            XCTAssertEqual(sha1Result.toHexString(), "943a702d06f34599aee1f8da8ef9f7296031d699", "SHA1 hexadecimal representation does not match expected value")
+        } else {
+            XCTFail("SHA1 hash function not found or computation failed")
+        }
+
+        // SHA256
+        if let sha256Function = HashFunction.from(string: "sha256"),
+           let sha256Result = try? sha256Function.computeHash(of: testData) {
+            XCTAssertEqual(sha256Result.toHexString(), "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3", "SHA256 hexadecimal representation does not match expected value")
+        } else {
+            XCTFail("SHA256 hash function not found or computation failed")
+        }
+
+        // MD5
+        if let md5Function = HashFunction.from(string: "md5"),
+           let md5Result = try? md5Function.computeHash(of: testData) {
+            XCTAssertEqual(md5Result.toHexString(), "6cd3556deb0da54bca060b4c39479839", "MD5 hexadecimal representation does not match expected value")
+        } else {
+            XCTFail("MD5 hash function not found or computation failed")
+        }
+    }
+
+}

--- a/Tests/ClientRuntimeTests/NetworkingTests/HashFunctionTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/HashFunctionTests.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 @testable import ClientRuntime
+import AwsCommonRuntimeKit
 
 class HashFunctionTests: XCTestCase {
 
@@ -98,6 +99,9 @@ class HashFunctionTests: XCTestCase {
     }
 
     func testHashFunctionToHexString() {
+        // Must be called to work on linux
+        CommonRuntimeKit.initialize()
+
         let testData = Data("Hello, world!".utf8)
 
         // CRC32

--- a/Tests/ClientRuntimeTests/NetworkingTests/HashFunctionTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/HashFunctionTests.swift
@@ -121,7 +121,7 @@ class HashFunctionTests: XCTestCase {
 
         // CRC32
         if let crc32Function = HashFunction.from(string: "crc32"),
-           let crc32Result = try? crc32Function.computeHash(of: testData)?.toHexString() {
+           let crc32Result = try? crc32Function.computeHash(of: testData).toHexString() {
             XCTAssertEqual(crc32Result, "ebe6c6e6", "CRC32 hexadecimal representation does not match expected value")
         } else {
             XCTFail("CRC32 hash function not found or computation failed")
@@ -129,7 +129,7 @@ class HashFunctionTests: XCTestCase {
 
         // CRC32C
         if let crc32cFunction = HashFunction.from(string: "crc32c"),
-           let crc32cResult = try? crc32cFunction.computeHash(of: testData)?.toHexString() {
+           let crc32cResult = try? crc32cFunction.computeHash(of: testData).toHexString() {
             XCTAssertEqual(crc32cResult, "c8a106e5", "CRC32C hexadecimal representation does not match expected value")
         } else {
             XCTFail("CRC32C hash function not found or computation failed")
@@ -137,7 +137,7 @@ class HashFunctionTests: XCTestCase {
 
         // SHA1
         if let sha1Function = HashFunction.from(string: "sha1"),
-           let sha1Result = try? sha1Function.computeHash(of: testData)?.toHexString() {
+           let sha1Result = try? sha1Function.computeHash(of: testData).toHexString() {
             XCTAssertEqual(sha1Result, "943a702d06f34599aee1f8da8ef9f7296031d699", "SHA1 hexadecimal representation does not match expected value")
         } else {
             XCTFail("SHA1 hash function not found or computation failed")
@@ -145,7 +145,7 @@ class HashFunctionTests: XCTestCase {
 
         // SHA256
         if let sha256Function = HashFunction.from(string: "sha256"),
-           let sha256Result = try? sha256Function.computeHash(of: testData)?.toHexString() {
+           let sha256Result = try? sha256Function.computeHash(of: testData).toHexString() {
             XCTAssertEqual(sha256Result, "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3", "SHA256 hexadecimal representation does not match expected value")
         } else {
             XCTFail("SHA256 hash function not found or computation failed")
@@ -153,7 +153,7 @@ class HashFunctionTests: XCTestCase {
 
         // MD5
         if let md5Function = HashFunction.from(string: "md5"),
-           let md5Result = try? md5Function.computeHash(of: testData)?.toHexString() {
+           let md5Result = try? md5Function.computeHash(of: testData).toHexString() {
             XCTAssertEqual(md5Result, "6cd3556deb0da54bca060b4c39479839", "MD5 hexadecimal representation does not match expected value")
         } else {
             XCTFail("MD5 hash function not found or computation failed")


### PR DESCRIPTION
Create a wrapper class to utilize hash/checksum functions. We will read desired checksum from an enum and want to go from string -> hash function -> computed value -> hexadecimal string easily based on whatever input algorithm is chosen.

## Issue \#
[#1287](https://github.com/awslabs/aws-sdk-swift/issues/1287)

## Description of changes
- Add a HashFunction class that wraps hash/checksum implementations in CRT swift
- Add ability to go from string -> hash function and use .computeHash() to get the returned value which is of type `HashResult` and be either a .data(Data) or a .integer(UInt32)
- Add ability to go from Data -> hexadecimal string using %02 or UInt32 -> hexadecimal string using %08
- Unit tests for class


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.