### PR TITLE
fix: URLSessionHTTPClient defensive fixes

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/URLSession/FoundationStreamBridge.swift
+++ b/Sources/ClientRuntime/Networking/Http/URLSession/FoundationStreamBridge.swift
@@ -108,8 +108,9 @@ class FoundationStreamBridge: NSObject, StreamDelegate {
         self.outputStream = outputStream
         self.logger = logger
 
-        // The stream is configured to deliver its callbacks on the dispatch queue.
+        // The output stream is configured to deliver its callbacks on the dispatch queue.
         // This precludes the need for a Thread with RunLoop.
+        // For safety, all interactions with the output stream will be performed on this queue.
         CFWriteStreamSetDispatchQueue(outputStream, queue)
     }
 

--- a/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionHTTPClient.swift
+++ b/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionHTTPClient.swift
@@ -53,8 +53,29 @@ public final class URLSessionHTTPClient: HTTPClient {
         /// The continuation for the asynchronous call that was made to initiate this request.
         ///
         /// Once the initial response is received, the continuation is called, and is subsequently set to `nil` so its
-        /// resources may be deallocated.
-        var continuation: CheckedContinuation<HttpResponse, Error>?
+        /// resources may be deallocated and to prevent it from being resumed twice.
+        private var continuation: CheckedContinuation<HttpResponse, Error>?
+
+        /// Returns `true` once the continuation is set to `nil`, which will happen once it has been resumed.
+        var hasBeenResumed: Bool { continuation == nil }
+
+        /// Resumes the continuation, returning the passed value.
+        ///
+        /// Calling this method and/or `resume(throwing:)` more than once has no effect.
+        /// - Parameter httpResponse: The HTTP response to be asynchronously returned to the caller.
+        func resume(returning httpResponse: HttpResponse) {
+            continuation?.resume(returning: httpResponse)
+            continuation = nil
+        }
+
+        /// Resumes the continuation, throwing the passed error.
+        ///
+        /// Calling this method and/or `resume(returning:)` more than once has no effect.
+        /// - Parameter error: The error to be asynchronously thrown to the caller.
+        func resume(throwing error: Error) {
+            continuation?.resume(throwing: error)
+            continuation = nil
+        }
 
         /// Any error received during a delegate callback for this request.
         ///
@@ -73,19 +94,23 @@ public final class URLSessionHTTPClient: HTTPClient {
             self.streamBridge = streamBridge
             self.continuation = continuation
         }
+
+        /// Ensure continuation is resumed and stream is closed before deallocation.
+        ///
+        /// This should never happen in practice but is being done defensively.
+        deinit {
+            if let continuation {
+                continuation.resume(throwing: URLSessionHTTPClientError.unresumedConnection)
+                responseStream.close()
+            } else {
+                // This has no effect if the response stream was already closed
+                responseStream.closeWithError(URLSessionHTTPClientError.unclosedResponseStream)
+            }
+        }
     }
 
     /// Provides thread-safe associative storage of `Connection`s keyed by their `URLSessionDataTask`.
     private final class Storage: @unchecked Sendable {
-
-        /// Ensure all continuations are resumed before deallocation.
-        ///
-        /// This should never happen in practice but is being done defensively.
-        deinit {
-            connections.values.forEach {
-                $0.continuation?.resume(throwing: URLSessionHTTPClientError.unresumedConnection)
-            }
-        }
 
         /// Lock used to enforce exclusive access to this `Storage` object.
         private let lock = NSRecursiveLock()
@@ -227,8 +252,7 @@ public final class URLSessionHTTPClient: HTTPClient {
                 guard let httpResponse = response as? HTTPURLResponse else {
                     logger.error("Received non-HTTP urlResponse")
                     let error = URLSessionHTTPClientError.responseNotHTTP
-                    connection.continuation?.resume(throwing: error)
-                    connection.continuation = nil
+                    connection.resume(throwing: error)
                     return
                 }
                 let statusCode = HttpStatusCode(rawValue: httpResponse.statusCode) ?? .insufficientStorage
@@ -239,8 +263,7 @@ public final class URLSessionHTTPClient: HTTPClient {
                 let headers = Headers(httpHeaders: httpHeaders)
                 let body = ByteStream.stream(connection.responseStream)
                 let response = HttpResponse(headers: headers, body: body, statusCode: statusCode)
-                connection.continuation?.resume(returning: response)
-                connection.continuation = nil
+                connection.resume(returning: response)
             }
             return .allow
         }
@@ -252,6 +275,8 @@ public final class URLSessionHTTPClient: HTTPClient {
                 do {
                     try connection.responseStream.write(contentsOf: data)
                 } catch {
+                    // If the response stream errored on write, save the error for later return &
+                    // cancel the HTTP request.
                     connection.error = error
                     dataTask.cancel()
                 }
@@ -263,26 +288,41 @@ public final class URLSessionHTTPClient: HTTPClient {
         /// If the error is returned prior to the initial response, the request fails with an error.
         /// If the error is returned after the initial response, the error is used to fail the response stream.
         func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-            logger.debug("urlSession(_:task:didCompleteWithError:) called. \(error == nil ? "Success" : "Failure")")
-            if let error { logger.debug("  Error: \(error.localizedDescription)") }
+            if let error {
+                logger.error("urlSession(_:task:didCompleteWithError:) failed. Error: \(error.localizedDescription)")
+            } else {
+                logger.debug("urlSession(_:task:didCompleteWithError:) called. Success")
+            }
+
+            // This connection is complete.  No further data will be sent, and none will be received.
+            // Below, we ensure that, successful or not, before disposing of the connection:
+            //  - The continuation has been resumed.
+            //  - The response stream is closed.
+            //  - The stream bridge is closed.
+            // This ensures that resources are freed and stream readers/writers are continued.
             storage.modify(task) { connection in
                 if let error = connection.error ?? error {
-                    if let continuation = connection.continuation {
-                        continuation.resume(throwing: error)
-                        connection.continuation = nil
-                    } else {
+                    if connection.hasBeenResumed {
                         connection.responseStream.closeWithError(error)
+                    } else {
+                        connection.resume(throwing: error)
+                        connection.responseStream.close()
                     }
                 } else {
+                    if !connection.hasBeenResumed {
+                        connection.resume(throwing: URLSessionHTTPClientError.closedBeforeResponse)
+                    }
                     connection.responseStream.close()
                 }
 
                 // Close the stream bridge so that its resources are deallocated
-                Task { await connection.streamBridge?.close() }
-            }
+                Task {
+                    await connection.streamBridge?.close()
 
-            // Task is complete & no longer needed.  Remove it from storage.
-            storage.remove(task)
+                    // Task is complete & no longer needed.  Remove it from storage.
+                    storage.remove(task)
+                }
+            }
         }
     }
 
@@ -310,8 +350,24 @@ public final class URLSessionHTTPClient: HTTPClient {
     ///
     /// The client is created with its own internal `URLSession`, which is configured with system defaults and with a private delegate for handling
     /// URL task lifecycle events.
-    /// - Parameter urlsessionConfiguration: The configuration to use for the client's `URLSession`.
-    public init(httpClientConfiguration: HttpClientConfiguration) {
+    /// - Parameters:
+    ///   - httpClientConfiguration: The configuration to use for the client's `URLSession`.
+    public convenience init(
+        httpClientConfiguration: HttpClientConfiguration
+    ) {
+        self.init(httpClientConfiguration: httpClientConfiguration, sessionType: URLSession.self)
+    }
+
+    /// Creates a new `URLSessionHTTPClient`.
+    ///
+    /// The client is created with its own internal `URLSession`.  A mocked subclass may be substituted.
+    /// - Parameters:
+    ///   - httpClientConfiguration: The configuration to use for the client's `URLSession`.
+    ///   - SessionType: The type for the URLSession to be created.  Used for testing.  Defaults to `URLSession`.
+    init(
+        httpClientConfiguration: HttpClientConfiguration,
+        sessionType SessionType: URLSession.Type
+    ) {
         self.config = httpClientConfiguration
         self.logger = SwiftLogger(label: "URLSessionHTTPClient")
         self.tlsConfiguration = config.tlsConfiguration as? URLSessionTLSOptions
@@ -319,7 +375,7 @@ public final class URLSessionHTTPClient: HTTPClient {
         self.connectionTimeout = httpClientConfiguration.connectTimeout ?? 60.0
         var urlsessionConfiguration = URLSessionConfiguration.default
         urlsessionConfiguration = URLSessionConfiguration.from(httpClientConfiguration: httpClientConfiguration)
-        self.session = URLSession(configuration: urlsessionConfiguration, delegate: delegate, delegateQueue: nil)
+        self.session = SessionType.init(configuration: urlsessionConfiguration, delegate: delegate, delegateQueue: nil)
     }
 
     /// On deallocation, finish any in-process tasks before disposing of the `URLSession`.
@@ -420,9 +476,18 @@ public enum URLSessionHTTPClientError: Error {
     /// Please file a bug with aws-sdk-swift if you experience this error.
     case responseNotHTTP
 
-    /// A connection was not ended
+    /// A HTTP connection was closed before a response could be returned,
+    /// and there was no Foundation error returned.
+    /// Please file a bug with aws-sdk-swift if you experience this error.
+    case closedBeforeResponse
+
+    /// A connection was not ended before disposing the connection.
     /// Please file a bug with aws-sdk-swift if you experience this error.
     case unresumedConnection
+
+    /// A response stream was not closed before disposing the connection.
+    /// Please file a bug with aws-sdk-swift if you experience this error.
+    case unclosedResponseStream
 }
 
 #endif


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1457

## Description of changes
- Code for managing HTTP connection continuations has been pulled into the Connection class to ensure continuations are managed properly
- Code paths through delegate methods have been audited to ensure that continuations are always resumed and streams are always closed on the completion of a connection
- Custom `deinit` has been added to connections that ensure their continuation/output stream are resumed/closed on dealloc
- One `fatalError()` was converted into a throwing error

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.