### PR TITLE
chore: Move struct encode/decode to HTTPBindingProtocolGenerator

### DIFF
--- a/smithy-swift-codegen-test-utils/src/main/kotlin/software/amazon/smithy/swift/codegen/test/utils/TestProtocolGenerator.kt
+++ b/smithy-swift-codegen-test-utils/src/main/kotlin/software/amazon/smithy/swift/codegen/test/utils/TestProtocolGenerator.kt
@@ -5,11 +5,8 @@
 
 package software.amazon.smithy.swift.codegen.test.utils
 
-import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.integration.DefaultHTTPProtocolCustomizations
 import software.amazon.smithy.swift.codegen.integration.DefaultServiceConfig
@@ -23,10 +20,7 @@ import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestRequ
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.ServiceConfig
-import software.amazon.smithy.swift.codegen.integration.serde.struct.StructDecodeGenerator
-import software.amazon.smithy.swift.codegen.integration.serde.struct.StructEncodeGenerator
 import software.amazon.smithy.swift.codegen.middleware.OperationMiddleware
-import software.amazon.smithy.swift.codegen.model.ShapeMetadata
 
 class TestCustomizations : DefaultHTTPProtocolCustomizations()
 /**
@@ -37,29 +31,6 @@ class TestProtocolGenerator : HTTPBindingProtocolGenerator(TestCustomizations())
     override val protocol: ShapeId = ShapeId.from("common#fakeProtocol")
     override val httpProtocolClientGeneratorFactory = HttpProtocolClientGeneratorFactory()
     override val shouldRenderEncodableConformance = false
-
-    override fun renderStructEncode(
-        ctx: ProtocolGenerator.GenerationContext,
-        shapeContainingMembers: Shape,
-        shapeMetadata: Map<ShapeMetadata, Any>,
-        members: List<MemberShape>,
-        writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format,
-        path: String?
-    ) {
-        StructEncodeGenerator(ctx, shapeContainingMembers, members, shapeMetadata, writer).render()
-    }
-    override fun renderStructDecode(
-        ctx: ProtocolGenerator.GenerationContext,
-        shapeContainingMembers: Shape,
-        shapeMetadata: Map<ShapeMetadata, Any>,
-        members: List<MemberShape>,
-        writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format,
-        path: String
-    ) {
-        StructDecodeGenerator(ctx, shapeContainingMembers, members, shapeMetadata, writer).render()
-    }
 
     override fun addProtocolSpecificMiddleware(ctx: ProtocolGenerator.GenerationContext, operation: OperationShape) {
         // Intentionally empty

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HTTPBindingProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HTTPBindingProtocolGenerator.kt
@@ -442,11 +442,11 @@ abstract class HTTPBindingProtocolGenerator(
     private fun renderStructDecode(
         ctx: ProtocolGenerator.GenerationContext,
         shapeContainingMembers: Shape,
-        shapeMetaData: Map<ShapeMetadata, Any>,
+        shapeMetadata: Map<ShapeMetadata, Any>,
         members: List<MemberShape>,
         writer: SwiftWriter,
     ) {
-        StructDecodeGenerator(ctx, shapeContainingMembers, members, shapeMetaData, writer).render()
+        StructDecodeGenerator(ctx, shapeContainingMembers, members, shapeMetadata, writer).render()
     }
 
     protected abstract fun addProtocolSpecificMiddleware(ctx: ProtocolGenerator.GenerationContext, operation: OperationShape)

--- a/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPAWSJson11ProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPAWSJson11ProtocolGenerator.kt
@@ -7,12 +7,9 @@ package mocks
 import TestHttpProtocolClientGeneratorFactory
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_1Trait
 import software.amazon.smithy.model.pattern.UriPattern
-import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.HttpTrait
-import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.integration.DefaultHTTPProtocolCustomizations
 import software.amazon.smithy.swift.codegen.integration.HTTPBindingProtocolGenerator
@@ -23,9 +20,6 @@ import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestRequ
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.protocols.core.StaticHttpBindingResolver
-import software.amazon.smithy.swift.codegen.integration.serde.struct.StructDecodeGenerator
-import software.amazon.smithy.swift.codegen.integration.serde.struct.StructEncodeGenerator
-import software.amazon.smithy.swift.codegen.model.ShapeMetadata
 
 class MockJsonHttpBindingResolver(
     private val context: ProtocolGenerator.GenerationContext,
@@ -72,30 +66,6 @@ class MockHTTPAWSJson11ProtocolGenerator() : HTTPBindingProtocolGenerator(MockAW
 
     override val httpProtocolClientGeneratorFactory = TestHttpProtocolClientGeneratorFactory()
     override val shouldRenderEncodableConformance = false
-
-    override fun renderStructEncode(
-        ctx: ProtocolGenerator.GenerationContext,
-        shapeContainingMembers: Shape,
-        shapeMetadata: Map<ShapeMetadata, Any>,
-        members: List<MemberShape>,
-        writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format,
-        path: String?
-    ) {
-        val encodeGenerator = StructEncodeGenerator(ctx, shapeContainingMembers, members, shapeMetadata, writer)
-        encodeGenerator.render()
-    }
-    override fun renderStructDecode(
-        ctx: ProtocolGenerator.GenerationContext,
-        shapeContainingMembers: Shape,
-        shapeMetadata: Map<ShapeMetadata, Any>,
-        members: List<MemberShape>,
-        writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format,
-        path: String
-    ) {
-        StructDecodeGenerator(ctx, shapeContainingMembers, members, shapeMetadata, writer).render()
-    }
 
     override fun addProtocolSpecificMiddleware(ctx: ProtocolGenerator.GenerationContext, operation: OperationShape) {
         // Intentionally empty

--- a/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPEC2QueryProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPEC2QueryProtocolGenerator.kt
@@ -8,13 +8,9 @@ package mocks
 import TestHttpProtocolClientGeneratorFactory
 import software.amazon.smithy.aws.traits.protocols.Ec2QueryTrait
 import software.amazon.smithy.model.pattern.UriPattern
-import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.HttpTrait
-import software.amazon.smithy.model.traits.TimestampFormatTrait
-import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.integration.DefaultHTTPProtocolCustomizations
 import software.amazon.smithy.swift.codegen.integration.HTTPBindingProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
@@ -24,9 +20,6 @@ import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestRequ
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.protocols.core.StaticHttpBindingResolver
-import software.amazon.smithy.swift.codegen.integration.serde.struct.StructDecodeGenerator
-import software.amazon.smithy.swift.codegen.integration.serde.struct.StructEncodeGenerator
-import software.amazon.smithy.swift.codegen.model.ShapeMetadata
 
 class MockEC2QueryHTTPProtocolCustomizations() : DefaultHTTPProtocolCustomizations()
 
@@ -50,29 +43,6 @@ class MockHTTPEC2QueryProtocolGenerator : HTTPBindingProtocolGenerator(MockEC2Qu
     override val protocol: ShapeId = Ec2QueryTrait.ID
     override val httpProtocolClientGeneratorFactory = TestHttpProtocolClientGeneratorFactory()
     override val shouldRenderEncodableConformance = true
-    override fun renderStructEncode(
-        ctx: ProtocolGenerator.GenerationContext,
-        shapeContainingMembers: Shape,
-        shapeMetadata: Map<ShapeMetadata, Any>,
-        members: List<MemberShape>,
-        writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format,
-        path: String?
-    ) {
-        StructEncodeGenerator(ctx, shapeContainingMembers, members, shapeMetadata, writer).render()
-    }
-    override fun renderStructDecode(
-        ctx: ProtocolGenerator.GenerationContext,
-        shapeContainingMembers: Shape,
-        shapeMetadata: Map<ShapeMetadata, Any>,
-        members: List<MemberShape>,
-        writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format,
-        path: String
-    ) {
-        val decodeGenerator = StructDecodeGenerator(ctx, shapeContainingMembers, members, mapOf(), writer)
-        decodeGenerator.render()
-    }
 
     override fun addProtocolSpecificMiddleware(ctx: ProtocolGenerator.GenerationContext, operation: OperationShape) {
         // Intentionally empty

--- a/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPRestJsonProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPRestJsonProtocolGenerator.kt
@@ -4,12 +4,8 @@
  */
 
 import software.amazon.smithy.aws.traits.protocols.RestJson1Trait
