### PR TITLE
fix: Render enum default values correctly

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/member/MemberShapeDecodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/member/MemberShapeDecodeGenerator.kt
@@ -183,10 +183,7 @@ open class MemberShapeDecodeGenerator(
         val matchingMember = enumShape.members().first { member ->
             value == member.expectTrait<EnumValueTrait>().expectStringValue()
         }
-        return swiftEnumCaseName(
-            matchingMember.memberName,
-            matchingMember.expectTrait<EnumValueTrait>().expectStringValue()
-        )
+        return swiftEnumCaseName(matchingMember.memberName, value)
     }
 
     private fun intEnumDefaultValue(node: Node): String {


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1622

## Description of changes
To render the default value for an enum, an enum member matching the default value is located, then it is rendered as an enum case using the same logic as the enum definition.  See the [Smithy docs](https://smithy.io/2.0/spec/type-refinement-traits.html#default-value-constraints) for more details on how to interpret enum default values.

Enum default values have previously worked, even though the logic was incorrect, because enum values tend to closely resemble the enum member names.  This fixes a compile error introduced with the AWS Q Apps service, which uses enum values that are unlike the member names.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.