### PR TITLE
chore: Allow old Node to be used on Linux CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -195,6 +195,8 @@ jobs:
           - 5.10-jammy
     container:
       image: swift:${{ matrix.swift }}
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -249,6 +249,8 @@ jobs:
           - 5.10-jammy
     container:
       image: swift:${{ matrix.swift }}
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1608

## Description of changes
Disable forcing of Github Actions onto Node 20, since it does not work with Amazon Linux 2.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.