### PR TITLE
feat: add runtime plugins

### DIFF
--- a/Sources/ClientRuntime/Client/Client.swift
+++ b/Sources/ClientRuntime/Client/Client.swift
@@ -1,0 +1,10 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+public protocol Client {
+    associatedtype Config: ClientConfiguration
+    init(config: Config)
+}

--- a/Sources/ClientRuntime/Client/ClientBuilder.swift
+++ b/Sources/ClientRuntime/Client/ClientBuilder.swift
@@ -1,0 +1,32 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+public class ClientBuilder<ClientType: Client> {
+
+    private var plugins: [Plugin]
+
+    public init(defaultPlugins: [Plugin] = []) {
+        self.plugins = defaultPlugins
+    }
+
+    public func withPlugin(_ plugin: any Plugin) -> ClientBuilder<ClientType> {
+        self.plugins.append(plugin)
+        return self
+    }
+
+    public func build() async throws -> ClientType {
+        let configuration = try await resolve(plugins: self.plugins)
+        return ClientType(config: configuration)
+    }
+
+    func resolve(plugins: [any Plugin]) async throws -> ClientType.Config {
+        let clientConfiguration = try await ClientType.Config()
+        for plugin in plugins {
+            try await plugin.configureClient(clientConfiguration: clientConfiguration)
+        }
+        return clientConfiguration
+    }
+}

--- a/Sources/ClientRuntime/Config/ClientConfiguration.swift
+++ b/Sources/ClientRuntime/Config/ClientConfiguration.swift
@@ -1,0 +1,10 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public protocol ClientConfiguration {
+    init() async throws
+}

--- a/Sources/ClientRuntime/Config/DefaultClientConfiguration.swift
+++ b/Sources/ClientRuntime/Config/DefaultClientConfiguration.swift
@@ -1,0 +1,33 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public protocol DefaultClientConfiguration: ClientConfiguration {
+    /// The logger to be used for client activity.
+    ///
+    /// If none is provided, the SDK's logger will be used.
+    var logger: LogAgent { get set }
+
+    /// The configuration for retry of failed network requests.
+    ///
+    /// Default options are provided if none are set.
+    var retryStrategyOptions: RetryStrategyOptions { get set }
+
+    /// The log mode to use for client logging.
+    ///
+    /// If none is provided, `.request` will be used.
+    var clientLogMode: ClientLogMode { get set }
+
+    /// The network endpoint to use.
+    ///
+    /// If none is provided, the service will select its own endpoint to use.
+    var endpoint: String? { get set }
+
+    /// A token generator to ensure idempotency of requests.
+    var idempotencyTokenGenerator: IdempotencyTokenGenerator { get set }
+
+    /// TODO(plugins): Add Checksum, Traceprobes, etc.
+}

--- a/Sources/ClientRuntime/Config/DefaultHttpClientConfiguration.swift
+++ b/Sources/ClientRuntime/Config/DefaultHttpClientConfiguration.swift
@@ -1,0 +1,20 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public protocol DefaultHttpClientConfiguration: ClientConfiguration {
+
+    /// The HTTP client to be used for the target platform, configured with the supplied configuration.
+    ///
+    /// By default, Swift SDK will set this to `CRTClientEngine` client on Mac & Linux platforms,
+    /// or `URLSessionHttpClient` on non-Mac Apple platforms.
+    var httpClientEngine: HTTPClient { get set }
+
+    /// Configuration for the HTTP client.
+    var httpClientConfiguration: HttpClientConfiguration { get }
+
+    /// TODO: Add auth scheme
+}

--- a/Sources/ClientRuntime/Plugins/DefaultClientPlugin.swift
+++ b/Sources/ClientRuntime/Plugins/DefaultClientPlugin.swift
@@ -1,0 +1,18 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public class DefaultClientPlugin: Plugin {
+    public init() {}
+    public func configureClient(clientConfiguration: ClientConfiguration) {
+        if var config = clientConfiguration as? DefaultClientConfiguration {
+            // Populate default values for configuration here if they are missing
+            config.retryStrategyOptions =
+                DefaultSDKRuntimeConfiguration<DefaultRetryStrategy, DefaultRetryErrorInfoProvider>
+                    .defaultRetryStrategyOptions
+        }
+    }
+}

