### PR TITLE
feat: Use URLRequest.httpBody when body data is already in-memory

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionHTTPClient.swift
+++ b/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionHTTPClient.swift
@@ -416,27 +416,28 @@ public final class URLSessionHTTPClient: HTTPClient {
     public func send(request: SdkHttpRequest) async throws -> HttpResponse {
         return try await withCheckedThrowingContinuation { continuation in
 
-            // Get the request stream to use for the body, if any.
-            let requestStream: ReadableStream?
+            // Get the in-memory data or request stream to use for the body, if any.
+            // Keep a reference to the stream bridge for a streaming request.
+            let body: Body
+            var streamBridge: FoundationStreamBridge?
+
             switch request.body {
             case .data(let data):
-                requestStream = BufferedStream(data: data, isClosed: true)
+                body = .data(data)
             case .stream(let stream):
-                requestStream = stream
+                // Create a stream bridge that streams data from a SDK stream to a Foundation InputStream
+                // that URLSession can stream its request body from.
+                // Allow 16kb of in-memory buffer for request body streaming
+                let bridge = FoundationStreamBridge(readableStream: stream, bridgeBufferSize: 16_384, logger: logger)
+                streamBridge = bridge
+                body = .stream(bridge)
             case .noStream:
-                requestStream = nil
+                body = .data(nil)
             }
 
-            // If needed, create a stream bridge that streams data from a SDK stream to a Foundation InputStream
-            // that URLSession can stream its request body from.
-            // Allow 16kb of in-memory buffer for request body streaming
-            let streamBridge = requestStream.map {
-                FoundationStreamBridge(readableStream: $0, bridgeBufferSize: 16_384, logger: logger)
-            }
-
-            // Create the request (with a streaming body when needed.)
             do {
-                let urlRequest = try self.makeURLRequest(from: request, httpBodyStream: streamBridge?.inputStream)
+                // Create a data task for the request, and store it as a Connection along with its continuation.
+                let urlRequest = try self.makeURLRequest(from: request, body: body)
                 // Create the data task and associated connection object, then place them in storage.
                 let dataTask = session.dataTask(with: urlRequest)
                 let connection = Connection(streamBridge: streamBridge, continuation: continuation)
@@ -445,22 +446,29 @@ public final class URLSessionHTTPClient: HTTPClient {
                 // Start the HTTP connection and start streaming the request body data
                 dataTask.resume()
                 logger.info("start URLRequest(\(urlRequest.url?.absoluteString ?? "")) called")
-                Task { await streamBridge?.open() }
+                Task { [streamBridge] in
+                    await streamBridge?.open()
+                }
             } catch {
                 continuation.resume(throwing: error)
             }
-
         }
     }
 
-    // MARK: - Private methods
+    // MARK: - Private methods & types
+
+    /// A private type used to encapsulate the body to be used for a URLRequest.
+    private enum Body {
+        case stream(FoundationStreamBridge)
+        case data(Data?)
+    }
 
     /// Create a `URLRequest` for the Smithy operation to be performed.
     /// - Parameters:
     ///   - request: The SDK-native, signed `SdkHttpRequest` ready to be transmitted.
     ///   - httpBodyStream: A Foundation `InputStream` carrying the HTTP body for this request.
     /// - Returns: A `URLRequest` ready to be transmitted by `URLSession` for this operation.
-    private func makeURLRequest(from request: SdkHttpRequest, httpBodyStream: InputStream?) throws -> URLRequest {
+    private func makeURLRequest(from request: SdkHttpRequest, body: Body) throws -> URLRequest {
         var components = URLComponents()
         components.scheme = config.protocolType?.rawValue ?? request.endpoint.protocolType?.rawValue ?? "https"
         components.host = request.endpoint.host
@@ -474,7 +482,12 @@ public final class URLSessionHTTPClient: HTTPClient {
         guard let url = components.url else { throw URLSessionHTTPClientError.incompleteHTTPRequest }
         var urlRequest = URLRequest(url: url, timeoutInterval: self.connectionTimeout)
         urlRequest.httpMethod = request.method.rawValue
-        urlRequest.httpBodyStream = httpBodyStream
+        switch body {
+        case .stream(let bridge):
+            urlRequest.httpBodyStream = bridge.inputStream
+        case .data(let data):
+            urlRequest.httpBody = data
+        }
         for header in request.headers.headers + config.defaultHeaders.headers {
             for value in header.value {
                 urlRequest.addValue(value, forHTTPHeaderField: header.name)


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1504

## Description of changes
When HTTP request body is in-memory `Data`, set the `httpBody` property on the URL request instead of streaming the body with Foundation streams.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.