### PR TITLE
fix: remove reference to KinesisClientTypes.Tag and set variable directly

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HttpResponseTraitWithoutHttpPayload.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HttpResponseTraitWithoutHttpPayload.kt
@@ -150,7 +150,7 @@ class HttpResponseTraitWithoutHttpPayload(
             write("let response = try decoder.decode([String: String].self, from: initialDataWithoutHttp)")
             initialResponseMembers.forEach { responseMember ->
                 val responseMemberName = ctx.symbolProvider.toMemberName(responseMember.member)
-                write("self.$responseMemberName = response[\"$responseMemberName\"].map { value in KinesisClientTypes.Tag(value: value) }")
+                write("self.$responseMemberName = response[\"$responseMemberName\"]")
             }
             dedent()
             write("} catch {")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/XMLHttpResponseTraitWithoutHttpPayload.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/XMLHttpResponseTraitWithoutHttpPayload.kt
@@ -107,7 +107,7 @@ class XMLHttpResponseTraitWithoutHttpPayload(
             write("let response = try decoder.decode([String: String].self, from: initialDataWithoutHttp)")
             initialResponseMembers.forEach { responseMember ->
                 val responseMemberName = ctx.symbolProvider.toMemberName(responseMember.member)
-                write("self.$responseMemberName = response[\"$responseMemberName\"].map { value in KinesisClientTypes.Tag(value: value) }")
+                write("self.$responseMemberName = response[\"$responseMemberName\"]")
             }
             dedent()
             write("} catch {")

--- a/smithy-swift-codegen/src/test/kotlin/EventStreamsInitialResponseTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/EventStreamsInitialResponseTests.kt
@@ -32,8 +32,8 @@ extension TestStreamOperationWithInitialRequestResponseOutput: ClientRuntime.Htt
                 let decoder = JSONDecoder()
                 do {
                     let response = try decoder.decode([String: String].self, from: initialDataWithoutHttp)
-                    self.initial1 = response["initial1"].map { value in KinesisClientTypes.Tag(value: value) }
-                    self.initial2 = response["initial2"].map { value in KinesisClientTypes.Tag(value: value) }
+                    self.initial1 = response["initial1"]
+                    self.initial2 = response["initial2"]
                 } catch {
                     print("Error decoding JSON: \(error)")
                     self.initial1 = nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.