### PR TITLE
fix: Implement URLSessionTaskDelegate needNewBodyStream method

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionConfiguration+HTTPClientConfiguration.swift
+++ b/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionConfiguration+HTTPClientConfiguration.swift
@@ -14,6 +14,9 @@ extension URLSessionConfiguration {
     public static func from(httpClientConfiguration: HttpClientConfiguration) -> URLSessionConfiguration {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = httpClientConfiguration.socketTimeout
+        config.httpShouldSetCookies = false
+        config.httpCookieAcceptPolicy = .never
+        config.httpCookieStorage = nil
         return config
     }
 }


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1457

## Description of changes
- Implement the `urlSession(_:task:needNewBodyStream:)` delegate method.  This method must be implemented whenever `URLRequest` input body streaming is used.  When called, the `FoundationStreamBridge` replaces its bound stream pair and passes the new `InputStream` to the `URLSessionTask`.
- In practice, this method gets called when there are multiple concurrent HTTP requests to the same host, so without it we were seeing intermittent connection failures on Amplify customers, when they attempted to authenticate to the server at app startup (this involves multiple concurrent requests to AWS Cognito.)

Also:
- Configure the `URLSession` to never handle cookies, which are not set or used on AWS API endpoints.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.