### PR TITLE
fix: Add Smithy smoke test APIs to project

### DIFF
--- a/smithy-swift-codegen/build.gradle.kts
+++ b/smithy-swift-codegen/build.gradle.kts
@@ -28,6 +28,8 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
     api("software.amazon.smithy:smithy-waiters:$smithyVersion")
+    api("software.amazon.smithy:smithy-smoke-test-traits:${smithyVersion}")
+    api("software.amazon.smithy:smithy-aws-smoke-test-model:${smithyVersion}")
     api("com.atlassian.commonmark:commonmark:$commonMarkParserVersion")
     api("org.jsoup:jsoup:$jsoupVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")


### PR DESCRIPTION
## Description of changes
Add the Smithy smoke-test APIs to the project so that smoke test traits do not cause an unhandled error during codegen.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.