### PR TITLE
fix: Add dependencies on symbol imports

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -37,3 +37,14 @@ jobs:
         run: |
           git diff
           test -z "$(git diff)"
+
+      - name: Log Swift version
+        if: ${{matrix.os}} == "macos-latest"
+        run: |
+          which swift
+          swift --version
+
+      - name: Build test projections (e.g. the Weather SDK)
+        if: ${{matrix.os}} == "macos-latest"
+        run: |
+          ./scripts/ci_steps/build_test_projections.sh

--- a/scripts/ci_steps/build_test_projections.sh
+++ b/scripts/ci_steps/build_test_projections.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+# This script tests the built test projections, e.g. `weather` for the WeatherSDK.
+
+PROJECTIONS_DIR="./smithy-swift-codegen-test/build/smithyprojections/smithy-swift-codegen-test/"
+if [ ! -d "$PROJECTIONS_DIR" ]; then
+  exit 1
+fi
+
+cd $PROJECTIONS_DIR
+PROJECTIONS=$(find . -maxdepth 1 -type d -exec echo {} \;)
+for projection in $PROJECTIONS; do
+  if [ "$projection" = "." ]; then
+    continue
+  elif [ "$projection" = "./source" ]; then
+    continue
+  fi
+  echo "Building projection: $projection"
+  cd $projection/swift-codegen
+  swift build
+  cd ../../
+done

--- a/smithy-swift-codegen-test/smithy-build.json
+++ b/smithy-swift-codegen-test/smithy-build.json
@@ -13,6 +13,20 @@
                     "swiftVersion": "5.7.0"
                 }
             }
+        },
+        "weather-interceptors": {
+            "plugins": {
+                "swift-codegen": {
+                    "service": "example.weather#Weather",
+                    "module": "WeatherInterceptorsSDK",
+                    "moduleVersion": "1.0",
+                    "gitRepo": "https://github.com/smithy-lang/smithy-swift.git",
+                    "author": "Amazon Web Services",
+                    "homepage": "https://docs.amplify.aws/",
+                    "swiftVersion": "5.7.0",
+                    "useInterceptors": true
+                }
+            }
         }
     }
 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
@@ -13,6 +13,8 @@ fun writePackageManifest(settings: SwiftSettings, fileManifest: FileManifest, de
 
     // filter duplicates in dependencies
     val distinctDependencies = dependencies.distinctBy { it.packageName }
+    val targetDependencies = dependencies
+        .distinctBy { it.packageName + "." + it.expectProperty("target", String::class.java) }
     val writer = CodeWriter().apply {
         trimBlankLines()
         trimTrailingSpaces()
@@ -40,7 +42,7 @@ fun writePackageManifest(settings: SwiftSettings, fileManifest: FileManifest, de
             writer.openBlock(".target(", "),") {
                 writer.write("name: \"${settings.moduleName}\",")
                 writer.openBlock("dependencies: [", "],") {
-                    for (dependency in distinctDependencies) {
+                    for (dependency in targetDependencies) {
                         writer.openBlock(".product(", "),") {
                             val target = dependency.expectProperty("target", String::class.java)
                             writer.write("name: \"${target}\",")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftWriter.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftWriter.kt
@@ -98,6 +98,9 @@ class SwiftWriter(private val fullPackageName: String, swiftImportContainer: Swi
     fun addImport(symbol: Symbol) {
         if (symbol.isBuiltIn || symbol.isServiceNestedNamespace || symbol.namespace.isEmpty()) return
         addImport(symbol.namespace)
+        symbol.dependencies?.forEach {
+            addDependency(it)
+        }
     }
 
     fun addImport(

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HTTPResponseBindingErrorGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HTTPResponseBindingErrorGenerator.kt
@@ -34,7 +34,7 @@ class HTTPResponseBindingErrorGenerator(
         ctx.delegator.useFileWriter(fileName) { writer ->
             with(writer) {
                 addImport(SwiftDependency.CLIENT_RUNTIME.target)
-                addImport(customizations.baseErrorSymbol.namespace)
+                addImport(customizations.baseErrorSymbol)
                 openBlock(
                     "func httpServiceError(baseError: \$N) throws -> \$N? {",
                     "}",
@@ -78,7 +78,7 @@ class HTTPResponseBindingErrorGenerator(
 
         ctx.delegator.useShapeWriter(httpBindingSymbol) { writer ->
             writer.addImport(SwiftDependency.CLIENT_RUNTIME.target)
-            writer.addImport(customizations.baseErrorSymbol.namespace)
+            writer.addImport(customizations.baseErrorSymbol)
             writer.addImports(ctx.service.responseWireProtocol)
             writer.openBlock("enum \$L {", "}", operationErrorName) {
                 writer.write("")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HTTPResponseBindingErrorInitGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/httpResponse/HTTPResponseBindingErrorInitGenerator.kt
@@ -45,7 +45,7 @@ class HTTPResponseBindingErrorInitGenerator(
 
         ctx.delegator.useShapeWriter(httpBindingSymbol) { writer ->
             writer.addImport(SwiftDependency.CLIENT_RUNTIME.target)
-            writer.addImport(customizations.baseErrorSymbol.namespace)
+            writer.addImport(customizations.baseErrorSymbol)
             writer.addImports(ctx.service.responseWireProtocol)
             writer.openBlock("extension \$N {", "}", errorShape) {
                 writer.write("")


### PR DESCRIPTION
## Issue \#

When trying to build the client under the smithy projections, it would fail due to a misconfigured package manifest.

## Description of changes

Add dependencies on symbol imports, and also:

- Add CI step to build test projections
- Add test projection with `useInterceptors`

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.