### PR TITLE
chore: change MyURLQueryItem to SDKURLQueryItem

### DIFF
--- a/Sources/ClientRuntime/PrimitiveTypeExtensions/URLQueryItem+Extensions.swift
+++ b/Sources/ClientRuntime/PrimitiveTypeExtensions/URLQueryItem+Extensions.swift
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-public typealias URLQueryItem = MyURLQueryItem
+public typealias URLQueryItem = SDKURLQueryItem
 
-public struct MyURLQueryItem: Hashable {
+public struct SDKURLQueryItem: Hashable {
     public var name: String
     public var value: String?
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
in aws-sdk-swift: https://github.com/awslabs/aws-sdk-swift/issues/1229
in smithy-swift: https://github.com/smithy-lang/smithy-swift/issues/561

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Renames typealias of ClientRuntime.URLQueryItem.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.