### PR TITLE
fix: Add overwrite behavior for endpoints 2.0 for signing properties

### DIFF
--- a/Sources/ClientRuntime/Auth/HTTPAuthAPI/SelectedAuthScheme.swift
+++ b/Sources/ClientRuntime/Auth/HTTPAuthAPI/SelectedAuthScheme.swift
@@ -18,3 +18,16 @@ public struct SelectedAuthScheme {
         self.signer = signer
     }
 }
+
+extension SelectedAuthScheme {
+    public func getCopyWithUpdatedSigningProperty<T>(key: AttributeKey<T>, value: T) -> SelectedAuthScheme {
+        var updatedSigningProperties = self.signingProperties
+        updatedSigningProperties?.set(key: key, value: value)
+        return SelectedAuthScheme(
+            schemeID: self.schemeID,
+            identity: self.identity,
+            signingProperties: updatedSigningProperties,
+            signer: self.signer
+        )
+    }
+}

--- a/Sources/ClientRuntime/Plugins/AuthSchemePlugin.swift
+++ b/Sources/ClientRuntime/Plugins/AuthSchemePlugin.swift
@@ -11,17 +11,20 @@ public class AuthSchemePlugin: Plugin {
 
     private var authSchemeResolver: ClientRuntime.AuthSchemeResolver?
 
-    public init(authSchemeResolver: ClientRuntime.AuthSchemeResolver? = nil, authSchemes: [ClientRuntime.AuthScheme]? = nil) {
+    public init(
+        authSchemeResolver: ClientRuntime.AuthSchemeResolver? = nil,
+        authSchemes: [ClientRuntime.AuthScheme]? = nil
+    ) {
         self.authSchemeResolver = authSchemeResolver
         self.authSchemes = authSchemes
     }
 
     public func configureClient(clientConfiguration: ClientConfiguration) {
         if var config = clientConfiguration as? DefaultHttpClientConfiguration {
-            if (self.authSchemes != nil) {
+            if self.authSchemes != nil {
                 config.authSchemes = self.authSchemes!
             }
-            if (self.authSchemeResolver != nil) {
+            if self.authSchemeResolver != nil {
                 config.authSchemeResolver = self.authSchemeResolver!
             }
         }


### PR DESCRIPTION
## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Adds convenience method to `SelectedAuthScheme` to be used to overwrite a signing property value.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.