### PR TITLE
feat: bump kotlin version to 1.9.24

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,0 +1,34 @@
+name: Codegen
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  codegen:
+    runs-on: ${{ matrix.os }}
+    name: Java ${{ matrix.java }} ${{ matrix.os }}
+    strategy:
+      matrix:
+        java: [17]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/wrapper-validation-action@v2
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'corretto'
+
+      - name: Log Kotlin version
+        run: |
+          which kotlin
+          kotlin -version
+
+      - name: Clean and Build
+        run: ./gradlew clean build -Plog-tests

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,8 @@
  */
 
 plugins {
-    kotlin("jvm") version "1.5.0" apply false
-    id("org.jetbrains.dokka") version "1.4.30"
+    kotlin("jvm")
+    id("org.jetbrains.dokka")
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ smithyVersion=1.47.0
 smithyGradleVersion=0.6.0
 
 # kotlin
-kotlinVersion=1.5.31
-dokkaVersion=1.5.31
+kotlinVersion=1.9.24
+dokkaVersion=1.9.20
 kotlin.native.ignoreDisabledTargets=true
 
 # kotlin libraries

--- a/smithy-swift-codegen-test-utils/build.gradle.kts
+++ b/smithy-swift-codegen-test-utils/build.gradle.kts
@@ -2,6 +2,9 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 description = "Generates Test Weather SDK Client code from Smithy models"
 extra["displayName"] = "Smithy :: Swift :: Codegen :: Test :: Utils"
 extra["moduleName"] = "software.amazon.smithy.swift.codegen.test.utils"
@@ -16,6 +19,17 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("stdlib"))
     implementation(project(":smithy-swift-codegen"))
+}
+
+tasks.withType<KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = JavaVersion.VERSION_17.toString()
+    targetCompatibility = JavaVersion.VERSION_17.toString()
 }

--- a/smithy-swift-codegen/build.gradle.kts
+++ b/smithy-swift-codegen/build.gradle.kts
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     kotlin("jvm")
     id("org.jetbrains.dokka")
@@ -25,7 +28,7 @@ val junitVersion: String by project
 val jacocoVersion: String by project
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("stdlib"))
     api("software.amazon.smithy:smithy-codegen-core:$smithyVersion")
     api("software.amazon.smithy:smithy-waiters:$smithyVersion")
     api("software.amazon.smithy:smithy-smoke-test-traits:${smithyVersion}")
@@ -37,6 +40,17 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
     testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
     implementation("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
+}
+
+tasks.withType<KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = JavaVersion.VERSION_17.toString()
+    targetCompatibility = JavaVersion.VERSION_17.toString()
 }
 
 jacoco {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
@@ -144,6 +144,7 @@ open class HttpProtocolUnitTestResponseGenerator protected constructor(builder: 
             when (shape.type) {
                 ShapeType.STRUCTURE -> renderEquatable(shape)
                 ShapeType.UNION -> renderEquatable(shape)
+                else -> {}
             }
         }
         writer.write("XCTAssertEqual(actual, expected)")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/readwrite/WritingClosureUtils.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/readwrite/WritingClosureUtils.kt
@@ -35,6 +35,7 @@ class WritingClosureUtils(
         when (ctx.service.requestWireProtocol) {
             WireProtocol.JSON -> return "JSONReadWrite.writingClosure()"
             WireProtocol.FORM_URL -> return "FormURLReadWrite.writingClosure()"
+            else -> {}
         }
         return when (shape) {
             is MapShape -> {


### PR DESCRIPTION
## Issue \#

There were a lot of noisy logs from Gradle / Kotlin, e.g.

```log
java.rmi.ServerError: Error occurred in server thread; nested exception is: 
Could not connect to kotlin daemon. Using fallback strategy.
	java.lang.AssertionError: symbolic reference class is not accessible: class sun.nio.ch.FileChannelImpl, from class org.jetbrains.kotlin.com.intellij.util.io.FileChannelUtil (unnamed module @46805db7)
...
```

This PR should fix all of the noise (at least locally).

See related links:

- https://youtrack.jetbrains.com/issue/KT-47152/Incremental-Compilation-with-Kotlin-compile-daemon-and-JDK-17-fails-with-IllegalAccessException
- https://kotlinlang.org/docs/whatsnew18.html#updated-jvm-compilation-target
- https://stackoverflow.com/questions/77607619/android-studio-kotlin-inconsistent-jvm-target-compatibility-detected-for-task

## Description of changes

Corresponding AWS SDK Swift PR: awslabs/aws-sdk-swift#1487

Bump kotlin version to 1.9.24

Also:

- bump dokka version to 1.9.20
- target JVM 17 output
- Add Codegen CI workflow

Kotlin and Dokka versions updated to the latest version, and JVM 17 targeted.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.