### PR TITLE
fix: Streamline HttpInterceptor type inference

### DIFF
--- a/Sources/ClientRuntime/Interceptor/HttpInterceptorProvider.swift
+++ b/Sources/ClientRuntime/Interceptor/HttpInterceptorProvider.swift
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import class SmithyHTTPAPI.HTTPRequest
+import class SmithyHTTPAPI.HTTPResponse
+
 /// Provides implementations of `HttpInterceptor`.
 ///
 /// For the generic counterpart, see `InterceptorProvider`.
@@ -13,5 +16,5 @@ public protocol HttpInterceptorProvider {
     /// Creates an instance of an `HttpInterceptor` implementation.
     ///
     /// - Returns: The `HttpInterceptor` implementation.
-    func create<InputType, OutputType>() -> any HttpInterceptor<InputType, OutputType>
+    func create<InputType, OutputType>() -> any Interceptor<InputType, OutputType, HTTPRequest, HTTPResponse>
 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareExecutionGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareExecutionGenerator.kt
@@ -51,25 +51,11 @@ class MiddlewareExecutionGenerator(
             SmithyHTTPAPITypes.HTTPRequest,
             SmithyHTTPAPITypes.HTTPResponse,
         )
-        writer.write(
-            """
-            config.interceptorProviders.forEach { provider in
-                builder.interceptors.add(provider.create())
-            }
-            """.trimIndent()
-        )
-        writer.openBlock(
-            "config.httpInterceptorProviders.forEach { (provider: any \$N) -> Void in",
-            "}",
-            ClientRuntimeTypes.Core.HttpInterceptorProvider,
-        ) {
-            writer.write(
-                "let i: any \$N<\$N, \$N> = provider.create()",
-                ClientRuntimeTypes.Core.HttpInterceptor,
-                inputShape,
-                outputShape,
-            )
-            writer.write("builder.interceptors.add(i)")
+        writer.openBlock("config.interceptorProviders.forEach { provider in", "}") {
+            writer.write("builder.interceptors.add(provider.create())")
+        }
+        writer.openBlock("config.httpInterceptorProviders.forEach { provider in", "}") {
+            writer.write("builder.interceptors.add(provider.create())")
         }
 
         renderMiddlewares(ctx, op, operationStackName)

--- a/smithy-swift-codegen/src/test/kotlin/EventStreamTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/EventStreamTests.kt
@@ -218,9 +218,8 @@ extension EventStreamTestClientTypes.TestStream {
         config.interceptorProviders.forEach { provider in
             builder.interceptors.add(provider.create())
         }
-        config.httpInterceptorProviders.forEach { (provider: any ClientRuntime.HttpInterceptorProvider) -> Void in
-            let i: any ClientRuntime.HttpInterceptor<TestStreamOpInput, TestStreamOpOutput> = provider.create()
-            builder.interceptors.add(i)
+        config.httpInterceptorProviders.forEach { provider in
+            builder.interceptors.add(provider.create())
         }
         builder.interceptors.add(ClientRuntime.URLPathMiddleware<TestStreamOpInput, TestStreamOpOutput>(TestStreamOpInput.urlPathProvider(_:)))
         builder.interceptors.add(ClientRuntime.URLHostMiddleware<TestStreamOpInput, TestStreamOpOutput>())

--- a/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/HttpProtocolClientGeneratorTests.kt
@@ -158,9 +158,8 @@ extension RestJsonProtocolClient {
         config.interceptorProviders.forEach { provider in
             builder.interceptors.add(provider.create())
         }
-        config.httpInterceptorProviders.forEach { (provider: any ClientRuntime.HttpInterceptorProvider) -> Void in
-            let i: any ClientRuntime.HttpInterceptor<AllocateWidgetInput, AllocateWidgetOutput> = provider.create()
-            builder.interceptors.add(i)
+        config.httpInterceptorProviders.forEach { provider in
+            builder.interceptors.add(provider.create())
         }
         builder.interceptors.add(ClientRuntime.IdempotencyTokenMiddleware<AllocateWidgetInput, AllocateWidgetOutput>(keyPath: \.clientToken))
         builder.interceptors.add(ClientRuntime.URLPathMiddleware<AllocateWidgetInput, AllocateWidgetOutput>(AllocateWidgetInput.urlPathProvider(_:)))


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1681

## Description of changes
Change construction of HTTP interceptors to match non-HTTP, which is never flagged in compiler crashes.

This is an attempt to address compiler crashes on the automated build system.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.