### PR TITLE
chore: Add Equatable to structs/unions used in response protocol tests

### DIFF
--- a/Sources/ClientRuntime/Networking/Streaming/ByteStream.swift
+++ b/Sources/ClientRuntime/Networking/Streaming/ByteStream.swift
@@ -34,7 +34,7 @@ extension ByteStream: Equatable {
         case (.data(let lhsData), .data(let rhsData)):
             return lhsData == rhsData
         case (.stream(let lhsStream), .stream(let rhsStream)):
-            return lhsStream === rhsStream
+            return try! lhsStream.readToEnd() == rhsStream.readToEnd()
         case (.noStream, .noStream):
             return true
         default:

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
@@ -111,12 +111,11 @@ class StructureGenerator(
     private fun generateStruct() {
         writer.writeShapeDocs(shape)
         writer.writeAvailableAttribute(model, shape)
-        writer.openBlock("public struct \$struct.name:L: \$N {", SwiftTypes.Protocols.Equatable)
+        writer.openBlock("public struct \$struct.name:L {")
             .call { generateStructMembers() }
             .write("")
             .call { generateInitializerForStructure(false) }
             .closeBlock("}")
-            .write("")
     }
 
     private fun generateStructMembers() {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/UnionGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/UnionGenerator.kt
@@ -74,7 +74,7 @@ class UnionGenerator(
         writer.writeShapeDocs(shape)
         writer.writeAvailableAttribute(model, shape)
         val indirectOrNot = "indirect ".takeIf { shape.hasTrait<RecursiveUnionTrait>() } ?: ""
-        writer.openBlock("public ${indirectOrNot}enum \$union.name:L: \$N {", "}\n", SwiftTypes.Protocols.Equatable) {
+        writer.openBlock("public ${indirectOrNot}enum \$union.name:L {", "}") {
             // event streams (@streaming union) MAY have variants that target errors.
             // These errors if encountered on the stream will be thrown as an exception rather
             // than showing up as one of the possible events the consumer will see on the stream (AsyncThrowingStream<T>).

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpBindingProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpBindingProtocolGenerator.kt
@@ -300,7 +300,7 @@ abstract class HttpBindingProtocolGenerator : ProtocolGenerator {
             .build()
 
         ctx.delegator.useShapeWriter(decodeSymbol) { writer ->
-            writer.openBlock("struct ${decodeSymbol.name}: \$N {", "}", SwiftTypes.Protocols.Equatable) {
+            writer.openBlock("struct ${decodeSymbol.name} {", "}") {
                 httpBodyMembers.forEach {
                     val memberSymbol = ctx.symbolProvider.toSymbol(it)
                     writer.write("let \$L: \$T", ctx.symbolProvider.toMemberName(it), memberSymbol)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
@@ -5,24 +5,24 @@
 package software.amazon.smithy.swift.codegen.integration
 
 import software.amazon.smithy.codegen.core.Symbol
-import software.amazon.smithy.codegen.core.SymbolProvider
-import software.amazon.smithy.model.Model
-import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.BlobShape
+import software.amazon.smithy.model.shapes.DoubleShape
+import software.amazon.smithy.model.shapes.FloatShape
+import software.amazon.smithy.model.shapes.ListShape
+import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.traits.ErrorTrait
 import software.amazon.smithy.model.traits.HttpQueryTrait
 import software.amazon.smithy.model.traits.StreamingTrait
-import software.amazon.smithy.protocoltests.traits.HttpMessageTestCase
 import software.amazon.smithy.protocoltests.traits.HttpResponseTestCase
 import software.amazon.smithy.swift.codegen.ShapeValueGenerator
-import software.amazon.smithy.swift.codegen.SwiftWriter
+import software.amazon.smithy.swift.codegen.SwiftTypes
 import software.amazon.smithy.swift.codegen.hasStreamingMember
 import software.amazon.smithy.swift.codegen.integration.serde.readwrite.ResponseClosureUtils
 import software.amazon.smithy.swift.codegen.model.RecursiveShapeBoxer
 import software.amazon.smithy.swift.codegen.model.hasTrait
-import software.amazon.smithy.swift.codegen.model.isBoxed
-import software.amazon.smithy.swift.codegen.utils.toUpperCamelCase
 
 /**
  * Generates HTTP protocol unit tests for `httpResponseTest` cases
@@ -139,9 +139,89 @@ open class HttpProtocolUnitTestResponseGenerator protected constructor(builder: 
     }
 
     protected open fun renderAssertions(test: HttpResponseTestCase, outputShape: Shape) {
-        val members = outputShape.members().filterNot { it.hasTrait(HttpQueryTrait::class.java) }
-        val path = ".properties".takeIf { outputShape.hasTrait<ErrorTrait>() } ?: ""
-        renderMemberAssertions(writer, test, members, model, symbolProvider, "expected$path", "actual$path")
+        findShapesRequiringEquatable(outputShape)
+        writer.write("XCTAssertEqual(actual, expected)")
+    }
+
+    private fun findShapesRequiringEquatable(shape: Shape) {
+        if (hasBeenRenderedEquatable.contains(identifier(ctx, shape))) { return }
+        hasBeenRenderedEquatable.add(identifier(ctx, shape))
+        when (shape) {
+            is StructureShape -> {
+                renderEquatable(shape)
+                val memberShapes = shape.members().map { ctx.model.expectShape(it.target) }
+                memberShapes.forEach { findShapesRequiringEquatable(it) }
+            }
+            is UnionShape -> {
+                renderEquatable(shape)
+                val memberShapes = shape.members().map { ctx.model.expectShape(it.target) }
+                memberShapes.forEach { findShapesRequiringEquatable(it) }
+            }
+            is MapShape -> {
+                findShapesRequiringEquatable(ctx.model.expectShape(shape.value.target))
+            }
+            is ListShape -> {
+                findShapesRequiringEquatable(ctx.model.expectShape(shape.member.target))
+            }
+        }
+    }
+
+    private fun identifier(ctx: ProtocolGenerator.GenerationContext, shape: Shape): String {
+        return "${ctx.service.id}.${shape.id}"
+    }
+
+    private fun renderEquatable(shape: Shape) {
+        if (!(shape is StructureShape || shape is UnionShape)) { return }
+        val symbol = ctx.symbolProvider.toSymbol(shape)
+        val httpBindingSymbol = Symbol.builder()
+            .definitionFile("./${ctx.settings.moduleName}Tests/models/${symbol.name}+Equatable.swift")
+            .name(symbol.name)
+            .build()
+        ctx.delegator.useShapeWriter(httpBindingSymbol) { writer ->
+            writer.addImport(ctx.settings.moduleName)
+            writer.openBlock("extension \$L: \$N {", "}", symbol.fullName, SwiftTypes.Protocols.Equatable) {
+                writer.write("")
+                writer.openBlock("public static func ==(lhs: \$L, rhs: \$L) -> Bool {", "}", symbol.fullName, symbol.fullName) {
+                    when (shape) {
+                        is StructureShape -> {
+                            shape.members().filter { !it.hasTrait<HttpQueryTrait>() }.forEach { member ->
+                                val propertyName = ctx.symbolProvider.toMemberName(member)
+                                val path = "properties.".takeIf { shape.hasTrait<ErrorTrait>() } ?: ""
+                                val propertyAccessor = "${path}${propertyName}"
+                                val target = ctx.model.expectShape(member.target)
+                                when (target) {
+                                    is FloatShape, is DoubleShape -> {
+                                        writer.write(
+                                            "if (lhs.\$L?.isNaN ?? false && rhs.\$L?.isNaN ?? false) || (lhs.\$L != rhs.\$L) { return true }",
+                                            propertyAccessor,
+                                            propertyAccessor,
+                                            propertyAccessor,
+                                            propertyAccessor,
+                                        )
+                                    }
+                                    else -> {
+                                        writer.write("if lhs.\$L != rhs.\$L { return false }", propertyAccessor, propertyAccessor)
+                                    }
+                                }
+                            }
+                            writer.write("return true")
+                        }
+                        is UnionShape -> {
+                            writer.openBlock("switch (lhs, rhs) {", "}") {
+                                shape.members().forEach { member ->
+                                    val enumCaseName = ctx.symbolProvider.toMemberName(member)
+                                    writer.write("case (.\$L(let lhs), .\$L(let rhs)):", enumCaseName, enumCaseName)
+                                    writer.indent {
+                                        writer.write("return lhs == rhs")
+                                    }
+                                }
+                                writer.write("default: return false")
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     open class Builder : HttpProtocolUnitTestGenerator.Builder<HttpResponseTestCase>() {
@@ -151,32 +231,4 @@ open class HttpProtocolUnitTestResponseGenerator protected constructor(builder: 
     }
 }
 
-fun renderMemberAssertions(writer: SwiftWriter, test: HttpMessageTestCase, members: Collection<MemberShape>, model: Model, symbolProvider: SymbolProvider, expected: String, actual: String) {
-    for (member in members) {
-        val shape = model.expectShape(member.target.toShapeId())
-        val baseVarName = symbolProvider.toMemberName(member)
-        val expectedMemberName = "$expected.$baseVarName"
-        val actualMemberName = "$actual.$baseVarName"
-        val suffix = if (symbolProvider.toSymbol(member).isBoxed()) "?" else ""
-        if (member.isStructureShape) {
-            writer.write("XCTAssert(\$L === \$L)", expectedMemberName, actualMemberName)
-        } else if ((shape.isDoubleShape || shape.isFloatShape)) {
-            val stringNodes = test.params.stringMap.values.map { it.asStringNode().orElse(null) }
-            if (stringNodes.isNotEmpty() && stringNodes.mapNotNull { it?.value }.contains("NaN")) {
-                writer.write("XCTAssertEqual(\$L$suffix.isNaN, \$L$suffix.isNaN)", expectedMemberName, actualMemberName)
-            } else {
-                writer.write("XCTAssertEqual(\$L, \$L)", expectedMemberName, actualMemberName)
-            }
-        } else if (shape.isBlobShape && shape.hasTrait<StreamingTrait>()) {
-            val expectedVarName = "${expected}${baseVarName.toUpperCamelCase()}Data"
-            val actualVarName = "${actual}${baseVarName.toUpperCamelCase()}Data"
-            writer.write("")
-            writer.write("// Compare blobs by reading them both to data")
-            writer.write("let $expectedVarName = try await $expectedMemberName$suffix.readData()")
-            writer.write("let $actualVarName = try await $actualMemberName$suffix.readData()")
-            writer.write("XCTAssertEqual(\$L, \$L)", expectedVarName, actualVarName)
-        } else {
-            writer.write("XCTAssertEqual(\$L, \$L)", expectedMemberName, actualMemberName)
-        }
-    }
-}
+val hasBeenRenderedEquatable = mutableSetOf<String>()


### PR DESCRIPTION
Remove auto Equatable from structs & unions, add Equatable as needed in response tests

<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.