### PR TITLE
chore: Run Linux CI on Swift 6.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -191,8 +191,8 @@ jobs:
         swift:
           - 5.9-amazonlinux2
           - 5.9-focal
-          - 5.10-amazonlinux2
-          - 5.10-jammy
+          - 6.0-amazonlinux2
+          - 6.0-jammy
     container:
       image: swift:${{ matrix.swift }}
     env:
@@ -245,8 +245,8 @@ jobs:
         swift:
           - 5.9-amazonlinux2
           - 5.9-focal
-          - 5.10-amazonlinux2
-          - 5.10-jammy
+          - 6.0-amazonlinux2
+          - 6.0-jammy
     container:
       image: swift:${{ matrix.swift }}
     env:


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1757

## Description of changes
Runs Swift 6.0 as max supported Swift on Linux builds.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.