### PR TITLE
chore: Remove unused code, refactor in protocol tests

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolTestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolTestGenerator.kt
@@ -13,12 +13,7 @@ import software.amazon.smithy.protocoltests.traits.HttpMessageTestCase
 import software.amazon.smithy.protocoltests.traits.HttpRequestTestsTrait
 import software.amazon.smithy.protocoltests.traits.HttpResponseTestsTrait
 import software.amazon.smithy.swift.codegen.SwiftDependency
-import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputUrlHostMiddleware
-import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputUrlPathMiddleware
-import software.amazon.smithy.swift.codegen.integration.middlewares.RequestTestEndpointResolverMiddleware
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 import software.amazon.smithy.swift.codegen.middleware.OperationMiddleware
-import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.model.toUpperCamelCase
 import software.amazon.smithy.swift.codegen.testModuleName
 import java.util.TreeSet

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestErrorGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestErrorGenerator.kt
@@ -22,7 +22,7 @@ open class HttpProtocolUnitTestErrorGenerator protected constructor(builder: Bui
             writer.openBlock("do {", "} catch {") {
                 renderBuildHttpResponse(test)
                 writer.write("")
-                renderInitOperationError(test, operationErrorType)
+                renderInitOperationError(operationErrorType)
                 writer.write("")
                 renderCompareActualAndExpectedErrors(test, it, operationErrorType)
                 writer.write("")
@@ -34,8 +34,8 @@ open class HttpProtocolUnitTestErrorGenerator protected constructor(builder: Bui
         }
     }
 
-    private fun renderInitOperationError(test: HttpResponseTestCase, operationErrorType: String) {
-        val operationErrorVariableName = operationErrorType.decapitalize()
+    private fun renderInitOperationError(operationErrorType: String) {
+        val operationErrorVariableName = operationErrorType.replaceFirstChar { it.lowercase() }
         val responseErrorClosure = ResponseErrorClosureUtils(ctx, writer, operation).render()
         writer.addImport(SwiftDependency.SMITHY_READ_WRITE.target)
         writer.write(
@@ -50,9 +50,8 @@ open class HttpProtocolUnitTestErrorGenerator protected constructor(builder: Bui
         errorShape: Shape,
         operationErrorType: String
     ) {
-        val operationErrorVariableName = operationErrorType.decapitalize()
+        val operationErrorVariableName = operationErrorType.replaceFirstChar { it.lowercase() }
         val errorType = symbolProvider.toSymbol(errorShape).name
-        val errorVariableName = errorType.decapitalize()
 
         writer.openBlock("if let actual = \$L as? \$L {", "} else {", operationErrorVariableName, errorType) {
             renderExpectedOutput(test, errorShape)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestGenerator.kt
@@ -10,7 +10,6 @@ import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.protocoltests.traits.HttpMessageTestCase
 import software.amazon.smithy.swift.codegen.SwiftWriter
-import software.amazon.smithy.swift.codegen.middleware.OperationMiddleware
 
 /**
  * Abstract base implementation for protocol test generators to extend in order to generate HttpMessageTestCase
@@ -28,7 +27,6 @@ protected constructor(builder: Builder<T>) {
     protected val operation: OperationShape = builder.operation!!
     protected val writer: SwiftWriter = builder.writer!!
     protected val httpProtocolCustomizable = builder.httpProtocolCustomizable!!
-    protected val operationMiddleware = builder.operationMiddleware!!
     protected val httpBindingResolver = builder.httpBindingResolver!!
     protected val serviceName: String = builder.serviceName!!
     abstract val baseTestClassName: String
@@ -75,7 +73,6 @@ protected constructor(builder: Builder<T>) {
         var writer: SwiftWriter? = null
         var serviceName: String? = null
         var httpProtocolCustomizable: HTTPProtocolCustomizable? = null
-        var operationMiddleware: OperationMiddleware? = null
         var httpBindingResolver: HttpBindingResolver? = null
 
         fun symbolProvider(provider: SymbolProvider): Builder<T> = apply { this.symbolProvider = provider }
@@ -86,7 +83,6 @@ protected constructor(builder: Builder<T>) {
         fun writer(writer: SwiftWriter): Builder<T> = apply { this.writer = writer }
         fun serviceName(serviceName: String): Builder<T> = apply { this.serviceName = serviceName }
         fun httpProtocolCustomizable(httpProtocolCustomizable: HTTPProtocolCustomizable): Builder<T> = apply { this.httpProtocolCustomizable = httpProtocolCustomizable }
-        fun operationMiddleware(operationMiddleware: OperationMiddleware): Builder<T> = apply { this.operationMiddleware = operationMiddleware }
         fun httpBindingResolver(httpBindingResolver: HttpBindingResolver): Builder<T> = apply { this.httpBindingResolver = httpBindingResolver }
         abstract fun build(): HttpProtocolUnitTestGenerator<T>
     }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
@@ -46,8 +46,6 @@ open class HttpProtocolUnitTestRequestGenerator protected constructor(builder: B
             }
         }
 
-        writer.write("let urlPrefix = urlPrefixFromHost(host: \$S)", test.host)
-        writer.write("let hostOnly = hostOnlyFromHost(host: \$S)", test.host)
         writer.openBlock("let expected = buildExpectedHttpRequest(")
             .write("method: .${test.method.toLowerCase()},")
             .write("path: \$S,", normalizedUri)
@@ -108,11 +106,6 @@ open class HttpProtocolUnitTestRequestGenerator protected constructor(builder: B
                 }
                 .write("")
             val inputSymbol = symbolProvider.toSymbol(inputShape)
-            val outputShapeId = operation.output.get()
-            val outputShape = model.expectShape(outputShapeId)
-            val outputSymbol = symbolProvider.toSymbol(outputShape)
-            val outputErrorName = "${operation.toUpperCamelCase()}OutputError"
-            writer.addImport(SwiftDependency.SMITHY.target)
             writer.addImport(SwiftDependency.SMITHY.target)
             writer.write(
                 """

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
@@ -44,7 +44,7 @@ open class HttpProtocolUnitTestResponseGenerator protected constructor(builder: 
             val symbol = symbolProvider.toSymbol(it)
             renderBuildHttpResponse(test)
             writer.write("")
-            renderActualOutput(test, symbol)
+            renderActualOutput(symbol)
             writer.write("")
             renderExpectedOutput(test, it)
             writer.write("")
@@ -103,7 +103,7 @@ open class HttpProtocolUnitTestResponseGenerator protected constructor(builder: 
         }
     }
 
-    private fun renderActualOutput(test: HttpResponseTestCase, outputStruct: Symbol) {
+    private fun renderActualOutput(outputStruct: Symbol) {
         val responseClosure = ResponseClosureUtils(ctx, writer, operation).render()
         writer.write("let actual: \$N = try await \$L(httpResponse)", outputStruct, responseClosure)
     }

--- a/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPAWSJson11ProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPAWSJson11ProtocolGenerator.kt
@@ -59,7 +59,6 @@ class MockHTTPAWSJson11ProtocolGenerator() : HTTPBindingProtocolGenerator(MockAW
             responseTestBuilder,
             errorTestBuilder,
             customizations,
-            operationMiddleware,
             getProtocolHttpBindingResolver(ctx, defaultContentType),
         ).generateProtocolTests()
     }

--- a/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPEC2QueryProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPEC2QueryProtocolGenerator.kt
@@ -62,7 +62,6 @@ class MockHTTPEC2QueryProtocolGenerator : HTTPBindingProtocolGenerator(MockEC2Qu
             responseTestBuilder,
             errorTestBuilder,
             customizations,
-            operationMiddleware,
             getProtocolHttpBindingResolver(ctx, defaultContentType),
         ).generateProtocolTests()
     }

--- a/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPRestJsonProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPRestJsonProtocolGenerator.kt
@@ -36,7 +36,6 @@ class MockHTTPRestJsonProtocolGenerator : HTTPBindingProtocolGenerator(MockRestJ
             responseTestBuilder,
             errorTestBuilder,
             customizations,
-            operationMiddleware,
             getProtocolHttpBindingResolver(ctx, defaultContentType),
         ).generateProtocolTests()
     }

--- a/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPRestXMLProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/mocks/MockHTTPRestXMLProtocolGenerator.kt
@@ -37,7 +37,6 @@ class MockHTTPRestXMLProtocolGenerator : HTTPBindingProtocolGenerator(MockRestXM
             responseTestBuilder,
             errorTestBuilder,
             customizations,
-            operationMiddleware,
             getProtocolHttpBindingResolver(ctx, defaultContentType),
         ).generateProtocolTests()
     }


### PR DESCRIPTION
## Description of changes
- Removes dead code associated with setting up the now-unused middleware stack for protocol tests
- Prevents two warnings per test for unused local vars by deleting them
- Extracts & simplifies some logic for rendering header expectations
- Remove other unused variables & functions
- General code cleanup

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.