-import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.TimestampFormatTrait
-import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.integration.DefaultHTTPProtocolCustomizations
 import software.amazon.smithy.swift.codegen.integration.HTTPBindingProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolTestGenerator
@@ -17,9 +13,6 @@ import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestErro
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestRequestGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import software.amazon.smithy.swift.codegen.integration.serde.struct.StructDecodeGenerator
-import software.amazon.smithy.swift.codegen.integration.serde.struct.StructEncodeGenerator
-import software.amazon.smithy.swift.codegen.model.ShapeMetadata
 
 class MockRestJsonHTTPProtocolCustomizations() : DefaultHTTPProtocolCustomizations()
 class MockHTTPRestJsonProtocolGenerator : HTTPBindingProtocolGenerator(MockRestJsonHTTPProtocolCustomizations()) {
@@ -27,29 +20,6 @@ class MockHTTPRestJsonProtocolGenerator : HTTPBindingProtocolGenerator(MockRestJ
     override val protocol: ShapeId = RestJson1Trait.ID
     override val httpProtocolClientGeneratorFactory = TestHttpProtocolClientGeneratorFactory()
     override val shouldRenderEncodableConformance = false
-
-    override fun renderStructEncode(
-        ctx: ProtocolGenerator.GenerationContext,
-        shapeContainingMembers: Shape,
-        shapeMetadata: Map<ShapeMetadata, Any>,
-        members: List<MemberShape>,
-        writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format,
-        path: String?
-    ) {
-        StructEncodeGenerator(ctx, shapeContainingMembers, members, shapeMetadata, writer).render()
-    }
-    override fun renderStructDecode(
-        ctx: ProtocolGenerator.GenerationContext,
-        shapeContainingMembers: Shape,
-        shapeMetadata: Map<ShapeMetadata, Any>,
-        members: List<MemberShape>,
-        writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format,
-        path: String
-    ) {
-        StructDecodeGenerator(ctx, shapeContainingMembers, members, shapeMetadata, writer).render()
-    }
 
     override fun addProtocolSpecificMiddleware(ctx: ProtocolGenerator.GenerationContext, operation: OperationShape) {
         // Intentionally empty

--- a/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPRestXMLProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPRestXMLProtocolGenerator.kt
@@ -4,12 +4,8 @@
  */
 
 import software.amazon.smithy.aws.traits.protocols.RestXmlTrait
-import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.TimestampFormatTrait
-import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.integration.DefaultHTTPProtocolCustomizations
 import software.amazon.smithy.swift.codegen.integration.HTTPBindingProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolTestGenerator
@@ -17,9 +13,6 @@ import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestErro
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestRequestGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import software.amazon.smithy.swift.codegen.integration.serde.struct.StructDecodeGenerator
-import software.amazon.smithy.swift.codegen.integration.serde.struct.StructEncodeGenerator
-import software.amazon.smithy.swift.codegen.model.ShapeMetadata
 
 class MockRestXMLHTTPProtocolCustomizations() : DefaultHTTPProtocolCustomizations()
 
@@ -28,31 +21,6 @@ class MockHTTPRestXMLProtocolGenerator : HTTPBindingProtocolGenerator(MockRestXM
     override val protocol: ShapeId = RestXmlTrait.ID
     override val httpProtocolClientGeneratorFactory = TestHttpProtocolClientGeneratorFactory()
     override val shouldRenderEncodableConformance = false
-
-    override fun renderStructEncode(
-        ctx: ProtocolGenerator.GenerationContext,
-        shapeContainingMembers: Shape,
-        shapeMetadata: Map<ShapeMetadata, Any>,
-        members: List<MemberShape>,
-        writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format,
-        path: String?
-    ) {
-        val encoder = StructEncodeGenerator(ctx, shapeContainingMembers, members, shapeMetadata, writer)
-        encoder.render()
-    }
-    override fun renderStructDecode(
-        ctx: ProtocolGenerator.GenerationContext,
-        shapeContainingMembers: Shape,
-        shapeMetadata: Map<ShapeMetadata, Any>,
-        members: List<MemberShape>,
-        writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format,
-        path: String
-    ) {
-        val decodeGenerator = StructDecodeGenerator(ctx, shapeContainingMembers, members, shapeMetadata, writer)
-        decodeGenerator.render()
-    }
 
     override fun addProtocolSpecificMiddleware(ctx: ProtocolGenerator.GenerationContext, operation: OperationShape) {
         // Intentionally empty


### PR DESCRIPTION
## Description of changes
`renderStructEncode()` and `renderStructDecode()` methods are moved into `HTTPBindingProtocolGenerator` and made private since all protocols now use the same implementation of these methods.

All of the overrides of these two methods are removed.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.