--- a/Sources/ClientRuntime/Plugins/Plugin.swift
+++ b/Sources/ClientRuntime/Plugins/Plugin.swift
@@ -1,0 +1,10 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public protocol Plugin {
+    func configureClient(clientConfiguration: ClientConfiguration) async throws
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ClientRuntimeTypes.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ClientRuntimeTypes.kt
@@ -15,7 +15,7 @@ import software.amazon.smithy.swift.codegen.model.buildSymbol
  */
 object ClientRuntimeTypes {
     object Http {
-        val HttpClientEngine = runtimeSymbol("HttpClientEngine")
+        val HttpClient = runtimeSymbol("HTTPClient")
         val HttpClientConfiguration = runtimeSymbol("HttpClientConfiguration")
         val Headers = runtimeSymbol("Headers")
         val HttpStatusCode = runtimeSymbol("HttpStatusCode")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/DefaultClientConfigurationIntegration.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/DefaultClientConfigurationIntegration.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.swift.codegen
+
+import software.amazon.smithy.swift.codegen.config.ClientConfiguration
+import software.amazon.smithy.swift.codegen.config.DefaultClientConfiguration
+import software.amazon.smithy.swift.codegen.config.DefaultHttpClientConfiguration
+import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
+import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+
+class DefaultClientConfigurationIntegration : SwiftIntegration {
+    override fun clientConfigurations(ctx: ProtocolGenerator.GenerationContext): List<ClientConfiguration> {
+        return listOf(DefaultClientConfiguration(), DefaultHttpClientConfiguration())
+    }
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/Dependency.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/Dependency.kt
@@ -1,0 +1,8 @@
+package software.amazon.smithy.swift.codegen
+
+import software.amazon.smithy.codegen.core.SymbolDependencyContainer
+
+interface Dependency : SymbolDependencyContainer {
+    val target: String
+    var packageName: String
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
@@ -6,17 +6,16 @@
 package software.amazon.smithy.swift.codegen
 
 import software.amazon.smithy.codegen.core.SymbolDependency
-import software.amazon.smithy.codegen.core.SymbolDependencyContainer
 import software.amazon.smithy.swift.codegen.resources.Resources
 
 enum class SwiftDependency(
-    val target: String,
+    override val target: String,
     private val branch: String? = null,
-    val version: String,
+    private val version: String,
     private val url: String,
     private val localPath: String,
-    var packageName: String
-) : SymbolDependencyContainer {
+    override var packageName: String
+) : Dependency {
     BIG("ComplexModule", null, "0.0.5", "https://github.com/apple/swift-numerics", "", "swift-numerics"),
     SWIFT_LOG("Logging", null, "", "", "", ""),
     CLIENT_RUNTIME(

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/ClientConfiguration.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/ClientConfiguration.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.swift.codegen.config
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.swift.codegen.Dependency
+import software.amazon.smithy.swift.codegen.model.buildSymbol
+
+/**
+ * Specifies the behaviour of the service configuration
+ */
+interface ClientConfiguration {
+    /**
+     * The protocol name of the client configuration
+     */
+    val swiftProtocolName: Symbol?
+
+    val properties: Set<ConfigProperty>
+
+    companion object {
+        fun runtimeSymbol(
+            name: String,
+            dependency: Dependency?,
+        ): Symbol = buildSymbol {
+            this.name = name
+            dependency?.also {
+                this.namespace = it.target
+                dependency(dependency)
+            }
+        }
+    }
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/ConfigProperty.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/ConfigProperty.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.swift.codegen.config
+
+import software.amazon.smithy.codegen.core.Symbol
+data class ConfigProperty(
+    val name: String,
+    val type: Symbol,
+    val default: DefaultProvider? = null
+) {
+    constructor(
+        name: String,
+        type: Symbol,
+        default: String,
+        isThrowable: Boolean = false,
+        isAsync: Boolean = false
+    ) : this(name, type, DefaultProvider(default, isThrowable, isAsync))
+
+    val isOptional: Boolean = type.name.endsWith('?')
+
+    fun toOptionalType(): String {
+        return if (isOptional) type.name else "${type.name}?"
+    }
+
+    init {
+        if (!this.isOptional && default == null)
+            throw RuntimeException("Non-optional client config property must have a default value")
+    }
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/DefaultClientConfiguration.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/DefaultClientConfiguration.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.swift.codegen.config
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
+import software.amazon.smithy.swift.codegen.SwiftDependency
+import software.amazon.smithy.swift.codegen.SwiftTypes
+import software.amazon.smithy.swift.codegen.config.ClientConfiguration.Companion.runtimeSymbol
+import software.amazon.smithy.swift.codegen.model.toNullable
+
+class DefaultClientConfiguration : ClientConfiguration {
+    override val swiftProtocolName: Symbol
+        get() = runtimeSymbol("DefaultClientConfiguration", SwiftDependency.CLIENT_RUNTIME)
+
+    override val properties: Set<ConfigProperty>
+        get() = setOf(
+            ConfigProperty("logger", ClientRuntimeTypes.Core.Logger, "AWSClientConfigDefaultsProvider.logger(clientName)"),
+            ConfigProperty("retryStrategyOptions", ClientRuntimeTypes.Core.RetryStrategyOptions, "AWSClientConfigDefaultsProvider.retryStrategyOptions()", true),
+            ConfigProperty("clientLogMode", ClientRuntimeTypes.Core.ClientLogMode, "AWSClientConfigDefaultsProvider.clientLogMode"),
+            ConfigProperty("endpoint", SwiftTypes.String.toNullable()),
+            ConfigProperty("idempotencyTokenGenerator", ClientRuntimeTypes.Core.IdempotencyTokenGenerator, "AWSClientConfigDefaultsProvider.idempotencyTokenGenerator"),
+        )
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/DefaultHttpClientConfiguration.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/DefaultHttpClientConfiguration.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.swift.codegen.config
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
+import software.amazon.smithy.swift.codegen.SwiftDependency
+import software.amazon.smithy.swift.codegen.config.ClientConfiguration.Companion.runtimeSymbol
+
+class DefaultHttpClientConfiguration : ClientConfiguration {
+    override val swiftProtocolName: Symbol
+        get() = runtimeSymbol("DefaultHttpClientConfiguration", SwiftDependency.CLIENT_RUNTIME)
+
+    override val properties: Set<ConfigProperty>
+        get() = setOf(
+            ConfigProperty("httpClientEngine", ClientRuntimeTypes.Http.HttpClient, "AWSClientConfigDefaultsProvider.httpClientEngine"),
+            ConfigProperty("httpClientConfiguration", ClientRuntimeTypes.Http.HttpClientConfiguration, "AWSClientConfigDefaultsProvider.httpClientConfiguration"),
+        )
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/DefaultProvider.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/DefaultProvider.kt
@@ -1,0 +1,35 @@
+package software.amazon.smithy.swift.codegen.config
+
+data class DefaultProvider(
+    val value: String,
+    val isThrowable: Boolean,
+    val isAsync: Boolean
+) {
+    /**
+     * Returns a default value for client configuration
+     *
+     * For example:
+     *
+     * // isAsync = true, isThrowable = true, paramNilCheck = null, default = DefaultProvider.region()
+     * try await DefaultProvider.region(),
+     *
+     * // isAsync = false, isThrowable = true, paramNilCheck = retryMode, default = DefaultProvider.region()
+     * try retryMode ?? DefaultProvider.region(),
+     *
+     * // isAsync = false, isThrowable = true, paramNilCheck = retryMode, default = DefaultProvider.logger()
+     * DefaultProvider.logger()
+     *
+     * @param paramNilCheck parameter to nil check
+     * @return default value.
+     */
+    fun render(paramNilCheck: String? = null): String {
+        var res = value
+        if (paramNilCheck != null)
+            res = "$paramNilCheck ?? $res"
+        if (isAsync)
+            res = "await $res"
+        if (isThrowable)
+            res = "try $res"
+        return res
+    }
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/ClientProperty.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/ClientProperty.kt
@@ -79,7 +79,7 @@ abstract class HttpRequestEncoder(private val requestEncoder: Symbol, private va
     }
 
     override fun renderInitialization(writer: SwiftWriter, nameOfConfigObject: String) {
-        writer.write("self.encoder = \$L.encoder ?? \$L", nameOfConfigObject, name)
+        writer.write("self.encoder = \$L", name)
     }
 }
 
@@ -102,7 +102,7 @@ abstract class HttpResponseDecoder(private val requestDecoder: Symbol, private v
     }
 
     override fun renderInitialization(writer: SwiftWriter, nameOfConfigObject: String) {
-        writer.write("self.decoder = \$L.decoder ?? \$L", nameOfConfigObject, name)
+        writer.write("self.decoder = \$L", name)
     }
 }
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/Plugin.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/Plugin.kt
@@ -1,0 +1,12 @@
+package software.amazon.smithy.swift.codegen.integration
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.swift.codegen.SwiftWriter
+
+interface Plugin {
+    val className: Symbol
+    val isDefault: Boolean
+    fun customInitialization(writer: SwiftWriter) {
+        writer.writeInline("\$L()", className)
+    }
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/ServiceConfig.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/ServiceConfig.kt
@@ -6,7 +6,6 @@
 package software.amazon.smithy.swift.codegen.integration
 
 import software.amazon.smithy.codegen.core.Symbol
-import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.utils.toUpperCamelCase
 
@@ -22,35 +21,5 @@ abstract class ServiceConfig(val writer: SwiftWriter, val clientName: String, va
 
     open val typeName: String = "${clientName.toUpperCamelCase()}.${clientName.toUpperCamelCase()}Configuration"
 
-    fun sdkRuntimeConfigProperties(): List<ConfigField> {
-        val configFields = mutableListOf(
-            ConfigField("encoder", ClientRuntimeTypes.Serde.RequestEncoder, propFormatter = "\$T"),
-            ConfigField("decoder", ClientRuntimeTypes.Serde.ResponseDecoder, propFormatter = "\$T"),
-            ConfigField("httpClientEngine", ClientRuntimeTypes.Http.HttpClientEngine),
-            ConfigField("httpClientConfiguration", ClientRuntimeTypes.Http.HttpClientConfiguration),
-            ConfigField("idempotencyTokenGenerator", ClientRuntimeTypes.Core.IdempotencyTokenGenerator),
-            ConfigField("retryStrategyOptions", ClientRuntimeTypes.Core.RetryStrategyOptions),
-            ConfigField("clientLogMode", ClientRuntimeTypes.Core.ClientLogMode),
-            ConfigField("logger", ClientRuntimeTypes.Core.Logger)
-        ).sortedBy { it.memberName }
-        return configFields
-    }
-
-    open fun otherRuntimeConfigProperties(): List<ConfigField> = listOf()
-
-    open fun renderInitializers(serviceSymbol: Symbol) {
-        writer.openBlock("public init(runtimeConfig: \$N) throws {", "}", ClientRuntimeTypes.Core.DefaultSDKRuntimeConfiguration) {
-            val configFields = sdkRuntimeConfigProperties()
-            configFields.forEach {
-                writer.write("self.${it.memberName} = runtimeConfig.${it.memberName}")
-            }
-        }
-        writer.write("")
-        writer.openBlock("public convenience init() throws {", "}") {
-            writer.write("let defaultRuntimeConfig = try \$N(\"${clientName}\")", ClientRuntimeTypes.Core.DefaultSDKRuntimeConfiguration)
-            writer.write("try self.init(runtimeConfig: defaultRuntimeConfig)")
-        }
-    }
-
-    open fun serviceConfigProperties(): List<ConfigField> = listOf()
+    open fun serviceSpecificConfigProperties(): List<ConfigField> = listOf()
 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/SwiftIntegration.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/SwiftIntegration.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.swift.codegen.SwiftDelegator
 import software.amazon.smithy.swift.codegen.SwiftSettings
 import software.amazon.smithy.swift.codegen.SwiftWriter
+import software.amazon.smithy.swift.codegen.config.ClientConfiguration
 import software.amazon.smithy.swift.codegen.core.CodegenContext
 import software.amazon.smithy.swift.codegen.middleware.OperationMiddleware
 
@@ -169,4 +170,14 @@ interface SwiftIntegration {
     fun serviceErrorProtocolSymbol(): Symbol? {
         return null
     }
+
+    /**
+     * Returns a list of default Plugins for configuring client configuration's default properties
+     */
+    fun plugins(): List<Plugin> = emptyList()
+
+    /**
+     * Returns a list of ClientConfiguration protocols to be implemented by the client configuration
+     */
+    fun clientConfigurations(ctx: ProtocolGenerator.GenerationContext): List<ClientConfiguration> = emptyList()
 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/SymbolBuilder.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/SymbolBuilder.kt
@@ -99,3 +99,5 @@ fun SymbolBuilder.namespace(dependency: SwiftDependency, type: String = "") {
 
     dependency(dependency)
 }
+
+fun Symbol.toNullable(): Symbol = this.toBuilder().name("${this.name}?").build()

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/plugins/DefaultClientPlugin.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/plugins/DefaultClientPlugin.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.swift.codegen.integration.plugins
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.swift.codegen.SwiftDependency
+import software.amazon.smithy.swift.codegen.integration.Plugin
+import software.amazon.smithy.swift.codegen.model.buildSymbol
+
+internal class DefaultClientPlugin : Plugin {
+    override val className: Symbol
+        get() = buildSymbol {
+            this.name = "DefaultClientPlugin"
+            this.namespace = SwiftDependency.CLIENT_RUNTIME.target
+            dependency(SwiftDependency.CLIENT_RUNTIME)
+        }
+    override val isDefault: Boolean
+        get() = true
+}

--- a/smithy-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+++ b/smithy-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
@@ -1,3 +1,4 @@
 software.amazon.smithy.swift.codegen.PaginatorGenerator
 software.amazon.smithy.swift.codegen.waiters.WaiterIntegration
 software.amazon.smithy.swift.codegen.ServiceNamespaceIntegration
+software.amazon.smithy.swift.codegen.DefaultClientConfigurationIntegration

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldContainOnlyOnce
 import org.junit.jupiter.api.Test
 
@@ -15,7 +16,7 @@ class HttpProtocolClientGeneratorTests {
         contents.shouldSyntacticSanityCheck()
         contents.shouldContainOnlyOnce(
             """
-            public class RestJsonProtocolClient {
+            public class RestJsonProtocolClient: Client {
                 public static let clientName = "RestJsonProtocolClient"
                 let client: ClientRuntime.SdkHttpClient
                 let config: RestJsonProtocol.RestJsonProtocolConfiguration
@@ -23,39 +24,34 @@ class HttpProtocolClientGeneratorTests {
                 let encoder: ClientRuntime.RequestEncoder
                 let decoder: ClientRuntime.ResponseDecoder
             
-                public init(config: RestJsonProtocol.RestJsonProtocolConfiguration) {
+                public required init(config: RestJsonProtocol.RestJsonProtocolConfiguration) {
                     client = ClientRuntime.SdkHttpClient(engine: config.httpClientEngine, config: config.httpClientConfiguration)
                     let encoder = ClientRuntime.JSONEncoder()
                     encoder.dateEncodingStrategy = .secondsSince1970
                     encoder.nonConformingFloatEncodingStrategy = .convertToString(positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
-                    self.encoder = config.encoder ?? encoder
+                    self.encoder = encoder
                     let decoder = ClientRuntime.JSONDecoder()
                     decoder.dateDecodingStrategy = .secondsSince1970
                     decoder.nonConformingFloatDecodingStrategy = .convertFromString(positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
-                    self.decoder = config.decoder ?? decoder
+                    self.decoder = decoder
                     self.config = config
                 }
             
-                public convenience init() throws {
-                    let config = try RestJsonProtocol.RestJsonProtocolConfiguration()
+                public convenience required init() throws {
+                    let config = try RestJsonProtocol.RestJsonProtocolConfiguration("Rest Json Protocol", "RestJsonProtocolClient")
                     self.init(config: config)
                 }
+            
             }
             
-            public init(runtimeConfig: ClientRuntime.DefaultSDKRuntimeConfiguration) throws {
-                self.clientLogMode = runtimeConfig.clientLogMode
-                self.decoder = runtimeConfig.decoder
-                self.encoder = runtimeConfig.encoder
-                self.httpClientConfiguration = runtimeConfig.httpClientConfiguration
-                self.httpClientEngine = runtimeConfig.httpClientEngine
-                self.idempotencyTokenGenerator = runtimeConfig.idempotencyTokenGenerator
-                self.logger = runtimeConfig.logger
-                self.retryStrategyOptions = runtimeConfig.retryStrategyOptions
-            }
+            extension RestJsonProtocolClient {
+                public typealias RestJsonProtocolConfiguration = ClientRuntime.DefaultSDKRuntimeConfiguration
             
-            public convenience init() throws {
-                let defaultRuntimeConfig = try ClientRuntime.DefaultSDKRuntimeConfiguration("Rest Json Protocol")
-                try self.init(runtimeConfig: defaultRuntimeConfig)
+                public static func builder() -> ClientBuilder<RestJsonProtocolClient> {
+                    return ClientBuilder<RestJsonProtocolClient>(defaultPlugins: [
+                        ClientRuntime.DefaultClientPlugin()
+                    ])
+                }
             }
             
             public struct RestJsonProtocolClientLogHandlerFactory: ClientRuntime.SDKLogHandlerFactory {
@@ -97,7 +93,7 @@ class HttpProtocolClientGeneratorTests {
         val context = setupTests("service-generator-test-operations.smithy", "com.test#Example")
         val contents = getFileContents(context.manifest, "/RestJson/RestJsonProtocolClient.swift")
         contents.shouldSyntacticSanityCheck()
-        contents.shouldContainOnlyOnce("extension RestJsonProtocolClient {")
+        contents.shouldContain("extension RestJsonProtocolClient {")
     }
 
     @Test


### PR DESCRIPTION
Add runtime plugins functionality to smithy swift.

A runtime plugin defines instructions for how an SDK client is configured. For example, a plugin can be initialized and passed to the client as follows:

```
let s3Client = S3Client.builder()
    .withPlugin(new VeyronPlugin())
    .build();
```

## Description of changes
* `ClientConfiguration` is an interface that includes settings that can be modified on a service client. Because services have different configuration, each service has a code-generated ClientConfiguration implementation. (`DefaultClientConfiguration` and `DefaultHttpClientConfiguration` specify default client config properties and will always be present.)
* `ConfigProperty` specifies the name, type and default value of the client configuration property.
* A `Plugin` is an object allowing users to modifies the client’s configuration object
* Two new functions: `plugins` and `clientConfigurations ` are added to `SwiftIntegration` to allow SDK code generators to extending from `smithy-swift` (e.g. `aws-sdk-swift`) to include their custom ClientConfigurations and Plugins in generated clients.

Example:

```
// CustomClientConfigurationIntegration.kt
class CustomClientConfigurationIntegration : SwiftIntegration {
    override fun plugins(): List<Plugin> {
        return listOf(CustomClientPlugin())
    }

    override fun clientConfigurations(): List<ClientConfiguration> {
        return listOf(CustomClientConfiguration())
    }
}

// CustomClientConfiguration.kt
class CustomClientConfiguration : ClientConfiguration {
    override val swiftProtocolName: Symbol
        get() = runtimeSymbol("CustomClientConfiguration", SwiftDependency.CLIENT_RUNTIME)

    override val properties: Set<ConfigProperty>
        get() = setOf(
            ConfigProperty("logger", ClientRuntimeTypes.Core.Logger, "logger ?? defaultProvider.logger"),
            ConfigProperty("retryStrategyOptions", ClientRuntimeTypes.Core.RetryStrategyOptions, "try retryStrategyOptions ?? defaultProvider.retryStrategyOptions()"),
        )
}

// CustomClientPlugin.swift
public class CustomClientPlugin: Plugin {
    public init() {}
    public func configureClient(clientConfiguration: ClientConfiguration) {
        if var config = clientConfiguration as? CustomClientConfiguration {
            // Add clientConfiguration update logic here
            config.logger = ...
            config.retryStrategyOptions = ...
        }
    }
}

// CustomClientConfiguration.swift
public protocol CustomClientConfiguration: ClientConfiguration {
    var logger: Logger? { get set }
    var retryStrategyOptions: RetryStrategyOptions? { get set }
}
```
* `ClientBuilder` allows client to be initialized via builder pattern.

```
extension S3Client {
    public static func builder() -> ClientBuilder<S3Client> {
        return ClientBuilder<S3Client>(defaultPlugins: [DefaultClientPlugin()])
    }
}

let s3Client = S3Client.builder()
    .withPlugin(new VeyronPlugin())
    .build();
```

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.