### PR TITLE
fix: run retry integration tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -240,5 +240,9 @@ let package = Package(
             name: "SmithyWaitersAPITests",
             dependencies: ["Smithy", "SmithyWaitersAPI"]
         ),
+        .testTarget(
+            name: "SmithyRetriesTests",
+            dependencies: ["ClientRuntime", "SmithyRetriesAPI", "SmithyRetries", "SmithyTestUtil"]
+        ),
     ].compactMap { $0 }
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

SmithyRetriesTests test target was accidentally removed from Package.swift in #692, so this commit adds it back. The test was also not working properly, because Context.partitionID's attribute key name used by RetryMiddleware was different from the one being set in the test. This caused the test to exit early when partitionID wasn't found.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.