### PR TITLE
feat!: Remove Equatable protocol conformance unless necessary

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
@@ -112,8 +112,8 @@ class StructureGenerator(
     private fun generateStruct() {
         writer.writeShapeDocs(shape)
         writer.writeAvailableAttribute(model, shape)
-        val equatableConformance = (": " + SwiftTypes.Protocols.Equatable).takeIf { shape.hasTrait<EquatableConformanceTrait>() } ?: ""
-        writer.openBlock("public struct \$struct.name:L ${equatableConformance} {")
+        val equatableConformance = (": " + SwiftTypes.Protocols.Equatable + " ").takeIf { shape.hasTrait<EquatableConformanceTrait>() } ?: ""
+        writer.openBlock("public struct \$struct.name:L ${equatableConformance}{")
             .call { generateStructMembers() }
             .write("")
             .call { generateInitializerForStructure(false) }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.traits.ErrorTrait
 import software.amazon.smithy.model.traits.RetryableTrait
+import software.amazon.smithy.swift.codegen.customtraits.EquatableConformanceTrait
 import software.amazon.smithy.swift.codegen.customtraits.NestedTrait
 import software.amazon.smithy.swift.codegen.customtraits.SwiftBoxTrait
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
@@ -111,7 +112,8 @@ class StructureGenerator(
     private fun generateStruct() {
         writer.writeShapeDocs(shape)
         writer.writeAvailableAttribute(model, shape)
-        writer.openBlock("public struct \$struct.name:L: \$N {", SwiftTypes.Protocols.Equatable)
+        val equatableConformance = (": " + SwiftTypes.Protocols.Equatable).takeIf { shape.hasTrait<EquatableConformanceTrait>() } ?: ""
+        writer.openBlock("public struct \$struct.name:L ${equatableConformance} {")
             .call { generateStructMembers() }
             .write("")
             .call { generateInitializerForStructure(false) }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftCodegenPlugin.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftCodegenPlugin.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.model.transform.ModelTransformer
 import software.amazon.smithy.swift.codegen.core.GenerationContext
 import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
 import software.amazon.smithy.swift.codegen.model.AddOperationShapes
+import software.amazon.smithy.swift.codegen.model.EquatableConformanceTransformer
 import software.amazon.smithy.swift.codegen.model.NestedShapeTransformer
 import software.amazon.smithy.swift.codegen.model.RecursiveShapeBoxer
 import software.amazon.smithy.swift.codegen.model.UnionIndirectivizer
@@ -53,6 +54,7 @@ class SwiftCodegenPlugin : SmithyBuildPlugin {
             resolvedModel = RecursiveShapeBoxer.transform(resolvedModel)
             resolvedModel = NestedShapeTransformer.transform(resolvedModel, settings.getService(resolvedModel))
             resolvedModel = UnionIndirectivizer.transform(resolvedModel)
+            resolvedModel = EquatableConformanceTransformer.transform(resolvedModel, settings.getService(resolvedModel))
             return resolvedModel
         }
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/UnionGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/UnionGenerator.kt
@@ -75,8 +75,8 @@ class UnionGenerator(
         writer.writeShapeDocs(shape)
         writer.writeAvailableAttribute(model, shape)
         val indirectOrNot = "indirect ".takeIf { shape.hasTrait<RecursiveUnionTrait>() } ?: ""
-        val equatableConformance = (": " + SwiftTypes.Protocols.Equatable).takeIf { shape.hasTrait<EquatableConformanceTrait>() } ?: ""
-        writer.openBlock("public ${indirectOrNot}enum \$union.name:L ${equatableConformance} {", "}\n") {
+        val equatableConformance = (": " + SwiftTypes.Protocols.Equatable + " ").takeIf { shape.hasTrait<EquatableConformanceTrait>() } ?: ""
+        writer.openBlock("public ${indirectOrNot}enum \$union.name:L ${equatableConformance}{", "}\n") {
             // event streams (@streaming union) MAY have variants that target errors.
             // These errors if encountered on the stream will be thrown as an exception rather
             // than showing up as one of the possible events the consumer will see on the stream (AsyncThrowingStream<T>).

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/UnionGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/UnionGenerator.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.swift.codegen.customtraits.EquatableConformanceTrait
 import software.amazon.smithy.swift.codegen.customtraits.NestedTrait
 import software.amazon.smithy.swift.codegen.customtraits.RecursiveUnionTrait
 import software.amazon.smithy.swift.codegen.model.eventStreamEvents
@@ -74,7 +75,8 @@ class UnionGenerator(
         writer.writeShapeDocs(shape)
         writer.writeAvailableAttribute(model, shape)
         val indirectOrNot = "indirect ".takeIf { shape.hasTrait<RecursiveUnionTrait>() } ?: ""
-        writer.openBlock("public ${indirectOrNot}enum \$union.name:L: \$N {", "}\n", SwiftTypes.Protocols.Equatable) {
+        val equatableConformance = (": " + SwiftTypes.Protocols.Equatable).takeIf { shape.hasTrait<EquatableConformanceTrait>() } ?: ""
+        writer.openBlock("public ${indirectOrNot}enum \$union.name:L ${equatableConformance} {", "}\n") {
             // event streams (@streaming union) MAY have variants that target errors.
             // These errors if encountered on the stream will be thrown as an exception rather
             // than showing up as one of the possible events the consumer will see on the stream (AsyncThrowingStream<T>).

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/customtraits/EquatableConformanceTrait.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/customtraits/EquatableConformanceTrait.kt
@@ -1,0 +1,13 @@
+package software.amazon.smithy.swift.codegen.customtraits
+
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.Trait
+
+class EquatableConformanceTrait: Trait {
+    val ID = ShapeId.from("software.amazon.smithy.swift.codegen.swift.synthetic#equatableConformance")
+
+    override fun toNode(): Node = Node.objectNode()
+
+    override fun toShapeId(): ShapeId = ID
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/EquatableConformanceTransformer.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/EquatableConformanceTransformer.kt
@@ -1,0 +1,55 @@
+package software.amazon.smithy.swift.codegen.model
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.knowledge.PaginatedIndex
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.ShapeType
+import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.swift.codegen.customtraits.EquatableConformanceTrait
+
+/*
+ * This transformer is used to add @equatableConformance custom trait to
+ * Smithy structure shapes and Smithy union shapes only when necessary, which atm is for pagination tokens.
+ *
+ * E.g., if an operation uses pagination, then it has a corresponding @paginated trait with
+ * inputToken and outputToken fields that specify names of member shapes. Because the SDK uses equivalence checking
+ * on those tokens during pagination, all structure and union shapes nested under that member shape must have
+ * Equatable conformance in codegen output. Swift counterparts of Smithy simple types conform to Equatable by default.
+ *
+ * Minimizing protocol conformance has significant benefits for compile time and binary size of the SDK.
+ */
+object EquatableConformanceTransformer {
+    fun transform(model: Model, service: ServiceShape): Model {
+        val paginationTokenMembers = mutableSetOf<MemberShape>()
+        val paginatedIndex = PaginatedIndex.of(model)
+        // Collect all member shapes used as inputToken or outputToken for paginated operations.
+        for (op in service.allOperations) {
+            val paginationInfo = paginatedIndex.getPaginationInfo(service.id, op.toShapeId())
+            paginationInfo?.get()?.let {
+                paginationTokenMembers.add(it.inputTokenMember)
+                paginationTokenMembers.addAll(it.outputTokenMemberPath)
+            }
+        }
+        // Get all shapes nested within member shapes used as pagination tokens.
+        val shapesToAddEquatableConformanceTraitTo = mutableSetOf<Shape>()
+        for (tokenMemberShape in paginationTokenMembers) {
+            val nestedShapes = model.getNestedShapes(tokenMemberShape)
+            shapesToAddEquatableConformanceTraitTo.addAll(nestedShapes)
+        }
+        // Add @equatableConformance custom trait to all structure and union shapes
+        // ...nested under the token member shapes.
+        return ModelTransformer.create().mapShapes(model) { shape ->
+            if (shapesToAddEquatableConformanceTraitTo.contains(shape)) {
+                when (shape.type) {
+                    ShapeType.STRUCTURE -> shape.asStructureShape().get().toBuilder().addTrait(EquatableConformanceTrait()).build()
+                    ShapeType.UNION -> shape.asUnionShape().get().toBuilder().addTrait(EquatableConformanceTrait()).build()
+                    else -> shape
+                }
+            } else {
+                shape
+            }
+        }
+    }
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/EquatableConformanceTransformer.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/EquatableConformanceTransformer.kt
@@ -27,7 +27,7 @@ object EquatableConformanceTransformer {
         // Collect all member shapes used as inputToken or outputToken for paginated operations.
         for (op in service.allOperations) {
             val paginationInfo = paginatedIndex.getPaginationInfo(service.id, op.toShapeId())
-            paginationInfo?.get()?.let {
+            paginationInfo.ifPresent {
                 paginationTokenMembers.add(it.inputTokenMember)
                 paginationTokenMembers.addAll(it.outputTokenMemberPath)
             }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/ShapeExt.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/ShapeExt.kt
@@ -123,6 +123,12 @@ fun Model.getNestedShapes(serviceShape: ServiceShape): Set<Shape> {
         .select(this)
 }
 
+fun Model.getNestedShapes(memberShape: MemberShape): Set<Shape> {
+    return Selector
+        .parse("member [id=${memberShape.id}] ~> *")
+        .select(this)
+}
+
 /**
  * Test if an operation input is an event stream
  */

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/ShapeExt.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/model/ShapeExt.kt
@@ -125,7 +125,7 @@ fun Model.getNestedShapes(serviceShape: ServiceShape): Set<Shape> {
 
 fun Model.getNestedShapes(memberShape: MemberShape): Set<Shape> {
     return Selector
-        .parse("member [id=${memberShape.id}] ~> *")
+        .parse("member [id='${memberShape.id}'] ~> *")
         .select(this)
 }
 

--- a/smithy-swift-codegen/src/test/kotlin/PaginatorGeneratorTest.kt
+++ b/smithy-swift-codegen/src/test/kotlin/PaginatorGeneratorTest.kt
@@ -141,6 +141,39 @@ class PaginatorGeneratorTest {
         contents.shouldContainOnlyOnce(expected)
     }
 
+    @Test
+    fun testRenderEquatableConformanceForStructNestedInPaginationToken() {
+        val context = setupTests("pagination.smithy", "com.test#Lambda")
+        // Equatable conformance must have been generated for struct nested inside a pagination token.
+        val contents = getFileContents(context.manifest, "/Test/models/NestedInputTokenValue.swift")
+        val expected = """
+    public struct NestedInputTokenValue : Swift.Equatable {
+        """.trimIndent()
+        contents.shouldContainOnlyOnce(expected)
+    }
+
+    @Test
+    fun testRenderEquatableConformanceForStructDoublyNestedInPaginationToken() {
+        val context = setupTests("pagination.smithy", "com.test#Lambda")
+        // Equatable conformance must have been generated for struct nested under pagination token.
+        val contents = getFileContents(context.manifest, "/Test/models/DoublyNestedInputTokenValue.swift")
+        val expected = """
+    public struct DoublyNestedInputTokenValue : Swift.Equatable {
+        """.trimIndent()
+        contents.shouldContainOnlyOnce(expected)
+    }
+
+    @Test
+    fun testRenderEquatableConformanceForUnionNestedInPaginationToken() {
+        val context = setupTests("pagination.smithy", "com.test#Lambda")
+        // Equatable conformance must have been generated for union nested under pagination token.
+        val contents = getFileContents(context.manifest, "/Test/models/InputPaginationUnion.swift")
+        val expected = """
+    public enum InputPaginationUnion : Swift.Equatable {
+        """.trimIndent()
+        contents.shouldContainOnlyOnce(expected)
+    }
+
     private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {
         val context = TestContext.initContextFrom(smithyFile, serviceShapeId, MockHttpRestJsonProtocolGenerator()) { model ->
             model.defaultSettings(serviceShapeId, "Test", "2019-12-16", "Test")

--- a/smithy-swift-codegen/src/test/kotlin/RecursiveShapeBoxerTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/RecursiveShapeBoxerTests.kt
@@ -50,7 +50,7 @@ internal class RecursiveShapeBoxerTests {
         Assertions.assertNotNull(recursiveShapesInput)
         val expected =
             """
-            public struct RecursiveShapesInput: Swift.Equatable {
+            public struct RecursiveShapesInput {
                 public var nested: ExampleClientTypes.RecursiveShapesInputOutputNested1?
             
                 public init(
@@ -68,7 +68,7 @@ internal class RecursiveShapeBoxerTests {
         Assertions.assertNotNull(recursiveShapesOutput)
         val expected2 =
             """
-            public struct RecursiveShapesOutput: Swift.Equatable {
+            public struct RecursiveShapesOutput {
                 public var nested: ExampleClientTypes.RecursiveShapesInputOutputNested1?
             
                 public init(
@@ -87,7 +87,7 @@ internal class RecursiveShapeBoxerTests {
         val expected3 =
             """
             extension ExampleClientTypes {
-                public struct RecursiveShapesInputOutputNested1: Swift.Equatable {
+                public struct RecursiveShapesInputOutputNested1 {
                     public var foo: Swift.String?
                     @Indirect public var nested: ExampleClientTypes.RecursiveShapesInputOutputNested2?
             
@@ -111,7 +111,7 @@ internal class RecursiveShapeBoxerTests {
         val expected4 =
             """
         extension ExampleClientTypes {
-            public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
+            public struct RecursiveShapesInputOutputNested2 {
                 public var bar: Swift.String?
                 public var recursiveMember: ExampleClientTypes.RecursiveShapesInputOutputNested1?
         

--- a/smithy-swift-codegen/src/test/kotlin/ServiceRenamesTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ServiceRenamesTests.kt
@@ -21,7 +21,7 @@ class ServiceRenamesTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            public struct MyTestOperationInput: Swift.Equatable {
+            public struct MyTestOperationInput {
                 public var bar: ExampleClientTypes.RenamedGreeting?
             
                 public init(
@@ -49,7 +49,7 @@ class ServiceRenamesTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            public struct MyTestOperationOutput: Swift.Equatable {
+            public struct MyTestOperationOutput {
                 public var baz: ExampleClientTypes.GreetingStruct?
             
                 public init(
@@ -78,7 +78,7 @@ class ServiceRenamesTests {
         val expectedContents =
             """
             extension ExampleClientTypes {
-                public struct GreetingStruct: Swift.Equatable {
+                public struct GreetingStruct {
                     public var hi: Swift.String?
             
                     public init(
@@ -110,7 +110,7 @@ class ServiceRenamesTests {
         val expectedContents =
             """
             extension ExampleClientTypes {
-                public struct RenamedGreeting: Swift.Equatable {
+                public struct RenamedGreeting {
                     public var salutation: Swift.String?
             
                     public init(

--- a/smithy-swift-codegen/src/test/kotlin/StructEncodeGenerationIsolatedTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructEncodeGenerationIsolatedTests.kt
@@ -34,7 +34,7 @@ class StructEncodeGenerationIsolatedTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            public struct EnumInputInput: Swift.Equatable {
+            public struct EnumInputInput {
                 public var enumHeader: ExampleClientTypes.MyEnum?
                 public var nestedWithEnum: ExampleClientTypes.NestedEnum?
             """.trimIndent()

--- a/smithy-swift-codegen/src/test/kotlin/StructureGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/StructureGeneratorTests.kt
@@ -35,7 +35,7 @@ class StructureGeneratorTests {
         val expectedGeneratedStructure =
             """
             /// This is documentation about the shape.
-            public struct MyStruct: Swift.Equatable {
+            public struct MyStruct {
                 public var bar: Swift.Int
                 /// This is documentation about the member.
                 public var baz: Swift.Int?
@@ -68,7 +68,7 @@ class StructureGeneratorTests {
         Assertions.assertNotNull(primitiveTypesInput)
         val expected =
             """
-        public struct PrimitiveTypesInput: Swift.Equatable {
+        public struct PrimitiveTypesInput {
             public var booleanVal: Swift.Bool?
             public var byteVal: Swift.Int8?
             public var doubleVal: Swift.Double?
@@ -139,7 +139,7 @@ class StructureGeneratorTests {
         val contents = writer.toString()
         val expected =
             """
-public struct RecursiveShapesInputOutputNested1: Swift.Equatable {
+public struct RecursiveShapesInputOutputNested1 {
     public var foo: Swift.String?
     @Indirect public var nested: RecursiveShapesInputOutputNested2?
 
@@ -153,7 +153,7 @@ public struct RecursiveShapesInputOutputNested1: Swift.Equatable {
     }
 }
 
-public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
+public struct RecursiveShapesInputOutputNested2 {
     public var bar: Swift.String?
     public var recursiveMember: RecursiveShapesInputOutputNested1?
 
@@ -168,7 +168,7 @@ public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
 }
 
 /// This is documentation about the shape.
-public struct RecursiveShapesInputOutput: Swift.Equatable {
+public struct RecursiveShapesInputOutput {
     public var nested: RecursiveShapesInputOutputNested1?
 
     public init(
@@ -197,7 +197,7 @@ public struct RecursiveShapesInputOutput: Swift.Equatable {
         val contents = writer.toString()
         val expected =
             """
-public struct RecursiveShapesInputOutputNestedList1: Swift.Equatable {
+public struct RecursiveShapesInputOutputNestedList1 {
     public var foo: Swift.String?
     public var recursiveList: [RecursiveShapesInputOutputNested2]?
 
@@ -211,7 +211,7 @@ public struct RecursiveShapesInputOutputNestedList1: Swift.Equatable {
     }
 }
 
-public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
+public struct RecursiveShapesInputOutputNested2 {
     public var bar: Swift.String?
     public var recursiveMember: RecursiveShapesInputOutputNested1?
 
@@ -226,7 +226,7 @@ public struct RecursiveShapesInputOutputNested2: Swift.Equatable {
 }
 
 /// This is documentation about the shape.
-public struct RecursiveShapesInputOutputLists: Swift.Equatable {
+public struct RecursiveShapesInputOutputLists {
     public var nested: RecursiveShapesInputOutputNested1?
 
     public init(
@@ -315,7 +315,7 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
 
         val expectedContents =
             """
-            public struct JsonListsInput: Swift.Equatable {
+            public struct JsonListsInput {
                 public var booleanList: [Swift.Bool]?
                 public var integerList: [Swift.Int]?
                 public var nestedStringList: [[Swift.String]]?
@@ -363,7 +363,7 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         Assertions.assertNotNull(jsonMapsInput)
         val expectedJsonMapsInput =
             """
-            public struct JsonMapsInput: Swift.Equatable {
+            public struct JsonMapsInput {
                 public var denseBooleanMap: [Swift.String:Swift.Bool]?
                 public var denseNumberMap: [Swift.String:Swift.Int]?
                 public var denseStringMap: [Swift.String:Swift.String]?
@@ -402,7 +402,7 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         Assertions.assertNotNull(jsonMapsOutput)
         val expectedJsonMapsOutput =
             """
-            public struct JsonMapsOutput: Swift.Equatable {
+            public struct JsonMapsOutput {
                 public var denseBooleanMap: [Swift.String:Swift.Bool]?
                 public var denseNumberMap: [Swift.String:Swift.Int]?
                 public var denseStringMap: [Swift.String:Swift.String]?
@@ -451,7 +451,7 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         var structContainsDeprecatedTrait = """
         extension ExampleClientTypes {
             @available(*, deprecated, message: "This shape is no longer used. API deprecated since 1.3")
-            public struct StructWithDeprecatedTrait: Swift.Equatable {
+            public struct StructWithDeprecatedTrait {
         """.trimIndent()
         structWithDeprecatedTrait.shouldContain(structContainsDeprecatedTrait)
 
@@ -461,7 +461,7 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         structContainsDeprecatedTrait = """
         extension ExampleClientTypes {
             @available(*, deprecated, message: " API deprecated since 2019-03-21")
-            public struct StructSincePropertySet: Swift.Equatable {
+            public struct StructSincePropertySet {
         """.trimIndent()
         structWithDeprecatedTrait.shouldContain(structContainsDeprecatedTrait)
     }
@@ -478,7 +478,7 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         Assertions.assertNotNull(structWithDeprecatedTraitMember)
         val structContainsDeprecatedMember = """
         @available(*, deprecated, message: "This shape is no longer used. API deprecated since 1.3")
-        public struct OperationWithDeprecatedTraitInput: Swift.Equatable {
+        public struct OperationWithDeprecatedTraitInput {
             public var bool: Swift.Bool?
             public var foo: ExampleClientTypes.Foo?
             public var intVal: Swift.Int?
@@ -504,7 +504,7 @@ public struct RecursiveShapesInputOutputLists: Swift.Equatable {
         Assertions.assertNotNull(structWithDeprecatedTraitMember)
         val structContainsDeprecatedMember = """
         extension ExampleClientTypes {
-            public struct Foo: Swift.Equatable {
+            public struct Foo {
                 /// Test documentation with deprecated
                 @available(*, deprecated)
                 public var baz: Swift.String?

--- a/smithy-swift-codegen/src/test/kotlin/UnionGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/UnionGeneratorTests.kt
@@ -44,7 +44,7 @@ class UnionGeneratorTests {
         val expectedGeneratedEnum =
             """
             /// Really long multi-line Documentation for MyUnion
-            public enum MyUnion: Swift.Equatable {
+            public enum MyUnion {
                 case foo(Swift.String)
                 case baz(Swift.Int)
                 /// Documentation for bar
@@ -88,7 +88,7 @@ class UnionGeneratorTests {
         val expectedGeneratedEnum =
             """
             /// Really long multi-line Documentation for MyUnion
-            public enum MyUnion: Swift.Equatable {
+            public enum MyUnion {
                 case foo(Swift.String)
                 /// Documentation for bar
                 case bar(Swift.Int)
@@ -128,7 +128,7 @@ class UnionGeneratorTests {
         val expectedGeneratedEnum =
             """
             /// Really long multi-line Documentation for MyUnion
-            public indirect enum MyUnion: Swift.Equatable {
+            public indirect enum MyUnion {
                 /// Really long multi-line Documentation for MyUnion
                 case foo(MyUnion)
                 case baz(Swift.Int)

--- a/smithy-swift-codegen/src/test/kotlin/serde/awsjson11/NestedListEncodeJSONGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/awsjson11/NestedListEncodeJSONGenerationTests.kt
@@ -17,7 +17,7 @@ class NestedListEncodeJSONGenerationTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            public struct ListOfMapsOperationInput: Swift.Equatable {
+            public struct ListOfMapsOperationInput {
                 public var targetMaps: [[Swift.String:[Swift.String]]]?
             
                 public init(

--- a/smithy-swift-codegen/src/test/kotlin/serde/xml/UnionEncodeXMLGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/serde/xml/UnionEncodeXMLGenerationTests.kt
@@ -78,7 +78,7 @@ extension RestXmlProtocolClientTypes.XmlUnionShape {
         val expectedContents =
             """
             extension ExampleClientTypes {
-                public indirect enum XmlUnionShape: Swift.Equatable {
+                public indirect enum XmlUnionShape {
                     case doublevalue(Swift.Double)
                     case datavalue(ClientRuntime.Data)
                     case unionvalue(ExampleClientTypes.XmlUnionShape)

--- a/smithy-swift-codegen/src/test/resources/pagination.smithy
+++ b/smithy-swift-codegen/src/test/resources/pagination.smithy
@@ -4,7 +4,7 @@ use aws.protocols#restXml
 
 @restXml
 service Lambda {
-    operations: [ListFunctions, ListFunctions2]
+    operations: [ListFunctions, ListFunctions2, ListFunctions3]
 }
 
 @paginated(
@@ -70,4 +70,52 @@ structure ListFunctionsRequest2 {
 structure ListFunctionsResponse2 {
     functions: FunctionConfigurationList,
     nextMarker: String
+}
+
+// Suppress warning to mimic DynamoDB using map as pagination token.
+@suppress(["PaginatedTrait.WrongShapeType"])
+@paginated(
+    inputToken: "mapToken",
+    outputToken: "nextMapToken",
+    pageSize: "maxItems"
+)
+@readonly
+@http(method: "PUT", uri: "/function4", code: 200)
+operation ListFunctions3 {
+    input: ListFunctions3Input,
+    output: ListFunctions3Output
+}
+
+structure ListFunctions3Input {
+    @httpHeader("MaxItems")
+    maxItems: Integer
+    mapToken: PaginationMapInputToken
+}
+
+map PaginationMapInputToken {
+    key: String,
+    value: NestedInputTokenValue
+}
+
+structure NestedInputTokenValue {
+    doublyNestedValue: DoublyNestedInputTokenValue
+    doublyNextedUnion: InputPaginationUnion
+}
+
+structure DoublyNestedInputTokenValue {
+    a: String
+}
+
+union InputPaginationUnion {
+    a: Integer
+    b: String
+}
+
+structure ListFunctions3Output {
+    nextMapToken: PaginationMapOutputToken
+}
+
+map PaginationMapOutputToken {
+    key: String,
+    value: Integer
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/898

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Removing protocol conformance where possible brings great benefits to the SDK in many ways, including compile time reduction and binary size reduction.

This PR removes codegen for `Equatable` protocol conformance for Smithy structure shapes and Smithy union shapes, **except** when they are nested under member shapes used as pagination token. Also, `Equatable` protocol conformance is left intact for Smithy enum and intEnum shapes, as equivalence operators are to be frequently used on those enum types.
- Adds a new custom trait `@equatableConformance`, used for codegen
- Modifies Smithy structure & Smithy union codegen to generate `: Equatable` only if custom trait is found on the shape
- Update existing codegen tests and remove `: Equatable` from expected outputs where needed
- Enhance existing pagination codegen test to check for `Equatable` protocol conformance where needed

#### The background on pagination token & why it's relevant
DynamoDB uses Smithy map shape for their pagination token (every other service uses a simple String, as [recommended in Smithy docs](https://smithy.io/2.0/spec/behavior-traits.html#paginated-trait:~:text=input%20member%20MUST%20NOT%20be%20marked%20as%20required%20and-,SHOULD%20target%20a%20string%20shape.%20It%20can%2C%20but%20SHOULD%20NOT%20target%20a%20map%20shape.,-When%20contained%20within%20a%20service%2C%20a%20paginated%20operation%20MUST)). There can be any number of structure shapes or union shapes nested in the map shape DynamoDB uses for pagination token, and because [AWS Swift SDK uses equivalence operations on pagination token](https://github.com/smithy-lang/smithy-swift/blob/main/Sources/ClientRuntime/Pagination/PaginatorSequence.swift#L48) to detect infinite loop, `Equatable` protocol conformance must be generated for structure shapes and union shapes IF they're nested under a pagination token.

#### The approach
- Create a new custom trait called `@equatableConformance`.
- During model pre-processing, attach this trait to all structure shapes and union shapes nested under pagination token member shapes.
- During codegen, generate `: Equatable` for structure shapes and union shapes only if the custom trait is found on the shape.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.