### PR TITLE
chore: Added import rules to swiftlint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -27,6 +27,8 @@ disabled_rules:
 
 opt_in_rules:
   - empty_count
+  - sorted_imports
+  - unused_imports
 
 # configurable rules can be customized from this configuration file
 force_cast: warning

--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientTLSOptions.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientTLSOptions.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Smithy
 import AwsCommonRuntimeKit
+import Smithy
 
 public struct CRTClientTLSOptions: TLSConfiguration {
 

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/DeserializeMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/DeserializeMiddleware.swift
@@ -7,8 +7,8 @@
 
 import class Smithy.Context
 import protocol Smithy.ResponseMessageDeserializer
-import SmithyReadWrite
 import SmithyHTTPAPI
+import SmithyReadWrite
 
 public struct DeserializeMiddleware<OperationStackOutput>: Middleware {
     public var id: String = "Deserialize"

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/EventStreamBodyMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/EventStreamBodyMiddleware.swift
@@ -7,8 +7,8 @@
 
 import protocol Smithy.RequestMessageSerializer
 import class Smithy.Context
-import SmithyEventStreamsAPI
 import SmithyEventStreams
+import SmithyEventStreamsAPI
 import SmithyEventStreamsAuthAPI
 import struct Foundation.Data
 import typealias SmithyReadWrite.WritingClosure

--- a/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionHTTPClient.swift
+++ b/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionHTTPClient.swift
@@ -36,8 +36,8 @@ import class Foundation.URLSessionTask
 import class Foundation.URLSessionDataTask
 import protocol Foundation.URLSessionDataDelegate
 import struct Foundation.Data
-import Security
 import AwsCommonRuntimeKit
+import Security
 
 /// A client that can be used to make requests to AWS services using `Foundation`'s `URLSession` HTTP client.
 ///

--- a/Sources/SmithyHTTPAPI/Endpoint.swift
+++ b/Sources/SmithyHTTPAPI/Endpoint.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Smithy
 import Foundation
+import Smithy
 
 public struct Endpoint: Hashable {
     public let uri: URI


### PR DESCRIPTION
## Description of changes
New rules are added for sorted & unused imports (duplicate imports is enabled by default.)

Note that Swiftlint will fix the new import rules automatically by running `swiftlint --fix`.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.