### PR TITLE
feat: add interceptors interfaces

### DIFF
--- a/Sources/ClientRuntime/Interceptor/AnyInterceptor.swift
+++ b/Sources/ClientRuntime/Interceptor/AnyInterceptor.swift
@@ -7,11 +7,13 @@
 
 /// Type-erased, concrete interceptor.
 /// 
-/// This structure stores 
-public struct AnyInterceptor<RequestType, ResponseType, AttributesType: HasAttributes> {
-    public typealias InterceptorContextType = DefaultInterceptorContext<RequestType, ResponseType, AttributesType>
-    public typealias InterceptorFn = (InterceptorContextType) async throws -> Void
-    public typealias MutatingInterceptorFn = (inout InterceptorContextType) async throws -> Void
+/// In order to have multiple interceptors hooked into a single operation, we
+/// need a concrete type, not a protocol. This stores references to the closures
+/// of interceptor implementations and delegates to them for each interceptor hook.
+internal struct AnyInterceptor<RequestType, ResponseType, AttributesType: HasAttributes> {
+    internal typealias InterceptorContextType = DefaultInterceptorContext<RequestType, ResponseType, AttributesType>
+    internal typealias InterceptorFn = (InterceptorContextType) async throws -> Void
+    internal typealias MutatingInterceptorFn = (inout InterceptorContextType) async throws -> Void
 
     private var readBeforeExecution: InterceptorFn
     private var modifyBeforeSerialization: MutatingInterceptorFn
@@ -33,7 +35,7 @@ public struct AnyInterceptor<RequestType, ResponseType, AttributesType: HasAttri
     private var modifyBeforeCompletion: MutatingInterceptorFn
     private var readAfterExecution: InterceptorFn
 
-    public init<I: Interceptor>(interceptor: I)
+    internal init<I: Interceptor>(interceptor: I)
     where
         I.RequestType == RequestType,
         I.ResponseType == ResponseType,
@@ -59,61 +61,79 @@ public struct AnyInterceptor<RequestType, ResponseType, AttributesType: HasAttri
         self.readAfterExecution = interceptor.readAfterExecution(context:)
     }
 
-    public func readBeforeExecution(context: InterceptorContextType) async throws {
+    internal func readBeforeExecution(context: InterceptorContextType) async throws {
         try await self.readBeforeExecution(context)
     }
-    public func modifyBeforeSerialization(context: inout InterceptorContextType) async throws {
+
+    internal func modifyBeforeSerialization(context: inout InterceptorContextType) async throws {
         try await self.modifyBeforeSerialization(&context)
     }
-    public func readBeforeSerialization(context: InterceptorContextType) async throws {
+
+    internal func readBeforeSerialization(context: InterceptorContextType) async throws {
         try await self.readBeforeSerialization(context)
     }
-    public func readAfterSerialization(context: InterceptorContextType) async throws {
+
+    internal func readAfterSerialization(context: InterceptorContextType) async throws {
         try await self.readAfterSerialization(context)
     }
-    public func modifyBeforeRetryLoop(context: inout InterceptorContextType) async throws {
+
+    internal func modifyBeforeRetryLoop(context: inout InterceptorContextType) async throws {
         try await self.modifyBeforeRetryLoop(&context)
     }
-    public func readBeforeAttempt(context: InterceptorContextType) async throws {
+
+    internal func readBeforeAttempt(context: InterceptorContextType) async throws {
         try await self.readBeforeAttempt(context)
     }
-    public func modifyBeforeSigning(context: inout InterceptorContextType) async throws {
+
+    internal func modifyBeforeSigning(context: inout InterceptorContextType) async throws {
         try await self.modifyBeforeSigning(&context)
     }
-    public func readBeforeSigning(context: InterceptorContextType) async throws {
+
+    internal func readBeforeSigning(context: InterceptorContextType) async throws {
         try await self.readBeforeSigning(context)
     }
-    public func readAfterSigning(context: InterceptorContextType) async throws {
+
+    internal func readAfterSigning(context: InterceptorContextType) async throws {
         try await self.readAfterSigning(context)
     }
-    public func modifyBeforeTransmit(context: inout InterceptorContextType) async throws {
+
+    internal func modifyBeforeTransmit(context: inout InterceptorContextType) async throws {
         try await self.modifyBeforeTransmit(&context)
     }
-    public func readBeforeTransmit(context: InterceptorContextType) async throws {
+
+    internal func readBeforeTransmit(context: InterceptorContextType) async throws {
         try await self.readBeforeTransmit(context)
     }
-    public func readAfterTransmit(context: InterceptorContextType) async throws {
+
+    internal func readAfterTransmit(context: InterceptorContextType) async throws {
         try await self.readAfterTransmit(context)
     }
-    public func modifyBeforeDeserialization(context: inout InterceptorContextType) async throws {
+
+    internal func modifyBeforeDeserialization(context: inout InterceptorContextType) async throws {
         try await self.modifyBeforeDeserialization(&context)
     }
-    public func readBeforeDeserialization(context: InterceptorContextType) async throws {
+
+    internal func readBeforeDeserialization(context: InterceptorContextType) async throws {
         try await self.readBeforeDeserialization(context)
     }
-    public func readAfterDeserialization(context: InterceptorContextType) async throws {
+
+    internal func readAfterDeserialization(context: InterceptorContextType) async throws {
         try await self.readAfterDeserialization(context)
     }
-    public func modifyBeforeAttemptCompletion(context: inout InterceptorContextType) async throws {
+
+    internal func modifyBeforeAttemptCompletion(context: inout InterceptorContextType) async throws {
         try await self.modifyBeforeAttemptCompletion(&context)
     }
-    public func readAfterAttempt(context: InterceptorContextType) async throws {
+
+    internal func readAfterAttempt(context: InterceptorContextType) async throws {
         try await self.readAfterAttempt(context)
     }
-    public func modifyBeforeCompletion(context: inout InterceptorContextType) async throws {
+
+    internal func modifyBeforeCompletion(context: inout InterceptorContextType) async throws {
         try await self.modifyBeforeCompletion(&context)
     }
-    public func readAfterExecution(context: InterceptorContextType) async throws {
+
+    internal func readAfterExecution(context: InterceptorContextType) async throws {
         try await self.readAfterExecution(context)
     }
 }

--- a/Sources/ClientRuntime/Interceptor/AnyInterceptor.swift
+++ b/Sources/ClientRuntime/Interceptor/AnyInterceptor.swift
@@ -13,26 +13,25 @@
 internal struct AnyInterceptor<RequestType, ResponseType, AttributesType: HasAttributes> {
     internal typealias InterceptorContextType = DefaultInterceptorContext<RequestType, ResponseType, AttributesType>
     internal typealias InterceptorFn = (InterceptorContextType) async throws -> Void
-    internal typealias MutatingInterceptorFn = (inout InterceptorContextType) async throws -> Void
 
     private var readBeforeExecution: InterceptorFn
-    private var modifyBeforeSerialization: MutatingInterceptorFn
+    private var modifyBeforeSerialization: InterceptorFn
     private var readBeforeSerialization: InterceptorFn
     private var readAfterSerialization: InterceptorFn
-    private var modifyBeforeRetryLoop: MutatingInterceptorFn
+    private var modifyBeforeRetryLoop: InterceptorFn
     private var readBeforeAttempt: InterceptorFn
-    private var modifyBeforeSigning: MutatingInterceptorFn
+    private var modifyBeforeSigning: InterceptorFn
     private var readBeforeSigning: InterceptorFn
     private var readAfterSigning: InterceptorFn
-    private var modifyBeforeTransmit: MutatingInterceptorFn
+    private var modifyBeforeTransmit: InterceptorFn
     private var readBeforeTransmit: InterceptorFn
     private var readAfterTransmit: InterceptorFn
-    private var modifyBeforeDeserialization: MutatingInterceptorFn
+    private var modifyBeforeDeserialization: InterceptorFn
     private var readBeforeDeserialization: InterceptorFn
     private var readAfterDeserialization: InterceptorFn
-    private var modifyBeforeAttemptCompletion: MutatingInterceptorFn
+    private var modifyBeforeAttemptCompletion: InterceptorFn
     private var readAfterAttempt: InterceptorFn
-    private var modifyBeforeCompletion: MutatingInterceptorFn
+    private var modifyBeforeCompletion: InterceptorFn
     private var readAfterExecution: InterceptorFn
 
     internal init<I: Interceptor>(interceptor: I)
@@ -65,8 +64,8 @@ internal struct AnyInterceptor<RequestType, ResponseType, AttributesType: HasAtt
         try await self.readBeforeExecution(context)
     }
 
-    internal func modifyBeforeSerialization(context: inout InterceptorContextType) async throws {
-        try await self.modifyBeforeSerialization(&context)
+    internal func modifyBeforeSerialization(context: InterceptorContextType) async throws {
+        try await self.modifyBeforeSerialization(context)
     }
 
     internal func readBeforeSerialization(context: InterceptorContextType) async throws {
@@ -77,16 +76,16 @@ internal struct AnyInterceptor<RequestType, ResponseType, AttributesType: HasAtt
         try await self.readAfterSerialization(context)
     }
 
-    internal func modifyBeforeRetryLoop(context: inout InterceptorContextType) async throws {
-        try await self.modifyBeforeRetryLoop(&context)
+    internal func modifyBeforeRetryLoop(context: InterceptorContextType) async throws {
+        try await self.modifyBeforeRetryLoop(context)
     }
 
     internal func readBeforeAttempt(context: InterceptorContextType) async throws {
         try await self.readBeforeAttempt(context)
     }
 
-    internal func modifyBeforeSigning(context: inout InterceptorContextType) async throws {
-        try await self.modifyBeforeSigning(&context)
+    internal func modifyBeforeSigning(context: InterceptorContextType) async throws {
+        try await self.modifyBeforeSigning(context)
     }
 
     internal func readBeforeSigning(context: InterceptorContextType) async throws {
@@ -97,8 +96,8 @@ internal struct AnyInterceptor<RequestType, ResponseType, AttributesType: HasAtt
         try await self.readAfterSigning(context)
     }
 
-    internal func modifyBeforeTransmit(context: inout InterceptorContextType) async throws {
-        try await self.modifyBeforeTransmit(&context)
+    internal func modifyBeforeTransmit(context: InterceptorContextType) async throws {
+        try await self.modifyBeforeTransmit(context)
     }
 
     internal func readBeforeTransmit(context: InterceptorContextType) async throws {
@@ -109,8 +108,8 @@ internal struct AnyInterceptor<RequestType, ResponseType, AttributesType: HasAtt
         try await self.readAfterTransmit(context)
     }
 
-    internal func modifyBeforeDeserialization(context: inout InterceptorContextType) async throws {
-        try await self.modifyBeforeDeserialization(&context)
+    internal func modifyBeforeDeserialization(context: InterceptorContextType) async throws {
+        try await self.modifyBeforeDeserialization(context)
     }
 
     internal func readBeforeDeserialization(context: InterceptorContextType) async throws {
@@ -121,16 +120,16 @@ internal struct AnyInterceptor<RequestType, ResponseType, AttributesType: HasAtt
         try await self.readAfterDeserialization(context)
     }
 
-    internal func modifyBeforeAttemptCompletion(context: inout InterceptorContextType) async throws {
-        try await self.modifyBeforeAttemptCompletion(&context)
+    internal func modifyBeforeAttemptCompletion(context: InterceptorContextType) async throws {
+        try await self.modifyBeforeAttemptCompletion(context)
     }
 
     internal func readAfterAttempt(context: InterceptorContextType) async throws {
         try await self.readAfterAttempt(context)
     }
 
-    internal func modifyBeforeCompletion(context: inout InterceptorContextType) async throws {
-        try await self.modifyBeforeCompletion(&context)
+    internal func modifyBeforeCompletion(context: InterceptorContextType) async throws {
+        try await self.modifyBeforeCompletion(context)
     }
 
     internal func readAfterExecution(context: InterceptorContextType) async throws {

--- a/Sources/ClientRuntime/Interceptor/AnyInterceptor.swift
+++ b/Sources/ClientRuntime/Interceptor/AnyInterceptor.swift
@@ -6,12 +6,14 @@
 //
 
 /// Type-erased, concrete interceptor.
-/// 
+///
 /// In order to have multiple interceptors hooked into a single operation, we
 /// need a concrete type, not a protocol. This stores references to the closures
 /// of interceptor implementations and delegates to them for each interceptor hook.
-internal struct AnyInterceptor<RequestType, ResponseType, AttributesType: HasAttributes> {
-    internal typealias InterceptorContextType = DefaultInterceptorContext<RequestType, ResponseType, AttributesType>
+internal struct AnyInterceptor<InputType, OutputType, RequestType, ResponseType, AttributesType: HasAttributes> {
+    internal typealias InterceptorContextType = DefaultInterceptorContext<
+        InputType, OutputType, RequestType, ResponseType, AttributesType
+    >
     internal typealias InterceptorFn = (InterceptorContextType) async throws -> Void
 
     private var readBeforeExecution: InterceptorFn
@@ -36,6 +38,8 @@ internal struct AnyInterceptor<RequestType, ResponseType, AttributesType: HasAtt
 
     internal init<I: Interceptor>(interceptor: I)
     where
+        I.InputType == InputType,
+        I.OutputType == OutputType,
         I.RequestType == RequestType,
         I.ResponseType == ResponseType,
         I.AttributesType == AttributesType {

--- a/Sources/ClientRuntime/Interceptor/AnyInterceptor.swift
+++ b/Sources/ClientRuntime/Interceptor/AnyInterceptor.swift
@@ -1,0 +1,119 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// Type-erased, concrete interceptor.
+/// 
+/// This structure stores 
+public struct AnyInterceptor<RequestType, ResponseType, AttributesType: HasAttributes> {
+    public typealias InterceptorContextType = DefaultInterceptorContext<RequestType, ResponseType, AttributesType>
+    public typealias InterceptorFn = (InterceptorContextType) async throws -> Void
+    public typealias MutatingInterceptorFn = (inout InterceptorContextType) async throws -> Void
+
+    private var readBeforeExecution: InterceptorFn
+    private var modifyBeforeSerialization: MutatingInterceptorFn
+    private var readBeforeSerialization: InterceptorFn
+    private var readAfterSerialization: InterceptorFn
+    private var modifyBeforeRetryLoop: MutatingInterceptorFn
+    private var readBeforeAttempt: InterceptorFn
+    private var modifyBeforeSigning: MutatingInterceptorFn
+    private var readBeforeSigning: InterceptorFn
+    private var readAfterSigning: InterceptorFn
+    private var modifyBeforeTransmit: MutatingInterceptorFn
+    private var readBeforeTransmit: InterceptorFn
+    private var readAfterTransmit: InterceptorFn
+    private var modifyBeforeDeserialization: MutatingInterceptorFn
+    private var readBeforeDeserialization: InterceptorFn
+    private var readAfterDeserialization: InterceptorFn
+    private var modifyBeforeAttemptCompletion: MutatingInterceptorFn
+    private var readAfterAttempt: InterceptorFn
+    private var modifyBeforeCompletion: MutatingInterceptorFn
+    private var readAfterExecution: InterceptorFn
+
+    public init<I: Interceptor>(interceptor: I)
+    where
+        I.RequestType == RequestType,
+        I.ResponseType == ResponseType,
+        I.AttributesType == AttributesType {
+        self.readBeforeExecution = interceptor.readBeforeExecution(context:)
+        self.modifyBeforeSerialization = interceptor.modifyBeforeSerialization(context:)
+        self.readBeforeSerialization = interceptor.readBeforeSerialization(context:)
+        self.readAfterSerialization = interceptor.readAfterSerialization(context:)
+        self.modifyBeforeRetryLoop = interceptor.modifyBeforeRetryLoop(context:)
+        self.readBeforeAttempt = interceptor.readBeforeAttempt(context:)
+        self.modifyBeforeSigning = interceptor.modifyBeforeSigning(context:)
+        self.readBeforeSigning = interceptor.readBeforeSigning(context:)
+        self.readAfterSigning = interceptor.readAfterSigning(context:)
+        self.modifyBeforeTransmit = interceptor.modifyBeforeTransmit(context:)
+        self.readBeforeTransmit = interceptor.readBeforeTransmit(context:)
+        self.readAfterTransmit = interceptor.readAfterTransmit(context:)
+        self.modifyBeforeDeserialization = interceptor.modifyBeforeDeserialization(context:)
+        self.readBeforeDeserialization = interceptor.readBeforeDeserialization(context:)
+        self.readAfterDeserialization = interceptor.readAfterDeserialization(context:)
+        self.modifyBeforeAttemptCompletion = interceptor.modifyBeforeAttemptCompletion(context:)
+        self.readAfterAttempt = interceptor.readAfterAttempt(context:)
+        self.modifyBeforeCompletion = interceptor.modifyBeforeCompletion(context:)
+        self.readAfterExecution = interceptor.readAfterExecution(context:)
+    }
+
+    public func readBeforeExecution(context: InterceptorContextType) async throws {
+        try await self.readBeforeExecution(context)
+    }
+    public func modifyBeforeSerialization(context: inout InterceptorContextType) async throws {
+        try await self.modifyBeforeSerialization(&context)
+    }
+    public func readBeforeSerialization(context: InterceptorContextType) async throws {
+        try await self.readBeforeSerialization(context)
+    }
+    public func readAfterSerialization(context: InterceptorContextType) async throws {
+        try await self.readAfterSerialization(context)
+    }
+    public func modifyBeforeRetryLoop(context: inout InterceptorContextType) async throws {
+        try await self.modifyBeforeRetryLoop(&context)
+    }
+    public func readBeforeAttempt(context: InterceptorContextType) async throws {
+        try await self.readBeforeAttempt(context)
+    }
+    public func modifyBeforeSigning(context: inout InterceptorContextType) async throws {
+        try await self.modifyBeforeSigning(&context)
+    }
+    public func readBeforeSigning(context: InterceptorContextType) async throws {
+        try await self.readBeforeSigning(context)
+    }
+    public func readAfterSigning(context: InterceptorContextType) async throws {
+        try await self.readAfterSigning(context)
+    }
+    public func modifyBeforeTransmit(context: inout InterceptorContextType) async throws {
+        try await self.modifyBeforeTransmit(&context)
+    }
+    public func readBeforeTransmit(context: InterceptorContextType) async throws {
+        try await self.readBeforeTransmit(context)
+    }
+    public func readAfterTransmit(context: InterceptorContextType) async throws {
+        try await self.readAfterTransmit(context)
+    }
+    public func modifyBeforeDeserialization(context: inout InterceptorContextType) async throws {
+        try await self.modifyBeforeDeserialization(&context)
+    }
+    public func readBeforeDeserialization(context: InterceptorContextType) async throws {
+        try await self.readBeforeDeserialization(context)
+    }
+    public func readAfterDeserialization(context: InterceptorContextType) async throws {
+        try await self.readAfterDeserialization(context)
+    }
+    public func modifyBeforeAttemptCompletion(context: inout InterceptorContextType) async throws {
+        try await self.modifyBeforeAttemptCompletion(&context)
+    }
+    public func readAfterAttempt(context: InterceptorContextType) async throws {
+        try await self.readAfterAttempt(context)
+    }
+    public func modifyBeforeCompletion(context: inout InterceptorContextType) async throws {
+        try await self.modifyBeforeCompletion(&context)
+    }
+    public func readAfterExecution(context: InterceptorContextType) async throws {
+        try await self.readAfterExecution(context)
+    }
+}

--- a/Sources/ClientRuntime/Interceptor/DefaultInterceptorContext.swift
+++ b/Sources/ClientRuntime/Interceptor/DefaultInterceptorContext.swift
@@ -1,0 +1,89 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// Default implementation for all interceptor context types.
+/// 
+/// This object will be created before operation execution, and passed through each interceptor
+/// hook in the execution pipeline.
+public class DefaultInterceptorContext<RequestType, ResponseType, AttributesType: HasAttributes>: InterceptorContext {
+    private var attributes: AttributesType
+    private var input: Any
+    private var request: RequestType?
+    private var response: ResponseType?
+    private var output: Any?
+
+    public init(input: Any, attributes: AttributesType) {
+        self.input = input
+        self.attributes = attributes
+    }
+
+    public func getInput() -> Any {
+        self.input
+    }
+
+    public func getAttributes() -> AttributesType {
+        return self.attributes
+    }
+}
+
+extension DefaultInterceptorContext: BeforeSerialization {}
+
+extension DefaultInterceptorContext: MutableInput {
+    public func updateInput(updated: Any) {
+        self.input = updated
+    }
+}
+
+extension DefaultInterceptorContext: AfterSerialization {
+    public func getRequest() -> RequestType {
+        self.request!
+    }
+}
+
+extension DefaultInterceptorContext: MutableRequest {
+    public func updateRequest(updated: RequestType) {
+        self.request = updated
+    }
+}
+
+extension DefaultInterceptorContext: BeforeDeserialization {
+    public func getResponse() -> ResponseType {
+        self.response!
+    }
+}
+
+extension DefaultInterceptorContext: MutableResponse {
+    public func updateResponse(updated: ResponseType) {
+        self.response = updated
+    }
+}
+
+extension DefaultInterceptorContext: AfterDeserialization {
+    public func getOutput() -> Any {
+        self.output!
+    }
+}
+
+extension DefaultInterceptorContext: AfterAttempt {
+    public func getResponse() -> ResponseType? {
+        self.response
+    }
+}
+
+extension DefaultInterceptorContext: MutableOutputAfterAttempt {
+    public func updateOutput(updated: Any) {
+        self.output = updated
+    }
+}
+
+extension DefaultInterceptorContext: Finalization {
+    public func getRequest() -> RequestType? {
+        self.request
+    }
+}
+
+extension DefaultInterceptorContext: MutableOutputFinalization {}

--- a/Sources/ClientRuntime/Interceptor/DefaultInterceptorContext.swift
+++ b/Sources/ClientRuntime/Interceptor/DefaultInterceptorContext.swift
@@ -6,22 +6,23 @@
 //
 
 /// Default implementation for all interceptor context types.
-/// 
+///
 /// This object will be created before operation execution, and passed through each interceptor
 /// hook in the execution pipeline.
-public class DefaultInterceptorContext<RequestType, ResponseType, AttributesType: HasAttributes>: InterceptorContext {
+public class DefaultInterceptorContext<InputType, OutputType, RequestType, ResponseType, AttributesType: HasAttributes>:
+    InterceptorContext {
     private var attributes: AttributesType
-    private var input: Any
+    private var input: InputType
     private var request: RequestType?
     private var response: ResponseType?
-    private var output: Any?
+    private var output: OutputType?
 
-    public init(input: Any, attributes: AttributesType) {
+    public init(input: InputType, attributes: AttributesType) {
         self.input = input
         self.attributes = attributes
     }
 
-    public func getInput() -> Any {
+    public func getInput() -> InputType {
         self.input
     }
 
@@ -33,7 +34,7 @@ public class DefaultInterceptorContext<RequestType, ResponseType, AttributesType
 extension DefaultInterceptorContext: BeforeSerialization {}
 
 extension DefaultInterceptorContext: MutableInput {
-    public func updateInput(updated: Any) {
+    public func updateInput(updated: InputType) {
         self.input = updated
     }
 }
@@ -63,7 +64,7 @@ extension DefaultInterceptorContext: MutableResponse {
 }
 
 extension DefaultInterceptorContext: AfterDeserialization {
-    public func getOutput() -> Any {
+    public func getOutput() -> OutputType {
         self.output!
     }
 }
@@ -75,7 +76,7 @@ extension DefaultInterceptorContext: AfterAttempt {
 }
 
 extension DefaultInterceptorContext: MutableOutputAfterAttempt {
-    public func updateOutput(updated: Any) {
+    public func updateOutput(updated: OutputType) {
         self.output = updated
     }
 }

--- a/Sources/ClientRuntime/Interceptor/HttpInterceptor.swift
+++ b/Sources/ClientRuntime/Interceptor/HttpInterceptor.swift
@@ -1,0 +1,12 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public protocol HttpInterceptor: Interceptor
+where
+    RequestType == SdkHttpRequest,
+    ResponseType == HttpResponse,
+    AttributesType == HttpContext {}

--- a/Sources/ClientRuntime/Interceptor/HttpInterceptor.swift
+++ b/Sources/ClientRuntime/Interceptor/HttpInterceptor.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-public protocol HttpInterceptor: Interceptor
+public protocol HttpInterceptor<InputType, OutputType>: Interceptor
 where
     RequestType == SdkHttpRequest,
     ResponseType == HttpResponse,

--- a/Sources/ClientRuntime/Interceptor/Interceptor.swift
+++ b/Sources/ClientRuntime/Interceptor/Interceptor.swift
@@ -1,0 +1,128 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// An interceptor allows injecting code into the SDK's request execution pipeline.
+public protocol Interceptor<RequestType, ResponseType, AttributesType> {
+
+    /// The type of the request transport messages sent by operations this interceptor can hook into.
+    associatedtype RequestType
+
+    /// The type of the response transport message received by operations this interceptor can hook into.
+    associatedtype ResponseType
+
+    /// The type of the attributes that will be available to the interceptor.
+    associatedtype AttributesType: HasAttributes
+
+    /// A hook called at the start of execution, before the SDK does anything else.
+    func readBeforeExecution(context: some BeforeSerialization<AttributesType>) async throws
+
+    /// A hook called before the operation input is serialized into the transport message. This
+    /// method has the ability to modify the operation input.
+    func modifyBeforeSerialization(context: inout some MutableInput<AttributesType>) async throws
+
+    /// A hook called before the operation input is serialized into the transport message.
+    func readBeforeSerialization(context: some BeforeSerialization<AttributesType>) async throws
+
+    /// A hook called after the operation input is serialized into the transport message.
+    func readAfterSerialization(context: some AfterSerialization<RequestType, AttributesType>) async throws
+
+    /// A hook called before the retry loop is entered. This method has the ability to modify the transport
+    /// request message.
+    func modifyBeforeRetryLoop(context: inout some MutableRequest<RequestType, AttributesType>) async throws
+
+    /// A hook called before each attempt at sending the tranport request message to the service.
+    func readBeforeAttempt(context: some AfterSerialization<RequestType, AttributesType>) async throws
+
+    /// A hook called before the transport request message is signed. This method has the ability to modify
+    /// the transport request message.
+    func modifyBeforeSigning(context: inout some MutableRequest<RequestType, AttributesType>) async throws
+
+    /// A hook called before the transport request message is signed.
+    func readBeforeSigning(context: some AfterSerialization<RequestType, AttributesType>) async throws
+
+    /// A hook called after the transport request message is signed.
+    func readAfterSigning(context: some AfterSerialization<RequestType, AttributesType>) async throws
+
+    /// A hook called before the transport request message is sent to the service. This method has the ability
+    /// to modify the transport request message.
+    func modifyBeforeTransmit(context: inout some MutableRequest<RequestType, AttributesType>) async throws
+
+    /// A hook called before the transport request message is sent to the service.
+    func readBeforeTransmit(context: some AfterSerialization<RequestType, AttributesType>) async throws
+
+    /// A hook called after the transport request message is sent to the service, and a transport response
+    /// message has been received.
+    func readAfterTransmit(context: some BeforeDeserialization<RequestType, ResponseType, AttributesType>) async throws
+
+    /// A hook called before the transport response message is deserialized. This method has the ability to
+    /// modify the transport response message.
+    func modifyBeforeDeserialization(context: inout some MutableResponse<RequestType, ResponseType, AttributesType>) async throws
+
+    /// A hook alled before the transport response message is deserialized.
+    func readBeforeDeserialization(context: some BeforeDeserialization<RequestType, ResponseType, AttributesType>) async throws
+
+    /// A hook called after the transport response message is deserialized.
+    func readAfterDeserialization(context: some AfterDeserialization<RequestType, ResponseType, AttributesType>) async throws
+
+    /// A hook called when an attempt is completed. This method has the ability to modify the operation output.
+    func modifyBeforeAttemptCompletion(context: inout some MutableOutputAfterAttempt<RequestType, ResponseType, AttributesType>) async throws
+
+    /// A hook called when an attempt is completed.
+    func readAfterAttempt(context: some AfterAttempt<RequestType, ResponseType, AttributesType>) async throws
+
+    /// A hook called when execution is completed. This method has the ability to modify the operation output.
+    func modifyBeforeCompletion(context: inout some MutableOutputFinalization<RequestType, ResponseType, AttributesType>) async throws
+
+    /// A hook called when execution is completed.
+    func readAfterExecution(context: some Finalization<RequestType, ResponseType, AttributesType>) async throws
+}
+
+public extension Interceptor {
+    func readBeforeExecution(context: some BeforeSerialization<AttributesType>) async throws {}
+
+    func modifyBeforeSerialization(context: inout some MutableInput<AttributesType>) async throws {}
+
+    func readBeforeSerialization(context: some BeforeSerialization<AttributesType>) async throws {}
+
+    func readAfterSerialization(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
+
+    func modifyBeforeRetryLoop(context: inout some MutableRequest<RequestType, AttributesType>) async throws {}
+
+    func readBeforeAttempt(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
+
+    func modifyBeforeSigning(context: inout some MutableRequest<RequestType, AttributesType>) async throws {}
+
+    func readBeforeSigning(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
+
+    func readAfterSigning(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
+
+    func modifyBeforeTransmit(context: inout some MutableRequest<RequestType, AttributesType>) async throws {}
+
+    func readBeforeTransmit(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
+
+    func readAfterTransmit(context: some BeforeDeserialization<RequestType, ResponseType, AttributesType>) async throws {}
+
+    func modifyBeforeDeserialization(context: inout some MutableResponse<RequestType, ResponseType, AttributesType>) async throws {}
+
+    func readBeforeDeserialization(context: some BeforeDeserialization<RequestType, ResponseType, AttributesType>) async throws {}
+
+    func readAfterDeserialization(context: some AfterDeserialization<RequestType, ResponseType, AttributesType>) async throws {}
+
+    func modifyBeforeAttemptCompletion(context: inout some MutableOutputAfterAttempt<RequestType, ResponseType, AttributesType>) async throws {}
+
+    func readAfterAttempt(context: some AfterAttempt<RequestType, ResponseType, AttributesType>) async throws {}
+
+    func modifyBeforeCompletion(context: inout some MutableOutputFinalization<RequestType, ResponseType, AttributesType>) async throws {}
+
+    func readAfterExecution(context: some Finalization<RequestType, ResponseType, AttributesType>) async throws {}
+}
+
+public extension Interceptor {
+    func erase() -> AnyInterceptor<RequestType, ResponseType, AttributesType> {
+        return AnyInterceptor(interceptor: self)
+    }
+}

--- a/Sources/ClientRuntime/Interceptor/Interceptor.swift
+++ b/Sources/ClientRuntime/Interceptor/Interceptor.swift
@@ -121,7 +121,7 @@ public extension Interceptor {
     func readAfterExecution(context: some Finalization<RequestType, ResponseType, AttributesType>) async throws {}
 }
 
-public extension Interceptor {
+internal extension Interceptor {
     func erase() -> AnyInterceptor<RequestType, ResponseType, AttributesType> {
         return AnyInterceptor(interceptor: self)
     }

--- a/Sources/ClientRuntime/Interceptor/Interceptor.swift
+++ b/Sources/ClientRuntime/Interceptor/Interceptor.swift
@@ -6,7 +6,13 @@
 //
 
 /// An interceptor allows injecting code into the SDK's request execution pipeline.
-public protocol Interceptor<RequestType, ResponseType, AttributesType> {
+public protocol Interceptor<InputType, OutputType, RequestType, ResponseType, AttributesType> {
+
+    /// The type of the modeled operation input.
+    associatedtype InputType
+
+    /// The type of the modeled operation output.
+    associatedtype OutputType
 
     /// The type of the request transport messages sent by operations this interceptor can hook into.
     associatedtype RequestType
@@ -18,111 +24,158 @@ public protocol Interceptor<RequestType, ResponseType, AttributesType> {
     associatedtype AttributesType: HasAttributes
 
     /// A hook called at the start of execution, before the SDK does anything else.
-    func readBeforeExecution(context: some BeforeSerialization<AttributesType>) async throws
+    func readBeforeExecution(context: some BeforeSerialization<InputType, AttributesType>) async throws
 
     /// A hook called before the operation input is serialized into the transport message. This
     /// method has the ability to modify the operation input.
-    func modifyBeforeSerialization(context: some MutableInput<AttributesType>) async throws
+    func modifyBeforeSerialization(context: some MutableInput<InputType, AttributesType>) async throws
 
     /// A hook called before the operation input is serialized into the transport message.
-    func readBeforeSerialization(context: some BeforeSerialization<AttributesType>) async throws
+    func readBeforeSerialization(context: some BeforeSerialization<InputType, AttributesType>) async throws
 
     /// A hook called after the operation input is serialized into the transport message.
-    func readAfterSerialization(context: some AfterSerialization<RequestType, AttributesType>) async throws
+    func readAfterSerialization(context: some AfterSerialization<InputType, RequestType, AttributesType>) async throws
 
     /// A hook called before the retry loop is entered. This method has the ability to modify the transport
     /// request message.
-    func modifyBeforeRetryLoop(context: some MutableRequest<RequestType, AttributesType>) async throws
+    func modifyBeforeRetryLoop(context: some MutableRequest<InputType, RequestType, AttributesType>) async throws
 
     /// A hook called before each attempt at sending the tranport request message to the service.
-    func readBeforeAttempt(context: some AfterSerialization<RequestType, AttributesType>) async throws
+    func readBeforeAttempt(context: some AfterSerialization<InputType, RequestType, AttributesType>) async throws
 
     /// A hook called before the transport request message is signed. This method has the ability to modify
     /// the transport request message.
-    func modifyBeforeSigning(context: some MutableRequest<RequestType, AttributesType>) async throws
+    func modifyBeforeSigning(context: some MutableRequest<InputType, RequestType, AttributesType>) async throws
 
     /// A hook called before the transport request message is signed.
-    func readBeforeSigning(context: some AfterSerialization<RequestType, AttributesType>) async throws
+    func readBeforeSigning(context: some AfterSerialization<InputType, RequestType, AttributesType>) async throws
 
     /// A hook called after the transport request message is signed.
-    func readAfterSigning(context: some AfterSerialization<RequestType, AttributesType>) async throws
+    func readAfterSigning(context: some AfterSerialization<InputType, RequestType, AttributesType>) async throws
 
     /// A hook called before the transport request message is sent to the service. This method has the ability
     /// to modify the transport request message.
-    func modifyBeforeTransmit(context: some MutableRequest<RequestType, AttributesType>) async throws
+    func modifyBeforeTransmit(context: some MutableRequest<InputType, RequestType, AttributesType>) async throws
 
     /// A hook called before the transport request message is sent to the service.
-    func readBeforeTransmit(context: some AfterSerialization<RequestType, AttributesType>) async throws
+    func readBeforeTransmit(context: some AfterSerialization<InputType, RequestType, AttributesType>) async throws
 
     /// A hook called after the transport request message is sent to the service, and a transport response
     /// message has been received.
-    func readAfterTransmit(context: some BeforeDeserialization<RequestType, ResponseType, AttributesType>) async throws
+    func readAfterTransmit(
+        context: some BeforeDeserialization<InputType, RequestType, ResponseType, AttributesType>
+    ) async throws
 
     /// A hook called before the transport response message is deserialized. This method has the ability to
     /// modify the transport response message.
-    func modifyBeforeDeserialization(context: some MutableResponse<RequestType, ResponseType, AttributesType>) async throws
+    func modifyBeforeDeserialization(
+        context: some MutableResponse<InputType, RequestType, ResponseType, AttributesType>
+    ) async throws
 
     /// A hook alled before the transport response message is deserialized.
-    func readBeforeDeserialization(context: some BeforeDeserialization<RequestType, ResponseType, AttributesType>) async throws
+    func readBeforeDeserialization(
+        context: some BeforeDeserialization<InputType, RequestType, ResponseType, AttributesType>
+    ) async throws
 
     /// A hook called after the transport response message is deserialized.
-    func readAfterDeserialization(context: some AfterDeserialization<RequestType, ResponseType, AttributesType>) async throws
+    func readAfterDeserialization(
+        context: some AfterDeserialization<InputType, OutputType, RequestType, ResponseType, AttributesType>
+    ) async throws
 
     /// A hook called when an attempt is completed. This method has the ability to modify the operation output.
-    func modifyBeforeAttemptCompletion(context: some MutableOutputAfterAttempt<RequestType, ResponseType, AttributesType>) async throws
+    func modifyBeforeAttemptCompletion(
+        context: some MutableOutputAfterAttempt<InputType, OutputType, RequestType, ResponseType, AttributesType>
+    ) async throws
 
     /// A hook called when an attempt is completed.
-    func readAfterAttempt(context: some AfterAttempt<RequestType, ResponseType, AttributesType>) async throws
+    func readAfterAttempt(
+        context: some AfterAttempt<InputType, OutputType, RequestType, ResponseType, AttributesType>
+    ) async throws
 
     /// A hook called when execution is completed. This method has the ability to modify the operation output.
-    func modifyBeforeCompletion(context: some MutableOutputFinalization<RequestType, ResponseType, AttributesType>) async throws
+    func modifyBeforeCompletion(
+        context: some MutableOutputFinalization<InputType, OutputType, RequestType, ResponseType, AttributesType>
+    ) async throws
 
     /// A hook called when execution is completed.
-    func readAfterExecution(context: some Finalization<RequestType, ResponseType, AttributesType>) async throws
+    func readAfterExecution(
+        context: some Finalization<InputType, OutputType, RequestType, ResponseType, AttributesType>
+    ) async throws
 }
 
-public extension Interceptor {
-    func readBeforeExecution(context: some BeforeSerialization<AttributesType>) async throws {}
+extension Interceptor {
+    public func readBeforeExecution(context: some BeforeSerialization<InputType, AttributesType>) async throws {}
 
-    func modifyBeforeSerialization(context: some MutableInput<AttributesType>) async throws {}
+    public func modifyBeforeSerialization(context: some MutableInput<InputType, AttributesType>) async throws {}
 
-    func readBeforeSerialization(context: some BeforeSerialization<AttributesType>) async throws {}
+    public func readBeforeSerialization(context: some BeforeSerialization<InputType, AttributesType>) async throws {}
 
-    func readAfterSerialization(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
+    public func readAfterSerialization(
+        context: some AfterSerialization<InputType, RequestType, AttributesType>
+    ) async throws {}
 
-    func modifyBeforeRetryLoop(context: some MutableRequest<RequestType, AttributesType>) async throws {}
+    public func modifyBeforeRetryLoop(
+        context: some MutableRequest<InputType, RequestType, AttributesType>
+    ) async throws {}
 
-    func readBeforeAttempt(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
+    public func readBeforeAttempt(
+        context: some AfterSerialization<InputType, RequestType, AttributesType>
+    ) async throws {}
 
-    func modifyBeforeSigning(context: some MutableRequest<RequestType, AttributesType>) async throws {}
+    public func modifyBeforeSigning(context: some MutableRequest<InputType, RequestType, AttributesType>) async throws {
+    }
 
-    func readBeforeSigning(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
+    public func readBeforeSigning(
+        context: some AfterSerialization<InputType, RequestType, AttributesType>
+    ) async throws {}
 
-    func readAfterSigning(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
+    public func readAfterSigning(
+        context: some AfterSerialization<InputType, RequestType, AttributesType>
+    ) async throws {}
 
-    func modifyBeforeTransmit(context: some MutableRequest<RequestType, AttributesType>) async throws {}
+    public func modifyBeforeTransmit(
+        context: some MutableRequest<InputType, RequestType, AttributesType>
+    ) async throws {}
 
-    func readBeforeTransmit(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
+    public func readBeforeTransmit(
+        context: some AfterSerialization<InputType, RequestType, AttributesType>
+    ) async throws {}
 
-    func readAfterTransmit(context: some BeforeDeserialization<RequestType, ResponseType, AttributesType>) async throws {}
+    public func readAfterTransmit(
+        context: some BeforeDeserialization<InputType, RequestType, ResponseType, AttributesType>
+    ) async throws {}
 
-    func modifyBeforeDeserialization(context: some MutableResponse<RequestType, ResponseType, AttributesType>) async throws {}
+    public func modifyBeforeDeserialization(
+        context: some MutableResponse<InputType, RequestType, ResponseType, AttributesType>
+    ) async throws {}
 
-    func readBeforeDeserialization(context: some BeforeDeserialization<RequestType, ResponseType, AttributesType>) async throws {}
+    public func readBeforeDeserialization(
+        context: some BeforeDeserialization<InputType, RequestType, ResponseType, AttributesType>
+    ) async throws {}
 
-    func readAfterDeserialization(context: some AfterDeserialization<RequestType, ResponseType, AttributesType>) async throws {}
+    public func readAfterDeserialization(
+        context: some AfterDeserialization<InputType, OutputType, RequestType, ResponseType, AttributesType>
+    ) async throws {}
 
-    func modifyBeforeAttemptCompletion(context: some MutableOutputAfterAttempt<RequestType, ResponseType, AttributesType>) async throws {}
+    public func modifyBeforeAttemptCompletion(
+        context: some MutableOutputAfterAttempt<InputType, OutputType, RequestType, ResponseType, AttributesType>
+    ) async throws {}
 
-    func readAfterAttempt(context: some AfterAttempt<RequestType, ResponseType, AttributesType>) async throws {}
+    public func readAfterAttempt(
+        context: some AfterAttempt<InputType, OutputType, RequestType, ResponseType, AttributesType>
+    ) async throws {}
 
-    func modifyBeforeCompletion(context: some MutableOutputFinalization<RequestType, ResponseType, AttributesType>) async throws {}
+    public func modifyBeforeCompletion(
+        context: some MutableOutputFinalization<InputType, OutputType, RequestType, ResponseType, AttributesType>
+    ) async throws {}
 
-    func readAfterExecution(context: some Finalization<RequestType, ResponseType, AttributesType>) async throws {}
+    public func readAfterExecution(
+        context: some Finalization<InputType, OutputType, RequestType, ResponseType, AttributesType>
+    ) async throws {}
 }
 
-internal extension Interceptor {
-    func erase() -> AnyInterceptor<RequestType, ResponseType, AttributesType> {
+extension Interceptor {
+    func erase() -> AnyInterceptor<InputType, OutputType, RequestType, ResponseType, AttributesType> {
         return AnyInterceptor(interceptor: self)
     }
 }

--- a/Sources/ClientRuntime/Interceptor/Interceptor.swift
+++ b/Sources/ClientRuntime/Interceptor/Interceptor.swift
@@ -22,7 +22,7 @@ public protocol Interceptor<RequestType, ResponseType, AttributesType> {
 
     /// A hook called before the operation input is serialized into the transport message. This
     /// method has the ability to modify the operation input.
-    func modifyBeforeSerialization(context: inout some MutableInput<AttributesType>) async throws
+    func modifyBeforeSerialization(context: some MutableInput<AttributesType>) async throws
 
     /// A hook called before the operation input is serialized into the transport message.
     func readBeforeSerialization(context: some BeforeSerialization<AttributesType>) async throws
@@ -32,14 +32,14 @@ public protocol Interceptor<RequestType, ResponseType, AttributesType> {
 
     /// A hook called before the retry loop is entered. This method has the ability to modify the transport
     /// request message.
-    func modifyBeforeRetryLoop(context: inout some MutableRequest<RequestType, AttributesType>) async throws
+    func modifyBeforeRetryLoop(context: some MutableRequest<RequestType, AttributesType>) async throws
 
     /// A hook called before each attempt at sending the tranport request message to the service.
     func readBeforeAttempt(context: some AfterSerialization<RequestType, AttributesType>) async throws
 
     /// A hook called before the transport request message is signed. This method has the ability to modify
     /// the transport request message.
-    func modifyBeforeSigning(context: inout some MutableRequest<RequestType, AttributesType>) async throws
+    func modifyBeforeSigning(context: some MutableRequest<RequestType, AttributesType>) async throws
 
     /// A hook called before the transport request message is signed.
     func readBeforeSigning(context: some AfterSerialization<RequestType, AttributesType>) async throws
@@ -49,7 +49,7 @@ public protocol Interceptor<RequestType, ResponseType, AttributesType> {
 
     /// A hook called before the transport request message is sent to the service. This method has the ability
     /// to modify the transport request message.
-    func modifyBeforeTransmit(context: inout some MutableRequest<RequestType, AttributesType>) async throws
+    func modifyBeforeTransmit(context: some MutableRequest<RequestType, AttributesType>) async throws
 
     /// A hook called before the transport request message is sent to the service.
     func readBeforeTransmit(context: some AfterSerialization<RequestType, AttributesType>) async throws
@@ -60,7 +60,7 @@ public protocol Interceptor<RequestType, ResponseType, AttributesType> {
 
     /// A hook called before the transport response message is deserialized. This method has the ability to
     /// modify the transport response message.
-    func modifyBeforeDeserialization(context: inout some MutableResponse<RequestType, ResponseType, AttributesType>) async throws
+    func modifyBeforeDeserialization(context: some MutableResponse<RequestType, ResponseType, AttributesType>) async throws
 
     /// A hook alled before the transport response message is deserialized.
     func readBeforeDeserialization(context: some BeforeDeserialization<RequestType, ResponseType, AttributesType>) async throws
@@ -69,13 +69,13 @@ public protocol Interceptor<RequestType, ResponseType, AttributesType> {
     func readAfterDeserialization(context: some AfterDeserialization<RequestType, ResponseType, AttributesType>) async throws
 
     /// A hook called when an attempt is completed. This method has the ability to modify the operation output.
-    func modifyBeforeAttemptCompletion(context: inout some MutableOutputAfterAttempt<RequestType, ResponseType, AttributesType>) async throws
+    func modifyBeforeAttemptCompletion(context: some MutableOutputAfterAttempt<RequestType, ResponseType, AttributesType>) async throws
 
     /// A hook called when an attempt is completed.
     func readAfterAttempt(context: some AfterAttempt<RequestType, ResponseType, AttributesType>) async throws
 
     /// A hook called when execution is completed. This method has the ability to modify the operation output.
-    func modifyBeforeCompletion(context: inout some MutableOutputFinalization<RequestType, ResponseType, AttributesType>) async throws
+    func modifyBeforeCompletion(context: some MutableOutputFinalization<RequestType, ResponseType, AttributesType>) async throws
 
     /// A hook called when execution is completed.
     func readAfterExecution(context: some Finalization<RequestType, ResponseType, AttributesType>) async throws
@@ -84,39 +84,39 @@ public protocol Interceptor<RequestType, ResponseType, AttributesType> {
 public extension Interceptor {
     func readBeforeExecution(context: some BeforeSerialization<AttributesType>) async throws {}
 
-    func modifyBeforeSerialization(context: inout some MutableInput<AttributesType>) async throws {}
+    func modifyBeforeSerialization(context: some MutableInput<AttributesType>) async throws {}
 
     func readBeforeSerialization(context: some BeforeSerialization<AttributesType>) async throws {}
 
     func readAfterSerialization(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
 
-    func modifyBeforeRetryLoop(context: inout some MutableRequest<RequestType, AttributesType>) async throws {}
+    func modifyBeforeRetryLoop(context: some MutableRequest<RequestType, AttributesType>) async throws {}
 
     func readBeforeAttempt(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
 
-    func modifyBeforeSigning(context: inout some MutableRequest<RequestType, AttributesType>) async throws {}
+    func modifyBeforeSigning(context: some MutableRequest<RequestType, AttributesType>) async throws {}
 
     func readBeforeSigning(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
 
     func readAfterSigning(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
 
-    func modifyBeforeTransmit(context: inout some MutableRequest<RequestType, AttributesType>) async throws {}
+    func modifyBeforeTransmit(context: some MutableRequest<RequestType, AttributesType>) async throws {}
 
     func readBeforeTransmit(context: some AfterSerialization<RequestType, AttributesType>) async throws {}
 
     func readAfterTransmit(context: some BeforeDeserialization<RequestType, ResponseType, AttributesType>) async throws {}
 
-    func modifyBeforeDeserialization(context: inout some MutableResponse<RequestType, ResponseType, AttributesType>) async throws {}
+    func modifyBeforeDeserialization(context: some MutableResponse<RequestType, ResponseType, AttributesType>) async throws {}
 
     func readBeforeDeserialization(context: some BeforeDeserialization<RequestType, ResponseType, AttributesType>) async throws {}
 
     func readAfterDeserialization(context: some AfterDeserialization<RequestType, ResponseType, AttributesType>) async throws {}
 
-    func modifyBeforeAttemptCompletion(context: inout some MutableOutputAfterAttempt<RequestType, ResponseType, AttributesType>) async throws {}
+    func modifyBeforeAttemptCompletion(context: some MutableOutputAfterAttempt<RequestType, ResponseType, AttributesType>) async throws {}
 
     func readAfterAttempt(context: some AfterAttempt<RequestType, ResponseType, AttributesType>) async throws {}
 
-    func modifyBeforeCompletion(context: inout some MutableOutputFinalization<RequestType, ResponseType, AttributesType>) async throws {}
+    func modifyBeforeCompletion(context: some MutableOutputFinalization<RequestType, ResponseType, AttributesType>) async throws {}
 
     func readAfterExecution(context: some Finalization<RequestType, ResponseType, AttributesType>) async throws {}
 }

--- a/Sources/ClientRuntime/Interceptor/InterceptorContext.swift
+++ b/Sources/ClientRuntime/Interceptor/InterceptorContext.swift
@@ -1,0 +1,172 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// The base type of all context objects passed to `Interceptor` methods.
+public protocol InterceptorContext {
+
+    /// The type of the transport message that will be transmitted by the operation being invoked.
+    associatedtype RequestType
+
+    /// The type of the transport message that will be received by the operation being invoked.
+    associatedtype ResponseType
+
+    /// The type of the attributes that will be available to all interceptors.
+    associatedtype AttributesType: HasAttributes
+
+    /// - Returns: The input for the operation being invoked.
+    func getInput() -> Any
+
+    /// - Returns: The attributes available in this interceptor context.
+    func getAttributes() -> AttributesType
+}
+
+public extension InterceptorContext {
+    /// Get the input for the operation being invoked as the type `T`.
+    /// - Returns: The input as `T` if the input can be successfully cast to `T`.
+    func getInput<T>() -> T? {
+        self.getInput() as? T
+    }
+}
+
+/// Context given to interceptor hooks called before request serialization.
+public protocol BeforeSerialization<AttributesType>: InterceptorContext {}
+
+/// Context given to interceptor hooks that can mutate the operation input.
+public protocol MutableInput<AttributesType>: InterceptorContext {
+
+    /// Mutates the operation input.
+    /// - Parameter updated: The updated operation input.
+    mutating func updateInput(updated: Any)
+}
+
+/// Context given to interceptor hooks called after request serialization.
+/// 
+/// These hooks have access to the serialized `RequestType`.
+public protocol AfterSerialization<RequestType, AttributesType>: InterceptorContext {
+
+    /// - Returns: The serialized request.
+    func getRequest() -> RequestType
+}
+
+/// Context given to interceptor hooks that can mutate the serialized request.
+///
+/// These hooks have access to the serialized `RequestType`
+public protocol MutableRequest<RequestType, AttributesType>: InterceptorContext {
+
+    /// - Returns: The serialized request.
+    func getRequest() -> RequestType
+
+    /// Mutates the serialized request.
+    /// - Parameter updated: The updated request.
+    mutating func updateRequest(updated: RequestType)
+}
+
+/// Context given to interceptor hooks called before response deserialization, after the response has been received.
+/// 
+/// These hooks have access to the serialized `RequestType` and `ResponseType`.
+public protocol BeforeDeserialization<RequestType, ResponseType, AttributesType>: InterceptorContext {
+    /// - Returns: The serialized request.
+    func getRequest() -> RequestType
+
+    /// - Returns: The serialized response.
+    func getResponse() -> ResponseType
+}
+
+/// Context given to interceptor hooks that can mutate the serialized response.
+///
+/// These hooks have access to the serialized `RequestType` and `ResponseType`.
+public protocol MutableResponse<RequestType, ResponseType, AttributesType>: InterceptorContext {
+    /// - Returns: The serialized request.
+    func getRequest() -> RequestType
+
+    /// - Returns: The serialized response.
+    func getResponse() -> ResponseType
+
+    /// Mutates the serialized response.
+    /// - Parameter updated: The updated response.
+    mutating func updateResponse(updated: ResponseType)
+}
+
+/// Context given to interceptor hooks called after response deserialization.
+/// 
+/// These hooks have access to the serialized `RequestType` and `ResponseType`, as well as the operation output.
+public protocol AfterDeserialization<RequestType, ResponseType, AttributesType>: InterceptorContext {
+    /// - Returns: The serialized request.
+    func getRequest() -> RequestType
+
+    /// - Returns: The serialized response.
+    func getResponse() -> ResponseType
+
+    /// - Returns: The operation output.
+    func getOutput() -> Any
+}
+
+/// Context given to interceptor hooks called after each attempt at sending the request.
+/// 
+/// These hooks have access to the serialized `RequestType` and `ResponseType` (if a response was received), as well as the operation output.
+public protocol AfterAttempt<RequestType, ResponseType, AttributesType>: InterceptorContext {
+    /// - Returns: The serialized request.
+    func getRequest() -> RequestType
+
+    /// - Returns: The serialized response, if one was received.
+    func getResponse() -> ResponseType?
+
+    /// - Returns: The operation output.
+    func getOutput() -> Any
+}
+
+/// Context given to interceptor hooks that can mutate the operation output, called after each attempt at sending the request.
+///
+/// These hooks have access to the serialized `RequestType` and `ResponseType` (if a response was received), as well as the operation output.
+public protocol MutableOutputAfterAttempt<RequestType, ResponseType, AttributesType>: InterceptorContext {
+    /// - Returns: The serialized request.
+    func getRequest() -> RequestType
+
+    /// - Returns: The serialized response, if one was received.
+    func getResponse() -> ResponseType?
+
+    /// - Returns: The operation output.
+    func getOutput() -> Any
+
+    /// Mutates the operation output.
+    /// - Parameter updated: The updated output.
+    mutating func updateOutput(updated: Any)
+}
+
+/// Context given to interceptor hooks called after execution.
+/// 
+/// These hooks have access to the serialized `RequestType` (if it was successfully serialized) and the `ResponseType` 
+/// (if a response was received), as well as the operation output.
+public protocol Finalization<RequestType, ResponseType, AttributesType>: InterceptorContext {
+    /// - Returns: The serialized request, if available.
+    func getRequest() -> RequestType?
+
+    /// - Returns: The serialized response, if one was received.
+    func getResponse() -> ResponseType?
+
+    /// - Returns: The operation output.
+    func getOutput() -> Any
+}
+
+/// Context given to interceptor hooks that can mutate the operation output, called after execution.
+/// 
+/// These hooks have access to the serialized `RequestType` (if it was successfully serialized) and the `ResponseType` 
+/// (if a response was received), as well as the operation output.
+public protocol MutableOutputFinalization<RequestType, ResponseType, AttributesType>: InterceptorContext {
+    /// - Returns: The serialized request, if available.
+    func getRequest() -> RequestType?
+
+    /// - Returns: The serialized response, if one was received.
+    func getResponse() -> ResponseType?
+
+    /// - Returns: The operation output.
+    func getOutput() -> Any
+
+    /// Mutates the operation output.
+    /// - Parameter updated: The updated output.
+    mutating func updateOutput(updated: Any)
+}

--- a/Sources/ClientRuntime/Interceptor/InterceptorContext.swift
+++ b/Sources/ClientRuntime/Interceptor/InterceptorContext.swift
@@ -6,7 +6,7 @@
 //
 
 /// The base type of all context objects passed to `Interceptor` methods.
-public protocol InterceptorContext {
+public protocol InterceptorContext: AnyObject {
 
     /// The type of the transport message that will be transmitted by the operation being invoked.
     associatedtype RequestType
@@ -40,7 +40,7 @@ public protocol MutableInput<AttributesType>: InterceptorContext {
 
     /// Mutates the operation input.
     /// - Parameter updated: The updated operation input.
-    mutating func updateInput(updated: Any)
+    func updateInput(updated: Any)
 }
 
 /// Context given to interceptor hooks called after request serialization.
@@ -62,7 +62,7 @@ public protocol MutableRequest<RequestType, AttributesType>: InterceptorContext 
 
     /// Mutates the serialized request.
     /// - Parameter updated: The updated request.
-    mutating func updateRequest(updated: RequestType)
+    func updateRequest(updated: RequestType)
 }
 
 /// Context given to interceptor hooks called before response deserialization, after the response has been received.
@@ -88,7 +88,7 @@ public protocol MutableResponse<RequestType, ResponseType, AttributesType>: Inte
 
     /// Mutates the serialized response.
     /// - Parameter updated: The updated response.
-    mutating func updateResponse(updated: ResponseType)
+    func updateResponse(updated: ResponseType)
 }
 
 /// Context given to interceptor hooks called after response deserialization.
@@ -134,7 +134,7 @@ public protocol MutableOutputAfterAttempt<RequestType, ResponseType, AttributesT
 
     /// Mutates the operation output.
     /// - Parameter updated: The updated output.
-    mutating func updateOutput(updated: Any)
+    func updateOutput(updated: Any)
 }
 
 /// Context given to interceptor hooks called after execution.
@@ -168,5 +168,5 @@ public protocol MutableOutputFinalization<RequestType, ResponseType, AttributesT
 
     /// Mutates the operation output.
     /// - Parameter updated: The updated output.
-    mutating func updateOutput(updated: Any)
+    func updateOutput(updated: Any)
 }

--- a/Sources/ClientRuntime/Middleware/Attribute.swift
+++ b/Sources/ClientRuntime/Middleware/Attribute.swift
@@ -41,3 +41,22 @@ public struct Attributes {
         attributes.removeValue(forKey: key.name)
     }
 }
+
+/// A type that can be used as a type-safe property bag.
+public protocol HasAttributes: AnyObject {
+    /// - Parameter key: The key of the attribute to get.
+    /// - Returns: The attribute, if it exists.
+    func get<T>(key: AttributeKey<T>) -> T?
+
+    /// - Parameter key: The key of the attribute to get.
+    /// - Returns: `true` if the property bag contains a value for the specified `key`, otherwise `false`.
+    func contains<T>(key: AttributeKey<T>) -> Bool
+
+    /// - Parameters:
+    ///   - key: The key to associate with `value`.
+    ///   - value: The value to set in the property bag.
+    func set<T>(key: AttributeKey<T>, value: T)
+
+    /// - Parameter key: The key of the attribute to remove from the property bag.
+    func remove<T>(key: AttributeKey<T>)
+}

--- a/Sources/ClientRuntime/Networking/Http/HttpContext.swift
+++ b/Sources/ClientRuntime/Networking/Http/HttpContext.swift
@@ -372,3 +372,21 @@ public enum AttributeKeys {
 public enum FlowType {
     case NORMAL, PRESIGN_REQUEST, PRESIGN_URL
 }
+
+extension HttpContext: HasAttributes {
+    public func get<T>(key: AttributeKey<T>) -> T? {
+        self.attributes.get(key: key)
+    }
+
+    public func contains<T>(key: AttributeKey<T>) -> Bool {
+        self.attributes.contains(key: key)
+    }
+
+    public func set<T>(key: AttributeKey<T>, value: T) {
+        self.attributes.set(key: key, value: value)
+    }
+
+    public func remove<T>(key: AttributeKey<T>) {
+        self.attributes.remove(key: key)
+    }
+}

--- a/Tests/ClientRuntimeTests/InterceptorTests/InterceptorTests.swift
+++ b/Tests/ClientRuntimeTests/InterceptorTests/InterceptorTests.swift
@@ -1,0 +1,86 @@
+import ClientRuntime
+import XCTest
+
+class InterceptorTests: XCTestCase {
+    struct TestInput {
+        public var property: String?
+    }
+
+    struct TestOutput {
+        public var property: String?
+    }
+
+    struct AddAttributeInterceptor<T, RequestType, ResponseType, AttributesType: HasAttributes> : Interceptor {
+        private let key: AttributeKey<T>
+        private let value: T
+
+        init(key: AttributeKey<T>, value: T) {
+            self.key = key
+            self.value = value
+        }
+
+        public func modifyBeforeSerialization(context: inout some MutableInput<Self.AttributesType>) async throws {
+            let attributes = context.getAttributes()
+            attributes.set(key: self.key, value: self.value)
+        }
+    }
+
+    struct ModifyInputInterceptor<InputType, RequestType, ResponseType, AttributesType: HasAttributes> : Interceptor {
+        private let keyPath: WritableKeyPath<InputType, String?>
+        private let value: String
+
+        init(keyPath: WritableKeyPath<InputType, String?>, value: String) {
+            self.keyPath = keyPath
+            self.value = value
+        }
+
+        public func modifyBeforeSerialization(context: inout some MutableInput<Self.AttributesType>) async throws {
+            var input: InputType = context.getInput()!
+            input[keyPath: keyPath] = value
+            context.updateInput(updated: input)
+        }
+    }
+
+    struct AddHeaderInterceptor : HttpInterceptor {
+        private let headerName: String
+        private let headerValue: String
+
+        init(headerName: String, headerValue: String) {
+            self.headerName = headerName
+            self.headerValue = headerValue
+        }
+
+        public func modifyBeforeTransmit(context: inout some MutableRequest<Self.RequestType, Self.AttributesType>) async throws {
+            let builder = context.getRequest().toBuilder()
+            builder.withHeader(name: headerName, value: headerValue)
+            context.updateRequest(updated: builder.build())
+        }
+    }
+
+    func test_mutation() async throws {
+        let httpContext = HttpContext(attributes: Attributes())
+        let input = TestInput(property: "foo")
+        var interceptorContext = DefaultInterceptorContext<SdkHttpRequest, HttpResponse, HttpContext>(input: input, attributes: httpContext)
+        let addAttributeInterceptor = AddAttributeInterceptor<String, SdkHttpRequest, HttpResponse, HttpContext>(key: AttributeKey(name: "foo"), value: "bar")
+        let modifyInputInterceptor = ModifyInputInterceptor<TestInput, SdkHttpRequest, HttpResponse, HttpContext>(keyPath: \.property, value: "bar")
+        let addHeaderInterceptor = AddHeaderInterceptor(headerName: "foo", headerValue: "bar")
+
+        let interceptors: [AnyInterceptor<SdkHttpRequest, HttpResponse, HttpContext>] = [
+            addAttributeInterceptor.erase(), 
+            modifyInputInterceptor.erase(), 
+            addHeaderInterceptor.erase()
+        ]
+        for i in interceptors {
+            try await i.modifyBeforeSerialization(context: &interceptorContext)
+        }
+        interceptorContext.updateRequest(updated: SdkHttpRequestBuilder().build())
+        for i in interceptors {
+            try await i.modifyBeforeTransmit(context: &interceptorContext)
+        }
+
+        let updatedInput: TestInput = interceptorContext.getInput()!
+        XCTAssertEqual(updatedInput.property, "bar")
+        XCTAssertEqual(interceptorContext.getAttributes().get(key: AttributeKey(name: "foo")), "bar")
+        XCTAssertEqual(interceptorContext.getRequest().headers.value(for: "foo"), "bar")
+    }
+}


### PR DESCRIPTION
Add interceptors interfaces to client libraries.

Interceptors defines hooks that can be used to inject functionality into different phases of the operation execution pipeline.

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Adds the `Interceptor` protocol, which has methods defining the hooks into the operation execution pipeline. Protocol implementations can specify concrete types for the transport request/response types (i.e. `SdkHttpRequest`/`HttpResponse`), as well as a type that provides `Attributes` through the new `HasAttributes` protocol. This allows 'less specific' interceptors that don't care about the transport request/response types, or the available attributes, to be used with more specific interceptors. See an example in [InterceptorTests](Tests/ClientRuntimeTests/InterceptorTests/InterceptorTests.swift)
- Adds `HttpInterceptor`, which inherits from `Interceptor` and specializes the request, response, and attributes types to be http specific. Interceptor implementations can use this protocol so they don't have to define `RequestType`, `ResponseType`, and `AttributesType` if they need all http specific stuff.
- Adds the `InterceptorContext` protocol and various child protocols that define which properties of the interceptor context can be accessed at different points in the execution pipeline. Each interceptor hook accepts one of these child protocols as input. The context protocols have the same associated types as `Interceptor`, so implementations can define the types they will have in the context.
- Adds the `HasAttributes` protocol, which is basically a protocol version of the `Attributes` struct, and implements it for `HttpContext`. This lets us wrap `HttpContext` into interceptor context objects, and use it in interceptor implementations, much like how it is used in existing middleware.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.