### PR TITLE
feat!: add client observability configuration codegen

### DIFF
--- a/Sources/ClientRuntime/Config/DefaultClientConfiguration.swift
+++ b/Sources/ClientRuntime/Config/DefaultClientConfiguration.swift
@@ -6,11 +6,6 @@
 //
 
 public protocol DefaultClientConfiguration: ClientConfiguration {
-    /// The logger to be used for client activity.
-    ///
-    /// If none is provided, the SDK's logger will be used.
-    var logger: LogAgent { get set }
-
     /// The configuration for retry of failed network requests.
     ///
     /// Default options are provided if none are set.
@@ -29,5 +24,10 @@ public protocol DefaultClientConfiguration: ClientConfiguration {
     /// A token generator to ensure idempotency of requests.
     var idempotencyTokenGenerator: IdempotencyTokenGenerator { get set }
 
-    /// TODO(plugins): Add Checksum, Traceprobes, etc.
+    /// Configuration for telemetry, including tracing, metrics, and logging.
+    ///
+    /// If none is provided, only a default logger provider will be used.
+    var telemetryProvider: TelemetryProvider { get set }
+
+    /// TODO(plugins): Add Checksum, etc.
 }

--- a/Sources/ClientRuntime/Config/DefaultSDKRuntimeConfiguration.swift
+++ b/Sources/ClientRuntime/Config/DefaultSDKRuntimeConfiguration.swift
@@ -40,10 +40,10 @@ public struct DefaultSDKRuntimeConfiguration<DefaultSDKRuntimeRetryStrategy: Ret
     /// If none is provided. one will be provided that supplies UUIDs.
     public var idempotencyTokenGenerator: IdempotencyTokenGenerator
 
-    /// The logger to be used for client activity.
+    /// Configuration for telemetry, including tracing, metrics, and logging.
     ///
-    /// If none is provided, the SDK's logger will be used.
-    public var logger: LogAgent
+    /// If none is provided, only a default logger provider will be used.
+    public var telemetryProvider: TelemetryProvider
 
     /// The retry strategy options to be used.
     ///
@@ -76,7 +76,7 @@ public struct DefaultSDKRuntimeConfiguration<DefaultSDKRuntimeRetryStrategy: Ret
         self.httpClientEngine = Self.makeClient(httpClientConfiguration: self.httpClientConfiguration)
         self.idempotencyTokenGenerator = Self.defaultIdempotencyTokenGenerator
         self.retryStrategyOptions = Self.defaultRetryStrategyOptions
-        self.logger = Self.defaultLogger(clientName: clientName)
+        self.telemetryProvider = DefaultTelemetry.provider
         self.clientLogMode = Self.defaultClientLogMode
     }
 }
