### PR TITLE
chore!: Bump Swift minimum version & bump simulators in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ jobs:
           - macos-13-xlarge
           - macos-14-xlarge
         xcode:
-          - Xcode_15.1
+          - Xcode_15.2
           - Xcode_15.4
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
@@ -36,7 +36,7 @@ jobs:
             xcode: Xcode_15.4
           # Don't run new macOS with old Xcode
           - runner: macos-14-xlarge
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
           # Don't run old iOS/tvOS simulator with new Xcode
           - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
             xcode: Xcode_15.4
@@ -44,9 +44,9 @@ jobs:
             xcode: Xcode_15.4
           # Don't run new iOS/tvOS simulator with old Xcode
           - destination: 'platform=iOS Simulator,OS=17.5,name=iPhone 15'
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
           - destination: 'platform=tvOS Simulator,OS=17.5,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
     steps:
       - name: Checkout smithy-swift
         uses: actions/checkout@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -123,8 +123,8 @@ jobs:
       fail-fast: false
       matrix:
         swift:
-          - 5.7-amazonlinux2
-          - 5.7-focal
+          - 5.9-amazonlinux2
+          - 5.9-focal
           - 5.10-amazonlinux2
           - 5.10-jammy
     container:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,12 +22,12 @@ jobs:
           - macos-13-xlarge
           - macos-14-xlarge
         xcode:
-          - Xcode_14.1
+          - Xcode_15.1
           - Xcode_15.4
         destination:
-          - 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
+          - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
           - 'platform=iOS Simulator,OS=17.5,name=iPhone 15'
-          - 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=17.5,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=OS X'
         exclude:
@@ -36,17 +36,17 @@ jobs:
             xcode: Xcode_15.4
           # Don't run new macOS with old Xcode
           - runner: macos-14-xlarge
-            xcode: Xcode_14.1
+            xcode: Xcode_15.1
           # Don't run old iOS/tvOS simulator with new Xcode
-          - destination: 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
+          - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
             xcode: Xcode_15.4
-          - destination: 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.4
           # Don't run new iOS/tvOS simulator with old Xcode
           - destination: 'platform=iOS Simulator,OS=17.5,name=iPhone 15'
-            xcode: Xcode_14.1
+            xcode: Xcode_15.1
           - destination: 'platform=tvOS Simulator,OS=17.5,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_14.1
+            xcode: Xcode_15.1
     steps:
       - name: Checkout smithy-swift
         uses: actions/checkout@v4

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 
 import PackageDescription
 

--- a/smithy-swift-codegen-test/smithy-build.json
+++ b/smithy-swift-codegen-test/smithy-build.json
@@ -10,7 +10,7 @@
                     "gitRepo": "https://github.com/smithy-lang/smithy-swift.git",
                     "author": "Amazon Web Services",
                     "homepage": "https://docs.amplify.aws/",
-                    "swiftVersion": "5.7.0",
+                    "swiftVersion": "5.9.0",
                     "mergeModels": false
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/1518

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Bump minimum Swift version from 5.7 to 5.9
- Update simulator versions

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.