### PR TITLE
fix: Race condition on URLSession HTTP client request body

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/URLSession/FoundationStreamBridge.swift
+++ b/Sources/ClientRuntime/Networking/Http/URLSession/FoundationStreamBridge.swift
@@ -15,6 +15,8 @@ import class Foundation.InputStream
 import class Foundation.OutputStream
 import class Foundation.Thread
 import class Foundation.RunLoop
+import class Foundation.Timer
+import struct Foundation.TimeInterval
 import protocol Foundation.StreamDelegate
 
 /// Reads data from a smithy-swift native `ReadableStream` and streams the data to a Foundation `InputStream`.
@@ -63,7 +65,13 @@ class FoundationStreamBridge: NSObject, StreamDelegate {
     /// All stream operations should be performed on the same thread as the delegate callbacks.
     /// A single shared `Thread` is started and is used to host the RunLoop for all Foundation Stream callbacks.
     private static let thread: Thread = {
-        let thread = Thread { autoreleasepool { RunLoop.current.run() } }
+        let thread = Thread {
+            autoreleasepool {
+                let timer = Timer(timeInterval: TimeInterval.greatestFiniteMagnitude, repeats: true, block: { _ in })
+                RunLoop.current.add(timer, forMode: .default)
+                RunLoop.current.run(until: Date.distantFuture)
+            }
+        }
         thread.name = "AWSFoundationStreamBridge"
         thread.start()
         return thread


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1399

## Description of changes
It has been observed that when using the URLSession-based HTTP client, HTTP requests occasionally time out because the request does not stream its data to the server as expected.  The cause is that the run loop for stream event handling sometimes does not start.  Per Apple's docs:
```
If no input sources or timers are attached to the run loop, this method exits immediately; otherwise, it runs the receiver in the NSDefaultRunLoopMode by repeatedly invoking `run(mode:before:)`.
```
(https://developer.apple.com/documentation/foundation/runloop)

No input sources or timers are added to the stream event handling run loop's thread before it is started.  This creates a race condition between two events:
a) scheduling an event on the run loop in the `openOnThread()` method.
b) calling `run(mode:before:)` on the run loop after starting the thread (starting the thread is asynchronous and takes some time to complete.)

The race is triggered when the `thread` static property is first accessed, causing the thread to be lazily created and started; this happens when `open()` is called on the Foundation stream bridge.

When (a) happens first, the stream operates normally, since the run loop has an event scheduled when `run(mode:before:)` is called on it and it starts as expected.  When (b) happens first, nothing is attached to the run loop when it is first run, `run(mode:before:)` exits immediately, the run loop does not run, and the stream does not send data.  Testing shows that (a) happens the vast majority of the time on all platforms, but (b) tends to happen first more frequently on older macOS / Xcode.

To avoid the race, attach a timer to the run loop before starting it.  The timer fires in the distant future and does nothing when it does fire, but its attachment to the run loop is sufficient to ensure that the run loop runs continuously every time the thread starts, and the race condition is eliminated.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.