### PR TITLE
chore: Move Apple-platform CI to Apple Silicon

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,44 +19,44 @@ jobs:
       matrix:
         # This matrix runs tests on iOS sim & Mac, on oldest & newest supported Xcodes
         runner:
-          - macos-12
-          - macos-13
+          - macos-13-xlarge
+          - macos-14-xlarge
         xcode:
-          - Xcode_14.0.1
-          - Xcode_15.1
+          - Xcode_14.1
+          - Xcode_15.2
         destination:
-          - 'platform=iOS Simulator,OS=16.0,name=iPhone 14'
+          - 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
+          - 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=OS X'
         exclude:
           # Don't run old macOS with new Xcode
-          - runner: macos-12
-            xcode: Xcode_15.1
+          - runner: macos-13-xlarge
+            xcode: Xcode_15.2
           # Don't run new macOS with old Xcode
-          - runner: macos-13
-            xcode: Xcode_14.0.1
+          - runner: macos-14-xlarge
+            xcode: Xcode_14.1
           # Don't run old iOS/tvOS simulator with new Xcode
-          - destination: 'platform=iOS Simulator,OS=16.0,name=iPhone 14'
-            xcode: Xcode_15.1
-          - destination: 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
-            xcode: Xcode_15.1
+          - destination: 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
+            xcode: Xcode_15.2
+          - destination: 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
+            xcode: Xcode_15.2
           # Don't run new iOS/tvOS simulator with old Xcode
           - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-            xcode: Xcode_14.0.1
+            xcode: Xcode_14.1
           - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_14.0.1
+            xcode: Xcode_14.1
     steps:
       - name: Checkout smithy-swift
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Select aws-sdk-swift branch
         run: |
           ORIGINAL_REPO_HEAD_REF="$GITHUB_HEAD_REF" \
           DEPENDENCY_REPO_URL="https://github.com/awslabs/aws-sdk-swift.git" \
           ./scripts/ci_steps/select_dependency_branch.sh
       - name: Checkout aws-sdk-swift
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: awslabs/aws-sdk-swift
           ref: ${{ env.DEPENDENCY_REPO_SHA }}
@@ -64,7 +64,7 @@ jobs:
       - name: Move aws-sdk-swift into place
         run: mv aws-sdk-swift ..
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -74,7 +74,7 @@ jobs:
             1-${{ runner.os }}-gradle-${{ hashFiles('settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
             1-${{ runner.os }}-gradle-
       - name: Cache Swift
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
@@ -84,7 +84,7 @@ jobs:
             1-${{ runner.os }}-${{ matrix.xcode }}-spm-${{ hashFiles('Package.swift') }}
             1-${{ runner.os }}-${{ matrix.xcode }}-spm-
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: corretto
           java-version: 17


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1339

## Description of changes
Moves Apple platform CI from Intel Mac to M1 Mac.

Also updates several GH Action versions, and oldest/newest Xcode versions.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.