@@ -114,11 +114,6 @@ public extension DefaultSDKRuntimeConfiguration {
     ///
     /// Defaults to options with the defaults defined in `RetryStrategyOptions`.
     static var defaultRetryStrategyOptions: RetryStrategyOptions { RetryStrategyOptions() }
-
-    /// The logger to use when none is provided
-    /// - Parameter clientName: The name of the client being logged
-    /// - Returns: A Swift logger with `clientName` as its label.
-    static func defaultLogger(clientName: String) -> SwiftLogger { SwiftLogger(label: clientName) }
 
     /// The log mode to use when none is provided
     ///

--- a/Sources/ClientRuntime/Plugins/TelemetryPlugin.swift
+++ b/Sources/ClientRuntime/Plugins/TelemetryPlugin.swift
@@ -1,0 +1,53 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public class TelemetryPlugin: Plugin {
+    private let telemetryProvider: TelemetryProvider
+
+    public init(telemetryProvider: TelemetryProvider) {
+        self.telemetryProvider = telemetryProvider
+    }
+
+    public init(
+        contextManager: TelemetryContextManager? = DefaultTelemetry.defaultContextManager,
+        loggerProvider: LoggerProvider? = DefaultTelemetry.defaultLoggerProvider,
+        meterProvider: MeterProvider? = DefaultTelemetry.defaultMeterProvider,
+        tracerProvider: TracerProvider? = DefaultTelemetry.defaultTracerProvider
+    ) {
+        self.telemetryProvider = BasicTelemetryProvider(
+            contextManager: contextManager!,
+            loggerProvider: loggerProvider!,
+            meterProvider: meterProvider!,
+            tracerProvider: tracerProvider!
+        )
+    }
+
+    public func configureClient(clientConfiguration: ClientConfiguration) {
+        if var config = clientConfiguration as? DefaultClientConfiguration {
+            config.telemetryProvider = self.telemetryProvider
+        }
+    }
+}
+
+private class BasicTelemetryProvider: TelemetryProvider {
+    let contextManager: TelemetryContextManager
+    let loggerProvider: LoggerProvider
+    let meterProvider: MeterProvider
+    let tracerProvider: TracerProvider
+
+    fileprivate init(
+        contextManager: TelemetryContextManager,
+        loggerProvider: LoggerProvider,
+        meterProvider: MeterProvider,
+        tracerProvider: TracerProvider
+    ) {
+        self.contextManager = contextManager
+        self.loggerProvider = loggerProvider
+        self.meterProvider = meterProvider
+        self.tracerProvider = tracerProvider
+    }
+}

--- a/Sources/ClientRuntime/Telemetry/DefaultTelemetry.swift
+++ b/Sources/ClientRuntime/Telemetry/DefaultTelemetry.swift
@@ -16,16 +16,16 @@ public enum DefaultTelemetry {
     public static let provider: TelemetryProvider = _DefaultTelemetryProvider()
 
     fileprivate class _DefaultTelemetryProvider: TelemetryProvider {
-        var contextManager: TelemetryContextManager { defaultTelemetryContextManager }
-        var loggerProvider: LoggerProvider { defaultLoggerProvider }
-        var meterProvider: MeterProvider { defaultMeterProvider }
-        var tracerProvider: TracerProvider { defaultTracerProvider }
+        let contextManager: TelemetryContextManager = defaultContextManager
+        let loggerProvider: LoggerProvider = defaultLoggerProvider
+        let meterProvider: MeterProvider = defaultMeterProvider
+        let tracerProvider: TracerProvider = defaultTracerProvider
     }
 }
 
 // Context
 extension DefaultTelemetry {
-    fileprivate static let defaultTelemetryContextManager: TelemetryContextManager = NoOpTelemetryContextManager()
+    public static let defaultContextManager: TelemetryContextManager = NoOpTelemetryContextManager()
     fileprivate static let defaultTelemetryContext: TelemetryContext = NoOpTelemetryContext()
     fileprivate static let defaultTelemetryScope: TelemetryScope = NoOpTelemetryScope()
 
@@ -44,7 +44,7 @@ extension DefaultTelemetry {
 
 // Logging
 extension DefaultTelemetry {
-    fileprivate static let defaultLoggerProvider: LoggerProvider = _DefaultLoggerProvider()
+    public static let defaultLoggerProvider: LoggerProvider = _DefaultLoggerProvider()
 
     fileprivate class _DefaultLoggerProvider: LoggerProvider {
         func getLogger(name: String) -> LogAgent { SwiftLogger(label: name) }
@@ -53,7 +53,7 @@ extension DefaultTelemetry {
 
 // Metrics
 extension DefaultTelemetry {
-    fileprivate static let defaultMeterProvider: MeterProvider = NoOpMeterProvider()
+    public static let defaultMeterProvider: MeterProvider = NoOpMeterProvider()
     fileprivate static let defaultMeter: Meter = NoOpMeter()
     fileprivate static let defaultAsyncMeasurementHandle: AsyncMeasurementHandle = NoOpAsyncMeasurementHandle()
     fileprivate static let defaultUpDownCounter: UpDownCounter = NoOpUpDownCounter()
@@ -136,7 +136,7 @@ extension DefaultTelemetry {
 
 // Trace
 extension DefaultTelemetry {
-    fileprivate static let defaultTracerProvider: TracerProvider = NoOpTracerProvider()
+    public static let defaultTracerProvider: TracerProvider = NoOpTracerProvider()
     fileprivate static let defaultTracer: Tracer = NoOpTracer()
     fileprivate static let defaultTraceSpan: TraceSpan = NoOpTraceSpan()
 
@@ -156,7 +156,7 @@ extension DefaultTelemetry {
     }
 
     fileprivate class NoOpTraceSpan: TraceSpan {
-        var name: String { "" }
+        let name: String = ""
         func emitEvent(name: String, attributes: Attributes?) {}
         func setAttribute<T>(key: AttributeKey<T>, value: T) {}
         func setStatus(status: TraceSpanStatus) {}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ClientRuntimeTypes.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ClientRuntimeTypes.kt
@@ -114,6 +114,7 @@ object ClientRuntimeTypes {
         val UnknownClientError = runtimeSymbol("ClientError.unknownError")
         val ServiceError = runtimeSymbol("ServiceError")
         val Logger = runtimeSymbol("LogAgent")
+        val TelemetryProvider = runtimeSymbol("TelemetryProvider")
         val SDKLogHandlerFactory = runtimeSymbol("SDKLogHandlerFactory")
         val SDKLogLevel = runtimeSymbol("SDKLogLevel")
         val ClientLogMode = runtimeSymbol("ClientLogMode")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/DefaultClientConfiguration.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/DefaultClientConfiguration.kt
@@ -18,7 +18,11 @@ class DefaultClientConfiguration : ClientConfiguration {
         get() = runtimeSymbol("DefaultClientConfiguration", SwiftDependency.CLIENT_RUNTIME)
 
     override fun getProperties(ctx: ProtocolGenerator.GenerationContext): Set<ConfigProperty> = setOf(
-        ConfigProperty("logger", ClientRuntimeTypes.Core.Logger, "AWSClientConfigDefaultsProvider.logger(clientName)"),
+        ConfigProperty(
+            "telemetryProvider",
+            ClientRuntimeTypes.Core.TelemetryProvider,
+            "ClientRuntime.DefaultTelemetry.provider"
+        ),
         ConfigProperty(
             "retryStrategyOptions",
             ClientRuntimeTypes.Core.RetryStrategyOptions,

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/ExtractTelemetryLoggerConfig.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/ExtractTelemetryLoggerConfig.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.swift.codegen.integration
+
+import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
+import software.amazon.smithy.swift.codegen.SwiftWriter
+import software.amazon.smithy.swift.codegen.core.GenerationContext
+import software.amazon.smithy.swift.codegen.integration.HttpProtocolServiceClient.ConfigClassVariablesCustomization
+import software.amazon.smithy.swift.codegen.integration.HttpProtocolServiceClient.ConfigInitializerCustomization
+import software.amazon.smithy.utils.CodeInterceptor
+import software.amazon.smithy.utils.CodeSection
+
+class ExtractTelemetryLoggerConfig : SwiftIntegration {
+    override fun interceptors(codegenContext: GenerationContext): List<out CodeInterceptor<out CodeSection?, SwiftWriter>?> {
+        return listOf(InternalLoggerConfigVariable(), LoggerConfigInitializer())
+    }
+
+    private class InternalLoggerConfigVariable : CodeInterceptor.Appender<ConfigClassVariablesCustomization, SwiftWriter> {
+        override fun sectionType(): Class<ConfigClassVariablesCustomization> {
+            return ConfigClassVariablesCustomization::class.java
+        }
+
+        override fun append(writer: SwiftWriter, section: ConfigClassVariablesCustomization) {
+            writer.write("internal let logger: \$N", ClientRuntimeTypes.Core.Logger)
+            writer.write("")
+        }
+    }
+
+    private class LoggerConfigInitializer : CodeInterceptor.Appender<ConfigInitializerCustomization, SwiftWriter> {
+        override fun sectionType(): Class<ConfigInitializerCustomization> {
+            return ConfigInitializerCustomization::class.java
+        }
+
+        override fun append(writer: SwiftWriter, section: ConfigInitializerCustomization) {
+            writer.write("self.logger = telemetryProvider.loggerProvider.getLogger(name: \$L.clientName)", section.serviceSymbol.name)
+        }
+    }
+}

--- a/smithy-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+++ b/smithy-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
@@ -2,3 +2,4 @@ software.amazon.smithy.swift.codegen.PaginatorGenerator
 software.amazon.smithy.swift.codegen.waiters.WaiterIntegration
 software.amazon.smithy.swift.codegen.ServiceNamespaceIntegration
 software.amazon.smithy.swift.codegen.DefaultClientConfigurationIntegration
+software.amazon.smithy.swift.codegen.integration.ExtractTelemetryLoggerConfig

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
@@ -46,7 +46,7 @@ class HttpProtocolClientGeneratorTests {
             
             extension RestJsonProtocolClient {
                 public class RestJsonProtocolConfiguration: DefaultClientConfiguration & DefaultHttpClientConfiguration {
-                    public var logger: ClientRuntime.LogAgent
+                    public var telemetryProvider: ClientRuntime.TelemetryProvider
             
                     public var retryStrategyOptions: ClientRuntime.RetryStrategyOptions
             
@@ -64,8 +64,8 @@ class HttpProtocolClientGeneratorTests {
             
                     public var authSchemeResolver: ClientRuntime.AuthSchemeResolver?
             
-                    private init(_ logger: ClientRuntime.LogAgent, _ retryStrategyOptions: ClientRuntime.RetryStrategyOptions, _ clientLogMode: ClientRuntime.ClientLogMode, _ endpoint: Swift.String?, _ idempotencyTokenGenerator: ClientRuntime.IdempotencyTokenGenerator, _ httpClientEngine: ClientRuntime.HTTPClient, _ httpClientConfiguration: ClientRuntime.HttpClientConfiguration, _ authSchemes: [ClientRuntime.AuthScheme]?, _ authSchemeResolver: ClientRuntime.AuthSchemeResolver?) {
-                        self.logger = logger
+                    private init(_ telemetryProvider: ClientRuntime.TelemetryProvider, _ retryStrategyOptions: ClientRuntime.RetryStrategyOptions, _ clientLogMode: ClientRuntime.ClientLogMode, _ endpoint: Swift.String?, _ idempotencyTokenGenerator: ClientRuntime.IdempotencyTokenGenerator, _ httpClientEngine: ClientRuntime.HTTPClient, _ httpClientConfiguration: ClientRuntime.HttpClientConfiguration, _ authSchemes: [ClientRuntime.AuthScheme]?, _ authSchemeResolver: ClientRuntime.AuthSchemeResolver?) {
+                        self.telemetryProvider = telemetryProvider
                         self.retryStrategyOptions = retryStrategyOptions
                         self.clientLogMode = clientLogMode
                         self.endpoint = endpoint
@@ -76,8 +76,8 @@ class HttpProtocolClientGeneratorTests {
                         self.authSchemeResolver = authSchemeResolver
                     }
             
-                    public convenience init(logger: ClientRuntime.LogAgent? = nil, retryStrategyOptions: ClientRuntime.RetryStrategyOptions? = nil, clientLogMode: ClientRuntime.ClientLogMode? = nil, endpoint: Swift.String? = nil, idempotencyTokenGenerator: ClientRuntime.IdempotencyTokenGenerator? = nil, httpClientEngine: ClientRuntime.HTTPClient? = nil, httpClientConfiguration: ClientRuntime.HttpClientConfiguration? = nil, authSchemes: [ClientRuntime.AuthScheme]? = nil, authSchemeResolver: ClientRuntime.AuthSchemeResolver? = nil) throws {
-                        self.init(logger ?? AWSClientConfigDefaultsProvider.logger(clientName), try retryStrategyOptions ?? AWSClientConfigDefaultsProvider.retryStrategyOptions(), clientLogMode ?? AWSClientConfigDefaultsProvider.clientLogMode, endpoint, idempotencyTokenGenerator ?? AWSClientConfigDefaultsProvider.idempotencyTokenGenerator, httpClientEngine ?? AWSClientConfigDefaultsProvider.httpClientEngine, httpClientConfiguration ?? AWSClientConfigDefaultsProvider.httpClientConfiguration, authSchemes, authSchemeResolver)
+                    public convenience init(telemetryProvider: ClientRuntime.TelemetryProvider? = nil, retryStrategyOptions: ClientRuntime.RetryStrategyOptions? = nil, clientLogMode: ClientRuntime.ClientLogMode? = nil, endpoint: Swift.String? = nil, idempotencyTokenGenerator: ClientRuntime.IdempotencyTokenGenerator? = nil, httpClientEngine: ClientRuntime.HTTPClient? = nil, httpClientConfiguration: ClientRuntime.HttpClientConfiguration? = nil, authSchemes: [ClientRuntime.AuthScheme]? = nil, authSchemeResolver: ClientRuntime.AuthSchemeResolver? = nil) throws {
+                        self.init(telemetryProvider ?? ClientRuntime.DefaultTelemetry.provider, try retryStrategyOptions ?? AWSClientConfigDefaultsProvider.retryStrategyOptions(), clientLogMode ?? AWSClientConfigDefaultsProvider.clientLogMode, endpoint, idempotencyTokenGenerator ?? AWSClientConfigDefaultsProvider.idempotencyTokenGenerator, httpClientEngine ?? AWSClientConfigDefaultsProvider.httpClientEngine, httpClientConfiguration ?? AWSClientConfigDefaultsProvider.httpClientConfiguration, authSchemes, authSchemeResolver)
                     }
             
                 }


### PR DESCRIPTION
## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

awslabs/aws-sdk-swift#696

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

**Note: dependent on DirectedCodegen implemented in #681 and awslabs/aws-sdk-swift#1405**

**Note: coupled with awslabs/aws-sdk-swift#1426**

Adds client observability configuration codegen. Notably, `config.logger` is replaced with
`config.telemetryProvider`, which provides a default `loggerProvider`.

Changes:

- Breaking change: replace config `logger` with `telemetryProvider`
- Breaking change: codegen client configuration `telemetryProvider`
- make top-level default telemetry impls public
- add telemetry runtime plugin

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
  - Breaking change included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.