### PR TITLE
fix: Make tlsOptions nil for CRT HTTP client if protocol type is HTTP

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
@@ -68,10 +68,10 @@ public class CRTClientEngine: HTTPClient {
         }
 
         private func createConnectionPool(endpoint: Endpoint) throws -> HTTPClientConnectionManager {
-            let tlsConnectionOptions = TLSConnectionOptions(
+            let tlsConnectionOptions = endpoint.protocolType == .https ? TLSConnectionOptions(
                 context: sharedDefaultIO.tlsContext,
                 serverName: endpoint.host
-            )
+            ) : nil
 
             var socketOptions = SocketOptions(socketType: .stream)
 #if os(iOS) || os(watchOS)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
[Here](https://github.com/awslabs/aws-crt-swift/blob/13e5479c41e55e0fe0c5ce10252af46df1a1d97a/Source/AwsCommonRuntimeKit/http/HTTPClientConnectionOptions.swift#L22) in aws-crt-swift, the documentation states that tlsOptions must be null for HTTP connections.

In fact, CRT HTTP client fails to connect to servers if the connection is HTTP currently.

Added a small change that checks protocol type and assigns nil to it if it is HTTP instead of HTTPS.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.