### PR TITLE
fix: Ensure all data is written before closing FoundationStreamBridge

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionHTTPClient.swift
+++ b/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionHTTPClient.swift
@@ -410,7 +410,7 @@ public final class URLSessionHTTPClient: HTTPClient {
             // that URLSession can stream its request body from.
             // Allow 16kb of in-memory buffer for request body streaming
             let streamBridge = requestStream.map {
-                FoundationStreamBridge(readableStream: $0, bufferSize: 16_384, logger: logger)
+                FoundationStreamBridge(readableStream: $0, bridgeBufferSize: 16_384, logger: logger)
             }
 
             // Create the request (with a streaming body when needed.)

--- a/Tests/ClientRuntimeTests/NetworkingTests/URLSession/FoundationStreamBridgeTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/URLSession/FoundationStreamBridgeTests.swift
@@ -8,7 +8,7 @@
 // `FoundationStreamBridge` is not usable on Linux because it uses ObjC-interop features,
 // so this test is disabled there.
 
-#if !os(Linux)
+#if os(iOS) || os(macOS) || os(watchOS) || os(tvOS) || os(visionOS)
 
 import Foundation
 import XCTest


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1457

## Description of changes
- It was discovered that in certain circumstances, the `FoundationStreamBridge` can close while there is still data in the buffer left to stream.  This potential bug was corrected by ensuring that both the buffer is empty AND the readable stream is closed before closing the output stream.  (Before, we closed the output stream when the readable stream closed, without checking if there was data left to be streamed in the buffer.)
- If there is unwritten data in the buffer and the Foundation `OutputStream` has room to receive, the remaining buffer data is written prior to reading the `ReadableStream` for more.  This might increase the number of writes needed, but will ensure that available data is transferred to the Foundation `OutputStream` promptly.
- Modifies the `FoundationStreamBridge` to take a separate buffer size for the buffer between the bound streams.  This aids in testing by helping to create mismatches between the size of the buffer and the size of writes to the output stream.
- Modified the `FoundationStreamBridgeTests` to set random values for both of the `FoundationStreamBridge`'s internal buffers when performing test runs; this helps to create as many variations in operating parameters as possible.
- Modified `WriteCoordinator`'s `perform()` function to rethrow errors thrown by the block.
- Refactored `FoundationStreamBridge` to be more straightforward & easier to follow.
- Adds many comments on the content of `FoundationStreamBridge` to aid developers in working with the code.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.