### PR TITLE
feat: Add OS version info to user agent for Linux

### DIFF
--- a/Sources/ClientRuntime/Util/PlatformOperationSystemVersion.swift
+++ b/Sources/ClientRuntime/Util/PlatformOperationSystemVersion.swift
@@ -14,6 +14,21 @@ public struct PlatformOperationSystemVersion {
         return "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
     }
 }
+#elseif os(Linux)
+import Glibc
+public struct PlatformOperationSystemVersion {
+    static public func operatingSystemVersion() -> String? {
+        var sysInfo = utsname()
+        uname(&sysInfo)
+        var local = sysInfo
+        let releaseVersion = withUnsafePointer(to: &local.release) {
+            $0.withMemoryRebound(to: CChar.self, capacity: MemoryLayout.size(ofValue: sysInfo.release)) {
+                String(cString: $0)
+            }
+        }
+        return releaseVersion
+    }
+}
 #else
 // TODO: Implement for Linux & Windows
 public struct PlatformOperationSystemVersion {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/1206

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Use the `uname` POSIX function available in all Linux distros to get the release version of the OS & include that in User-Agent header of requests.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.