### PR TITLE
fix: Make HttpResponse.statusCode getter & setter thread-safe

### DIFF
--- a/Sources/ClientRuntime/Config/DefaultSDKRuntimeConfiguration.swift
+++ b/Sources/ClientRuntime/Config/DefaultSDKRuntimeConfiguration.swift
@@ -86,7 +86,7 @@ public extension DefaultSDKRuntimeConfiguration {
     static func makeClient(
         httpClientConfiguration: HttpClientConfiguration = defaultHttpClientConfiguration
     ) -> HTTPClient {
-        #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) //|| os(macOS)
+        #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) || os(macOS)
         return URLSessionHTTPClient(httpClientConfiguration: httpClientConfiguration)
         #else
         let connectTimeoutMs = httpClientConfiguration.connectTimeout.map { UInt32($0 * 1000) }

--- a/Sources/ClientRuntime/Config/DefaultSDKRuntimeConfiguration.swift
+++ b/Sources/ClientRuntime/Config/DefaultSDKRuntimeConfiguration.swift
@@ -86,7 +86,7 @@ public extension DefaultSDKRuntimeConfiguration {
     static func makeClient(
         httpClientConfiguration: HttpClientConfiguration = defaultHttpClientConfiguration
     ) -> HTTPClient {
-        #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) || os(macOS)
+        #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) //|| os(macOS)
         return URLSessionHTTPClient(httpClientConfiguration: httpClientConfiguration)
         #else
         let connectTimeoutMs = httpClientConfiguration.connectTimeout.map { UInt32($0 * 1000) }

--- a/Sources/ClientRuntime/Networking/Http/HttpResponse.swift
+++ b/Sources/ClientRuntime/Networking/Http/HttpResponse.swift
@@ -7,22 +7,37 @@
 
 import protocol SmithyReadWrite.WireDataProviding
 import AwsCommonRuntimeKit
+import class Foundation.DispatchQueue
 
 public class HttpResponse: HttpUrlResponse, ResponseMessage {
 
     public var headers: Headers
     public var body: ByteStream
-    public var statusCode: HttpStatusCode
+
+    private var _statusCode: HttpStatusCode
+    private let statusCodeQueue = DispatchQueue(label: "statusCodeSerialQueue")
+    public var statusCode: HttpStatusCode {
+        get {
+            statusCodeQueue.sync {
+                return _statusCode
+            }
+        }
+        set {
+            statusCodeQueue.sync {
+                self._statusCode = newValue
+            }
+        }
+    }
 
     public init(headers: Headers = .init(), statusCode: HttpStatusCode = .processing, body: ByteStream = .noStream) {
         self.headers = headers
-        self.statusCode = statusCode
+        self._statusCode = statusCode
         self.body = body
     }
 
     public init(headers: Headers = .init(), body: ByteStream, statusCode: HttpStatusCode) {
         self.body = body
-        self.statusCode = statusCode
+        self._statusCode = statusCode
         self.headers = headers
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/1324
https://github.com/aws-amplify/amplify-swift/issues/3708

Addresses SIM ticket `/V1219649867`.

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
A customer raised a SIM ticket with the following screenshot of data race warning on IDE:

![image](https://github.com/smithy-lang/smithy-swift/assets/55515281/b85c9081-1426-416d-a8eb-23af98ed4283)

To address this data race warning, use serial queue and hidden property `_statusCode` to make getter & setter thread-safe. Observed that the thread sanitization warning goes away when running CRT HTTP client with this change.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.