### PR TITLE
feat!: Remove unknown case from allCases in int & string enums

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -63,6 +63,7 @@ let package = Package(
         .target(
             name: "SmithyRetries",
             dependencies: [
+                "SmithyRetriesAPI",
                 .product(name: "AwsCommonRuntimeKit", package: "aws-crt-swift"),
             ]
         ),

--- a/Sources/WeatherSDK/models/SimpleYesNo.swift
+++ b/Sources/WeatherSDK/models/SimpleYesNo.swift
@@ -12,8 +12,7 @@ extension WeatherClientTypes {
         public static var allCases: [SimpleYesNo] {
             return [
                 .no,
-                .yes,
-                .sdkUnknown("")
+                .yes
             ]
         }
 

--- a/Sources/WeatherSDK/models/TypedYesNo.swift
+++ b/Sources/WeatherSDK/models/TypedYesNo.swift
@@ -12,8 +12,7 @@ extension WeatherClientTypes {
         public static var allCases: [TypedYesNo] {
             return [
                 .no,
-                .yes,
-                .sdkUnknown("")
+                .yes
             ]
         }
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/EnumGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/EnumGenerator.kt
@@ -193,7 +193,6 @@ class EnumGenerator(
     }
 
     fun generateAllCasesBlock() {
-        allCasesBuilder.add(".sdkUnknown(\"\")")
         writer.openBlock("public static var allCases: [\$enum.name:L] {", "}") {
             writer.openBlock("return [", "]") {
                 writer.write(allCasesBuilder.joinToString(",\n"))

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/IntEnumGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/IntEnumGenerator.kt
@@ -91,7 +91,6 @@ class IntEnumGenerator(
     }
 
     fun generateAllCasesBlock() {
-        allCasesBuilder.add(".sdkUnknown(0)")
         writer.openBlock("public static var allCases: [\$enum.name:L] {", "}") {
             writer.openBlock("return [", "]") {
                 writer.write(allCasesBuilder.joinToString(",\n"))

--- a/smithy-swift-codegen/src/test/kotlin/EnumGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/EnumGeneratorTests.kt
@@ -48,8 +48,7 @@ public enum MyEnum: Swift.Equatable, Swift.RawRepresentable, Swift.CaseIterable,
     public static var allCases: [MyEnum] {
         return [
             .bar,
-            .fooBazXap,
-            .sdkUnknown("")
+            .fooBazXap
         ]
     }
 
@@ -108,8 +107,7 @@ public enum MyEnum: Swift.Equatable, Swift.RawRepresentable, Swift.CaseIterable,
     public static var allCases: [MyEnum] {
         return [
             .t2Micro,
-            .t2Nano,
-            .sdkUnknown("")
+            .t2Nano
         ]
     }
 
@@ -155,8 +153,7 @@ extension ExampleClientTypes {
                 .club,
                 .diamond,
                 .heart,
-                .spade,
-                .sdkUnknown("")
+                .spade
             ]
         }
 

--- a/smithy-swift-codegen/src/test/kotlin/IntEnumGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/IntEnumGeneratorTests.kt
@@ -26,8 +26,7 @@ public enum Abcs: Swift.Equatable, Swift.RawRepresentable, Swift.CaseIterable, S
         return [
             .a,
             .b,
-            .c,
-            .sdkUnknown(0)
+            .c
         ]
     }
 

--- a/smithy-swift-codegen/src/test/kotlin/ReservedWordsGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/ReservedWordsGeneratorTests.kt
@@ -26,8 +26,7 @@ extension ExampleClientTypes {
                 .any,
                 .open,
                 .self,
-                .protocol,
-                .sdkUnknown("")
+                .protocol
             ]
         }
 
@@ -66,8 +65,7 @@ extension ExampleClientTypes {
         public static var allCases: [ModelType] {
             return [
                 .foo,
-                .test,
-                .sdkUnknown("")
+                .test
             ]
         }
 
@@ -104,8 +102,7 @@ extension ExampleClientTypes {
         public static var allCases: [ModelProtocol] {
             return [
                 .bar,
-                .foo,
-                .sdkUnknown("")
+                .foo
             ]
         }
 


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1463

## Description of changes
Removes the `.sdkUnknown()` case from the `allCases` property on both Int- & String-backed enums, because the case is not meaningful in the context of iterating or discovering the enum's cases.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.