### PR TITLE
fix: Ignore httpQuery trait on response members but don't ignore member

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
@@ -172,7 +172,7 @@ open class HttpProtocolUnitTestResponseGenerator protected constructor(builder: 
                 writer.openBlock("public static func ==(lhs: \$L, rhs: \$L) -> Bool {", "}", symbol.fullName, symbol.fullName) {
                     when (shape) {
                         is StructureShape -> {
-                            shape.members().filter { !it.hasTrait<HttpQueryTrait>() }.forEach { member ->
+                            shape.members().forEach { member ->
                                 val propertyName = ctx.symbolProvider.toMemberName(member)
                                 val path = "properties.".takeIf { shape.hasTrait<ErrorTrait>() } ?: ""
                                 val propertyAccessor = "$path$propertyName"

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HTTPResponseTraitQueryParams.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HTTPResponseTraitQueryParams.kt
@@ -24,7 +24,7 @@ class HTTPResponseTraitQueryParams(
             .map { ctx.symbolProvider.toMemberName(it.member) }
             .toMutableSet()
         bodyMembersWithQueryTrait.sorted().forEach {
-            writer.write("value.$it = nil")
+//            writer.write("value.$it = nil")
         }
     }
 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HTTPResponseTraitWithoutHTTPPayload.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/bindingTraits/HTTPResponseTraitWithoutHTTPPayload.kt
@@ -31,7 +31,7 @@ class HTTPResponseTraitWithoutHTTPPayload(
     override fun render() {
         val bodyMembers = responseBindings.filter { it.location == HttpBinding.Location.DOCUMENT }
         val bodyMembersWithoutQueryTrait = bodyMembers
-            .filter { !it.member.hasTrait(HttpQueryTrait::class.java) }
+//            .filter { !it.member.hasTrait(HttpQueryTrait::class.java) }
             .toMutableSet()
         val streamingMember = bodyMembers.firstOrNull { it.member.targetOrSelf(ctx.model).hasTrait(StreamingTrait::class.java) }
         if (streamingMember != null) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
- Generate deserialization for a response member bearing the `@httpQuery` trait just like for any other member
- When comparing the result of a response protocol test, compare all members & don't ignore members with the `@httpQuery` trait
- Update logic for when to create a `reader` in the response binding method so that a `reader` is only created when it is actually used

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.