### PR TITLE
chore: Fix indentation of code after modularization

### DIFF
--- a/Sources/SmithyEventStreams/DefaultMessageDecoderStream.swift
+++ b/Sources/SmithyEventStreams/DefaultMessageDecoderStream.swift
@@ -10,18 +10,30 @@ import SmithyEventStreamsAPI
 import SmithyEventStreamsAuthAPI
 import struct Foundation.Data
 
-// Code left indented to prevent Git diff from being blown up by whitespace changes.
-// Will fix after event stream modularizaion has been reviewed.
+/// Stream adapter that decodes input data into `EventStream.Message` objects.
+public struct DefaultMessageDecoderStream<Event>: MessageDecoderStream {
+    public typealias Element = Event
 
-    /// Stream adapter that decodes input data into `EventStream.Message` objects.
-    public struct DefaultMessageDecoderStream<Event>: MessageDecoderStream {
-        public typealias Element = Event
+    let stream: ReadableStream
+    let messageDecoder: MessageDecoder
+    let unmarshalClosure: UnmarshalClosure<Event>
 
+    public init(
+        stream: ReadableStream,
+        messageDecoder: MessageDecoder,
+        unmarshalClosure: @escaping UnmarshalClosure<Event>
+    ) {
+        self.stream = stream
+        self.messageDecoder = messageDecoder
+        self.unmarshalClosure = unmarshalClosure
+    }
+
+    public struct AsyncIterator: AsyncIteratorProtocol {
         let stream: ReadableStream
         let messageDecoder: MessageDecoder
         let unmarshalClosure: UnmarshalClosure<Event>
 
-        public init(
+        init(
             stream: ReadableStream,
             messageDecoder: MessageDecoder,
             unmarshalClosure: @escaping UnmarshalClosure<Event>
@@ -31,50 +43,35 @@ import struct Foundation.Data
             self.unmarshalClosure = unmarshalClosure
         }
 
-        public struct AsyncIterator: AsyncIteratorProtocol {
-            let stream: ReadableStream
-            let messageDecoder: MessageDecoder
-            let unmarshalClosure: UnmarshalClosure<Event>
+        mutating public func next() async throws -> Event? {
+            var data: Data?
+            // read until the end of the stream, starting with data already in the buffer, if any
+            repeat {
+                // feed the data to the decoder
+                // this may result in a message being returned
+                try messageDecoder.feed(data: data ?? Data())
 
-            init(
-                stream: ReadableStream,
-                messageDecoder: MessageDecoder,
-                unmarshalClosure: @escaping UnmarshalClosure<Event>
-            ) {
-                self.stream = stream
-                self.messageDecoder = messageDecoder
-                self.unmarshalClosure = unmarshalClosure
-            }
+                // if we have a message in the decoder buffer, return it
+                if let message = try messageDecoder.message() {
+                    return try unmarshalClosure(message)
+                }
 
-            mutating public func next() async throws -> Event? {
-                var data: Data?
-                // read until the end of the stream, starting with data already in the buffer, if any
-                repeat {
-                    // feed the data to the decoder
-                    // this may result in a message being returned
-                    try messageDecoder.feed(data: data ?? Data())
+                data = try await stream.readAsync(upToCount: Int.max)
+            // nil data from stream indicates stream has closed, so stop reading it & stop async iterating
+            } while data != nil
 
-                    // if we have a message in the decoder buffer, return it
-                    if let message = try messageDecoder.message() {
-                        return try unmarshalClosure(message)
-                    }
-
-                    data = try await stream.readAsync(upToCount: Int.max)
-                // nil data from stream indicates stream has closed, so stop reading it & stop async iterating
-                } while data != nil
-
-                // this is the end of the stream
-                // notify the decoder that the stream has ended
-                try messageDecoder.endOfStream()
-                return nil
-            }
-        }
-
-        public func makeAsyncIterator() -> AsyncIterator {
-            AsyncIterator(
-                stream: stream,
-                messageDecoder: messageDecoder,
-                unmarshalClosure: unmarshalClosure
-            )
+            // this is the end of the stream
+            // notify the decoder that the stream has ended
+            try messageDecoder.endOfStream()
+            return nil
         }
     }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(
+            stream: stream,
+            messageDecoder: messageDecoder,
+            unmarshalClosure: unmarshalClosure
+        )
+    }
+}

--- a/Sources/SmithyEventStreams/DefaultMessageEncoderStream.swift
+++ b/Sources/SmithyEventStreams/DefaultMessageEncoderStream.swift
@@ -10,20 +10,43 @@ import SmithyEventStreamsAPI
 import SmithyEventStreamsAuthAPI
 import struct Foundation.Data
 
-// Code left indented to prevent Git diff from being blown up by whitespace changes.
-// Will fix after event stream modularizaion has been reviewed.
+/// Stream adapter that encodes input into `Data` objects.
+public class DefaultMessageEncoderStream<Event>: MessageEncoderStream, Stream {
 
-    /// Stream adapter that encodes input into `Data` objects.
-    public class DefaultMessageEncoderStream<Event>: MessageEncoderStream, Stream {
+    let stream: AsyncThrowingStream<Event, Error>
+    let messageEncoder: MessageEncoder
+    let messageSigner: MessageSigner
+    let marshalClosure: MarshalClosure<Event>
+    var readAsyncIterator: AsyncIterator?
+    let initialRequestMessage: Message?
 
+    public required init(
+        stream: AsyncThrowingStream<Event, Error>,
+        messageEncoder: MessageEncoder,
+        marshalClosure: @escaping MarshalClosure<Event>,
+        messageSigner: MessageSigner,
+        initialRequestMessage: Message? = nil
+    ) {
+        self.stream = stream
+        self.messageEncoder = messageEncoder
+        self.messageSigner = messageSigner
+        self.marshalClosure = marshalClosure
+        self.initialRequestMessage = initialRequestMessage
+        self.readAsyncIterator = makeAsyncIterator()
+    }
+
+    public struct AsyncIterator: AsyncIteratorProtocol {
         let stream: AsyncThrowingStream<Event, Error>
         let messageEncoder: MessageEncoder
-        let messageSigner: MessageSigner
+        var messageSigner: MessageSigner
         let marshalClosure: MarshalClosure<Event>
-        var readAsyncIterator: AsyncIterator?
         let initialRequestMessage: Message?
 
-        public required init(
+        private var lastMessageSent: Bool = false
+        private var streamIterator: AsyncThrowingStream<Event, Error>.Iterator
+        private var sentInitialRequest: Bool = false
+
+        init(
             stream: AsyncThrowingStream<Event, Error>,
             messageEncoder: MessageEncoder,
             marshalClosure: @escaping MarshalClosure<Event>,
@@ -31,170 +54,144 @@ import struct Foundation.Data
             initialRequestMessage: Message? = nil
         ) {
             self.stream = stream
+            self.streamIterator = stream.makeAsyncIterator()
             self.messageEncoder = messageEncoder
             self.messageSigner = messageSigner
             self.marshalClosure = marshalClosure
             self.initialRequestMessage = initialRequestMessage
-            self.readAsyncIterator = makeAsyncIterator()
         }
 
-        public struct AsyncIterator: AsyncIteratorProtocol {
-            let stream: AsyncThrowingStream<Event, Error>
-            let messageEncoder: MessageEncoder
-            var messageSigner: MessageSigner
-            let marshalClosure: MarshalClosure<Event>
-            let initialRequestMessage: Message?
-
-            private var lastMessageSent: Bool = false
-            private var streamIterator: AsyncThrowingStream<Event, Error>.Iterator
-            private var sentInitialRequest: Bool = false
-
-            init(
-                stream: AsyncThrowingStream<Event, Error>,
-                messageEncoder: MessageEncoder,
-                marshalClosure: @escaping MarshalClosure<Event>,
-                messageSigner: MessageSigner,
-                initialRequestMessage: Message? = nil
-            ) {
-                self.stream = stream
-                self.streamIterator = stream.makeAsyncIterator()
-                self.messageEncoder = messageEncoder
-                self.messageSigner = messageSigner
-                self.marshalClosure = marshalClosure
-                self.initialRequestMessage = initialRequestMessage
-            }
-
-            mutating public func next() async throws -> Data? {
-                if let initialRequestMessage, !sentInitialRequest {
-                    sentInitialRequest = true
-                    let signedMessage = try await messageSigner.sign(message: initialRequestMessage)
-                    return try messageEncoder.encode(message: signedMessage)
-                } else {
-                    guard let event = try await streamIterator.next() else {
-                        // There are no more messages in the base stream
-                        // if we have not sent the last message, send it now
-                        guard lastMessageSent else {
-                            let emptySignedMessage = try await messageSigner.signEmpty()
-                            let data = try messageEncoder.encode(message: emptySignedMessage)
-                            lastMessageSent = true
-                            return data
-                        }
-                        // mark the stream as complete
-                        return nil
-                    }
-                    return try await processEventToData(event: event)
-                }
-            }
-
-            mutating func processEventToData(event: Event) async throws -> Data {
-                // marshall event to message
-                let message = try marshalClosure(event)
-                // sign the message
-                let signedMessage = try await messageSigner.sign(message: message)
-                // encode again the signed message then return
+        mutating public func next() async throws -> Data? {
+            if let initialRequestMessage, !sentInitialRequest {
+                sentInitialRequest = true
+                let signedMessage = try await messageSigner.sign(message: initialRequestMessage)
                 return try messageEncoder.encode(message: signedMessage)
-            }
-        }
-
-        public func makeAsyncIterator() -> AsyncIterator {
-            AsyncIterator(
-                stream: stream,
-                messageEncoder: messageEncoder,
-                marshalClosure: marshalClosure,
-                messageSigner: messageSigner,
-                initialRequestMessage: initialRequestMessage
-            )
-        }
-
-        // MARK: Stream
-
-        /// Returns the current position in the stream
-        public var position: Data.Index = 0
-
-        /// Returns nil because the length of async stream is not known
-        public var length: Int?
-
-        /// Returns false because the length of async stream is not known
-        /// and therefore cannot be empty
-        public var isEmpty: Bool = false
-
-        /// Returns false because async stream is not seekable
-        public var isSeekable: Bool = false
-
-        /// Internal buffer to store excess data read from async stream
-        var buffer = Data()
-
-        public func read(upToCount count: Int) throws -> Data? {
-            fatalError("read(upToCount:) is not supported by AsyncStream backed streams")
-        }
-
-        public func readToEnd() throws -> Data? {
-            fatalError("readToEnd() is not supported by AsyncStream backed streams")
-        }
-
-        public func readToEndAsync() async throws -> Data? {
-            var data = Data()
-            while let moreData = try await readAsync(upToCount: Int.max) {
-                data.append(moreData)
-            }
-            return data
-        }
-
-        /// Reads up to `count` bytes from the stream asynchronously
-        /// - Parameter count: maximum number of bytes to read
-        /// - Returns: Data read from the stream, or nil if the stream is closed and no data is available
-        public func readAsync(upToCount count: Int) async throws -> Data? {
-            var data = Data()
-            var remaining = count
-
-            // read from buffer
-            if !buffer.isEmpty {
-                let toRead = Swift.min(remaining, buffer.count)
-                data.append(buffer.subdata(in: 0..<toRead))
-
-                // reset buffer to remaining data
-                buffer = Data(buffer.subdata(in: toRead..<buffer.count))
-
-                // update remaining bytes to read
-                remaining -= toRead
-
-                // update position
-                position = position.advanced(by: toRead)
-            }
-
-            while remaining > 0, let next = try await readAsyncIterator?.next() {
-                // read from async stream
-                let toRead = Swift.min(remaining, next.count)
-                data.append(next[0..<toRead])
-                remaining -= toRead
-
-                // update position
-                position += toRead
-
-                // if we have more data, add it to the buffer
-                if next.count > toRead {
-                    buffer.append(next[toRead..<next.count])
+            } else {
+                guard let event = try await streamIterator.next() else {
+                    // There are no more messages in the base stream
+                    // if we have not sent the last message, send it now
+                    guard lastMessageSent else {
+                        let emptySignedMessage = try await messageSigner.signEmpty()
+                        let data = try messageEncoder.encode(message: emptySignedMessage)
+                        lastMessageSent = true
+                        return data
+                    }
+                    // mark the stream as complete
+                    return nil
                 }
+                return try await processEventToData(event: event)
             }
-
-            // async stream has ended, return nil to mark stream end
-            if data.isEmpty {
-                return nil
-            }
-
-            return data
         }
 
-        public func write(contentsOf data: Data) throws {
-            fatalError("write(contentsOf:) is not supported by AsyncStream backed streams")
-        }
-
-        /// Closing the stream is a no-op because the underlying async stream is not owned by this stream
-        public func close() {
-            // no-op
-        }
-
-        public func closeWithError(_ error: Error) {
-            // no-op
+        mutating func processEventToData(event: Event) async throws -> Data {
+            // marshall event to message
+            let message = try marshalClosure(event)
+            // sign the message
+            let signedMessage = try await messageSigner.sign(message: message)
+            // encode again the signed message then return
+            return try messageEncoder.encode(message: signedMessage)
         }
     }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(
+            stream: stream,
+            messageEncoder: messageEncoder,
+            marshalClosure: marshalClosure,
+            messageSigner: messageSigner,
+            initialRequestMessage: initialRequestMessage
+        )
+    }
+
+    // MARK: Stream
+
+    /// Returns the current position in the stream
+    public var position: Data.Index = 0
+
+    /// Returns nil because the length of async stream is not known
+    public var length: Int?
+
+    /// Returns false because the length of async stream is not known
+    /// and therefore cannot be empty
+    public var isEmpty: Bool = false
+
+    /// Returns false because async stream is not seekable
+    public var isSeekable: Bool = false
+
+    /// Internal buffer to store excess data read from async stream
+    var buffer = Data()
+
+    public func read(upToCount count: Int) throws -> Data? {
+        fatalError("read(upToCount:) is not supported by AsyncStream backed streams")
+    }
+
+    public func readToEnd() throws -> Data? {
+        fatalError("readToEnd() is not supported by AsyncStream backed streams")
+    }
+
+    public func readToEndAsync() async throws -> Data? {
+        var data = Data()
+        while let moreData = try await readAsync(upToCount: Int.max) {
+            data.append(moreData)
+        }
+        return data
+    }
+
+    /// Reads up to `count` bytes from the stream asynchronously
+    /// - Parameter count: maximum number of bytes to read
+    /// - Returns: Data read from the stream, or nil if the stream is closed and no data is available
+    public func readAsync(upToCount count: Int) async throws -> Data? {
+        var data = Data()
+        var remaining = count
+
+        // read from buffer
+        if !buffer.isEmpty {
+            let toRead = Swift.min(remaining, buffer.count)
+            data.append(buffer.subdata(in: 0..<toRead))
+
+            // reset buffer to remaining data
+            buffer = Data(buffer.subdata(in: toRead..<buffer.count))
+
+            // update remaining bytes to read
+            remaining -= toRead
+
+            // update position
+            position = position.advanced(by: toRead)
+        }
+
+        while remaining > 0, let next = try await readAsyncIterator?.next() {
+            // read from async stream
+            let toRead = Swift.min(remaining, next.count)
+            data.append(next[0..<toRead])
+            remaining -= toRead
+
+            // update position
+            position += toRead
+
+            // if we have more data, add it to the buffer
+            if next.count > toRead {
+                buffer.append(next[toRead..<next.count])
+            }
+        }
+
+        // async stream has ended, return nil to mark stream end
+        if data.isEmpty {
+            return nil
+        }
+
+        return data
+    }
+
+    public func write(contentsOf data: Data) throws {
+        fatalError("write(contentsOf:) is not supported by AsyncStream backed streams")
+    }
+
+    /// Closing the stream is a no-op because the underlying async stream is not owned by this stream
+    public func close() {
+        // no-op
+    }
+
+    public func closeWithError(_ error: Error) {
+        // no-op
+    }
+}

--- a/Sources/SmithyEventStreamsAPI/Header.swift
+++ b/Sources/SmithyEventStreamsAPI/Header.swift
@@ -7,38 +7,32 @@
 
 import Foundation
 
-// Code left indented to prevent Git diff from being blown up by whitespace changes.
-// Will fix after event stream modularizaion has been reviewed.
+/// A header in an event stream message.
+/// Headers are used to convey metadata about the message.
+public struct Header: Equatable {
 
-    /// A header in an event stream message.
-    /// Headers are used to convey metadata about the message.
-    public struct Header: Equatable {
+    /// The name of the header.
+    public let name: String
 
-        /// The name of the header.
-        public let name: String
+    /// The value of the header.
+    public let value: HeaderValue
 
-        /// The value of the header.
-        public let value: HeaderValue
-
-        public init(name: String, value: HeaderValue) {
-            self.name = name
-            self.value = value
-        }
+    public init(name: String, value: HeaderValue) {
+        self.name = name
+        self.value = value
     }
+}
 
-// Code left indented to prevent Git diff from being blown up by whitespace changes.
-// Will fix after event stream modularizaion has been reviewed.
-
-    /// The value of a header in an event stream message.
-    /// Encoders and decoders may use this to determine how to encode or decode the header.
-    public enum HeaderValue: Equatable {
-        case bool(Bool)
-        case byte(Int8)
-        case int16(Int16)
-        case int32(Int32)
-        case int64(Int64)
-        case byteArray(Data)
-        case string(String)
-        case timestamp(Date)
-        case uuid(UUID)
-    }
+/// The value of a header in an event stream message.
+/// Encoders and decoders may use this to determine how to encode or decode the header.
+public enum HeaderValue: Equatable {
+    case bool(Bool)
+    case byte(Int8)
+    case int16(Int16)
+    case int32(Int32)
+    case int64(Int64)
+    case byteArray(Data)
+    case string(String)
+    case timestamp(Date)
+    case uuid(UUID)
+}

--- a/Sources/SmithyEventStreamsAPI/Message.swift
+++ b/Sources/SmithyEventStreamsAPI/Message.swift
@@ -7,23 +7,20 @@
 
 import struct Foundation.Data
 
-// Code left indented to prevent Git diff from being blown up by whitespace changes.
-// Will fix after event stream modularizaion has been reviewed.
+/// A message in an event stream that can be sent or received.
+public struct Message: Equatable {
 
-    /// A message in an event stream that can be sent or received.
-    public struct Message: Equatable {
+    /// The headers associated with the message.
+    public let headers: [Header]
 
-        /// The headers associated with the message.
-        public let headers: [Header]
+    /// The payload associated with the message.
+    public let payload: Data
 
-        /// The payload associated with the message.
-        public let payload: Data
-
-        public init(headers: [Header] = [], payload: Data = .init()) {
-            self.headers = headers
-            self.payload = payload
-        }
+    public init(headers: [Header] = [], payload: Data = .init()) {
+        self.headers = headers
+        self.payload = payload
     }
+}
 
 extension Message: CustomDebugStringConvertible {
     public var debugDescription: String {


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1697

## Description of changes
Fix code indentation where it was left with previous indenting during modularization.

No changes in this PR other than deleting indentation-related comments and changing leading whitespace.
Might be easier to review this with the "hide whitespace" diff feature enabled:
https://github.com/smithy-lang/smithy-swift/pull/804/files?diff=unified&w=1

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.