### PR TITLE
fix: Supply explicit type on `forEach` block to try preventing compiler crash

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareExecutionGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareExecutionGenerator.kt
@@ -58,18 +58,18 @@ class MiddlewareExecutionGenerator(
             }
             """.trimIndent()
         )
-        // Swift can't infer the generic arguments to `create` for some reason
-        writer.write(
-            """
-            config.httpInterceptorProviders.forEach { provider in
-                let i: any ${'$'}N<${'$'}N, ${'$'}N> = provider.create()
-                builder.interceptors.add(i)
-            }
-            """.trimIndent(),
-            ClientRuntimeTypes.Core.HttpInterceptor,
-            inputShape,
-            outputShape,
-        )
+        writer.openBlock(
+            "config.httpInterceptorProviders.forEach { (provider: any \$N) -> Void in",
+            "}",
+            ClientRuntimeTypes.Core.HttpInterceptorProvider,
+        ) {
+            writer.write("let i: any \$N<\$N, \$N> = provider.create()",
+                ClientRuntimeTypes.Core.HttpInterceptor,
+                inputShape,
+                outputShape,
+            )
+            writer.write("builder.interceptors.add(i)")
+        }
 
         renderMiddlewares(ctx, op, operationStackName)
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareExecutionGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareExecutionGenerator.kt
@@ -63,7 +63,8 @@ class MiddlewareExecutionGenerator(
             "}",
             ClientRuntimeTypes.Core.HttpInterceptorProvider,
         ) {
-            writer.write("let i: any \$N<\$N, \$N> = provider.create()",
+            writer.write(
+                "let i: any \$N<\$N, \$N> = provider.create()",
                 ClientRuntimeTypes.Core.HttpInterceptor,
                 inputShape,
                 outputShape,

--- a/smithy-swift-codegen/src/test/kotlin/EventStreamTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/EventStreamTests.kt
@@ -218,7 +218,7 @@ extension EventStreamTestClientTypes.TestStream {
         config.interceptorProviders.forEach { provider in
             builder.interceptors.add(provider.create())
         }
-        config.httpInterceptorProviders.forEach { provider in
+        config.httpInterceptorProviders.forEach { (provider: any ClientRuntime.HttpInterceptorProvider) -> Void in
             let i: any ClientRuntime.HttpInterceptor<TestStreamOpInput, TestStreamOpOutput> = provider.create()
             builder.interceptors.add(i)
         }

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
@@ -158,7 +158,7 @@ extension RestJsonProtocolClient {
         config.interceptorProviders.forEach { provider in
             builder.interceptors.add(provider.create())
         }
-        config.httpInterceptorProviders.forEach { provider in
+        config.httpInterceptorProviders.forEach { (provider: any ClientRuntime.HttpInterceptorProvider) -> Void in
             let i: any ClientRuntime.HttpInterceptor<AllocateWidgetInput, AllocateWidgetOutput> = provider.create()
             builder.interceptors.add(i)
         }


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1681

## Description of changes
Preview builds are failing (on a compiler crash) while type checking the expression:
```swift
        config.httpInterceptorProviders.forEach { provider in
            let i: any ClientRuntime.HttpInterceptor<ListApplicationInstancesInput, ListApplicationInstancesOutput> = provider.create()
            builder.interceptors.add(i)
        }
```

This PR adds explicit type info to the `forEach` body, attempting to aid in type checking:
```swift
        config.httpInterceptorProviders.forEach { (provider: any ClientRuntime.HttpInterceptorProvider) -> Void in
            let i: any ClientRuntime.HttpInterceptor<ListApplicationInstancesInput, ListApplicationInstancesOutput> = provider.create()
            builder.interceptors.add(i)
        }
```

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.