### PR TITLE
chore: Use Swift 5.10 & Xcode 15.3 as latest on CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,29 +23,29 @@ jobs:
           - macos-14-xlarge
         xcode:
           - Xcode_14.1
-          - Xcode_15.2
+          - Xcode_15.3
         destination:
           - 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
-          - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
+          - 'platform=iOS Simulator,OS=17.4,name=iPhone 15'
           - 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
-          - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - 'platform=tvOS Simulator,OS=17.4,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=OS X'
         exclude:
           # Don't run old macOS with new Xcode
           - runner: macos-13-xlarge
-            xcode: Xcode_15.2
+            xcode: Xcode_15.3
           # Don't run new macOS with old Xcode
           - runner: macos-14-xlarge
             xcode: Xcode_14.1
           # Don't run old iOS/tvOS simulator with new Xcode
           - destination: 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
-            xcode: Xcode_15.2
+            xcode: Xcode_15.3
           - destination: 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_15.2
+            xcode: Xcode_15.3
           # Don't run new iOS/tvOS simulator with old Xcode
-          - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
+          - destination: 'platform=iOS Simulator,OS=17.4,name=iPhone 15'
             xcode: Xcode_14.1
-          - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - destination: 'platform=tvOS Simulator,OS=17.4,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_14.1
     steps:
       - name: Checkout smithy-swift
@@ -125,8 +125,8 @@ jobs:
         swift:
           - 5.7-amazonlinux2
           - 5.7-focal
-          - 5.9-amazonlinux2
-          - 5.9-jammy
+          - 5.10-amazonlinux2
+          - 5.10-jammy
     container:
       image: swift:${{ matrix.swift }}
     steps:


### PR DESCRIPTION
## Description of changes
Use Swift 5.10 & Xcode 15.3 as latest on CI.  This matches the Swift, Xcode, and sim versions in use on aws-sdk-swift.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.