### PR TITLE
fix: Set ports and scheme correctly for non-TLS HTTP connections

### DIFF
--- a/Sources/ClientRuntime/Networking/Endpoint.swift
+++ b/Sources/ClientRuntime/Networking/Endpoint.swift
@@ -31,11 +31,12 @@ public struct Endpoint: Hashable {
             throw ClientError.unknownError("invalid host \(String(describing: url.host))")
         }
 
+        let protocolType = ProtocolType(rawValue: url.scheme ?? "") ?? .https
         self.init(host: host,
                   path: url.path,
-                  port: Int16(url.port ?? 443),
+                  port: Int16(url.port ?? protocolType.port),
                   queryItems: url.toQueryItems(),
-                  protocolType: ProtocolType(rawValue: url.scheme ?? ProtocolType.https.rawValue),
+                  protocolType: protocolType,
                   headers: headers,
                   properties: properties)
     }

--- a/Sources/ClientRuntime/Networking/Http/ProtocolType.swift
+++ b/Sources/ClientRuntime/Networking/Http/ProtocolType.swift
@@ -15,3 +15,12 @@ public enum ALPNProtocol: String {
     case http1 = "http/1.1"
     case http2 = "h2"
 }
+
+extension ProtocolType {
+    var port: Int {
+        switch self {
+        case .http: return 80
+        case .https: return 443
+        }
+    }
+}

--- a/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionHTTPClient.swift
+++ b/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionHTTPClient.swift
@@ -279,6 +279,7 @@ public final class URLSessionHTTPClient: HTTPClient {
         var components = URLComponents()
         components.scheme = config.protocolType?.rawValue ?? request.endpoint.protocolType?.rawValue ?? "https"
         components.host = request.endpoint.host
+        components.port = port(for: request)
         components.percentEncodedPath = request.path
         if let queryItems = request.queryItems, !queryItems.isEmpty {
             components.percentEncodedQueryItems = queryItems.map {
@@ -295,6 +296,16 @@ public final class URLSessionHTTPClient: HTTPClient {
             }
         }
         return urlRequest
+    }
+
+    private func port(for request: SdkHttpRequest) -> Int? {
+        switch (request.endpoint.protocolType, request.endpoint.port) {
+        case (.https, 443), (.http, 80):
+            // Don't set port explicitly if it's the default port for the scheme
+            return nil
+        default:
+            return Int(request.endpoint.port)
+        }
     }
 }
 


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1348

## Description of changes
- Set the port number when preparing a URLSession HTTP request.  The port number was ignored before.  (When the default port is explicitly specified, omit it for clarity.)
- On `Endpoint`, when no port is supplied, use the default port for the chosen URL scheme (http/https) as the default, instead of always choosing 443 (the default https port.)

NOTE: Use of non-TLS http:// connections with the URLSession HTTP client is controlled by the ATS (App Transport Security) feature when run on Apple platforms.
- ATS allows connections to localhost by default (Verified this behavior on the desktop with a local server.)
- ATS must be disabled to reach a http:// server in any other location.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.