### PR TITLE
fix: codegen for orchestrator telemetry

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareExecutionGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareExecutionGenerator.kt
@@ -84,7 +84,9 @@ class MiddlewareExecutionGenerator(
             let op = builder.attributes(context)
                 .telemetry(${"$"}N(
                     telemetryProvider: config.telemetryProvider,
-                    metricsAttributes: metricsAttributes
+                    metricsAttributes: metricsAttributes,
+                    meterScope: serviceName,
+                    tracerScope: serviceName
                 ))
                 .executeRequest(client)
                 .build()

--- a/smithy-swift-codegen/src/test/kotlin/EventStreamTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/EventStreamTests.kt
@@ -239,7 +239,9 @@ extension EventStreamTestClientTypes.TestStream {
         let op = builder.attributes(context)
             .telemetry(ClientRuntime.OrchestratorTelemetry(
                 telemetryProvider: config.telemetryProvider,
-                metricsAttributes: metricsAttributes
+                metricsAttributes: metricsAttributes,
+                meterScope: serviceName,
+                tracerScope: serviceName
             ))
             .executeRequest(client)
             .build()

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
@@ -180,7 +180,9 @@ extension RestJsonProtocolClient {
         let op = builder.attributes(context)
             .telemetry(ClientRuntime.OrchestratorTelemetry(
                 telemetryProvider: config.telemetryProvider,
-                metricsAttributes: metricsAttributes
+                metricsAttributes: metricsAttributes,
+                meterScope: serviceName,
+                tracerScope: serviceName
             ))
             .executeRequest(client)
             .build()


### PR DESCRIPTION
`meterScope` and `tracerScope` would be used in any library exporter of observability

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.