### PR TITLE
fix: Use 'models' with lowercase 'm' for directory name

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ServiceNamespaceIntegration.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ServiceNamespaceIntegration.kt
@@ -18,7 +18,7 @@ class ServiceNamespaceIntegration : SwiftIntegration {
     ) {
         val service = ctx.settings.getService(ctx.model)
         val namespaceName = service.nestedNamespaceType(ctx.symbolProvider)
-        val filename = "${ctx.settings.moduleName}/Models/$namespaceName.swift"
+        val filename = "${ctx.settings.moduleName}/models/$namespaceName.swift"
         delegator.useFileWriter(filename) { writer ->
             writer.write("public enum \$L {}", namespaceName)
         }


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1356

## Description of changes
Change the directory for the model namespace file from `Models/` to `models/` which matches other models and prevents orphaned files when code-generating on Linux systems.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.