### PR TITLE
feat: tie up some loose ends

### DIFF
--- a/Sources/ClientRuntime/Auth/HTTPAuth/DefaultIdentityResolverConfiguration.swift
+++ b/Sources/ClientRuntime/Auth/HTTPAuth/DefaultIdentityResolverConfiguration.swift
@@ -6,16 +6,16 @@
 //
 
 public struct DefaultIdentityResolverConfiguration: IdentityResolverConfiguration {
-    let credentialsProvider: (any IdentityResolver)?
+    let credentialsProvider: Attributes
 
     public init(configuredIdResolvers: Attributes) {
-        self.credentialsProvider = configuredIdResolvers.get(key: AttributeKeys.awsIdResolver) ?? nil
+        self.credentialsProvider = configuredIdResolvers
     }
 
     func getIdentityResolver(identityKind: IdentityKind) -> (any IdentityResolver)? {
         switch identityKind {
         case .aws:
-            return self.credentialsProvider
+            return self.credentialsProvider.get(key: AttributeKeys.awsIdResolver)
         }
     }
 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/AuthSchemeResolverGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/AuthSchemeResolverGenerator.kt
@@ -59,8 +59,8 @@ class AuthSchemeResolverGenerator {
                     //   endpoint resolver's auth scheme resolution to resolve an auth scheme.
                     renderEndpointParamFields(ctx, this)
                 } else {
-                    // If service supports SigV4 auth scheme, it's a special-case for now - change once sigv4a trait is added
-                    //   and it becomes possible at model level to notate custom members for a given auth scheme.
+                    // If service supports SigV4/SigV4a auth scheme, it's a special-case for now - change once
+                    // it becomes possible at model level to notate custom members for a given auth scheme.
                     // Region has to be in params in addition to operation string.
                     if (serviceIndex.getEffectiveAuthSchemes(ctx.service).contains(SigV4Trait.ID)) {
                         write("// Region is used for SigV4 auth scheme")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ClientRuntimeTypes.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ClientRuntimeTypes.kt
@@ -76,7 +76,7 @@ object ClientRuntimeTypes {
         val RetryMiddleware = runtimeSymbol("RetryMiddleware")
         val IdempotencyTokenMiddleware = runtimeSymbol("IdempotencyTokenMiddleware")
         val NoopHandler = runtimeSymbol("NoopHandler")
-        val SigningMiddleware = runtimeSymbol("SignerMiddleware")
+        val SignerMiddleware = runtimeSymbol("SignerMiddleware")
         val AuthSchemeMiddleware = runtimeSymbol("AuthSchemeMiddleware")
         val BodyMiddleware = runtimeSymbol("BodyMiddleware")
         val PayloadBodyMiddleware = runtimeSymbol("PayloadBodyMiddleware")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpBindingProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpBindingProtocolGenerator.kt
@@ -53,7 +53,7 @@ import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInp
 import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputUrlHostMiddleware
 import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputUrlPathMiddleware
 import software.amazon.smithy.swift.codegen.integration.middlewares.RetryMiddleware
-import software.amazon.smithy.swift.codegen.integration.middlewares.SigningMiddleware
+import software.amazon.smithy.swift.codegen.integration.middlewares.SignerMiddleware
 import software.amazon.smithy.swift.codegen.integration.middlewares.providers.HttpHeaderProvider
 import software.amazon.smithy.swift.codegen.integration.middlewares.providers.HttpQueryItemProvider
 import software.amazon.smithy.swift.codegen.integration.middlewares.providers.HttpUrlPathProvider
@@ -465,7 +465,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
             operationMiddleware.appendMiddleware(operation, LoggingMiddleware(ctx.model, ctx.symbolProvider))
             operationMiddleware.appendMiddleware(operation, RetryMiddleware(ctx.model, ctx.symbolProvider, retryErrorInfoProviderSymbol))
 
-            operationMiddleware.appendMiddleware(operation, SigningMiddleware(ctx.model, ctx.symbolProvider))
+            operationMiddleware.appendMiddleware(operation, SignerMiddleware(ctx.model, ctx.symbolProvider))
 
             addProtocolSpecificMiddleware(ctx, operation)
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolServiceClient.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolServiceClient.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.swift.codegen.integration
 
+import software.amazon.smithy.aws.traits.auth.SigV4ATrait
 import software.amazon.smithy.aws.traits.auth.SigV4Trait
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.knowledge.ServiceIndex
@@ -44,6 +45,9 @@ open class HttpProtocolServiceClient(
                 writer.write("var modeledAuthSchemes: [ClientRuntime.AuthScheme] = Array()")
                 if (ServiceIndex(ctx.model).getEffectiveAuthSchemes(ctx.service).contains(SigV4Trait.ID)) {
                     writer.write("modeledAuthSchemes.append(SigV4AuthScheme())")
+                }
+                if (ServiceIndex(ctx.model).getEffectiveAuthSchemes(ctx.service).contains(SigV4ATrait.ID)) {
+                    writer.write("modeledAuthSchemes.append(SigV4AAuthScheme())")
                 }
                 writer.write("config.authSchemes = config.authSchemes ?? modeledAuthSchemes")
                 writer.write("self.config = config")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/SignerMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/SignerMiddleware.kt
@@ -11,7 +11,7 @@ import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 
-class SigningMiddleware(
+class SignerMiddleware(
     val model: Model,
     val symbolProvider: SymbolProvider
 ) : MiddlewareRenderable {
@@ -31,7 +31,7 @@ class SigningMiddleware(
         val outputError = MiddlewareShapeUtils.outputErrorSymbol(op)
         writer.write(
             "$operationStackName.${middlewareStep.stringValue()}.intercept(position: ${position.stringValue()}, middleware: \$N<\$N, \$N>())",
-            ClientRuntimeTypes.Middleware.SigningMiddleware, output, outputError
+            ClientRuntimeTypes.Middleware.SignerMiddleware, output, outputError
         )
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/1148

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Rename signer middleware kotlin name in the codegen backend to be consistent with runtime swift name
* Correct the default identity resolver configuration’s only member variable to be a list of identity resolvers rather than a single identity resolver
* Use newly added sigv4a trait to add sigv4a auth scheme to service client config's list of supported auth schemes during codegen


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.