### PR TITLE
chore: Run protocol tests with downstream CI builds

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -177,12 +177,22 @@ jobs:
         run: |
           cd ../aws-sdk-swift
           ./scripts/ci_steps/prepare_protocol_and_unit_tests.sh
-      - name: Build and Run aws-sdk-swift Protocol & Unit Tests
+      - name: Build and Run aws-sdk-swift Unit Tests
         run: |
           cd ../aws-sdk-swift
           set -o pipefail && \
           NSUnbufferedIO=YES xcodebuild \
             -scheme aws-sdk-swift-Package \
+            -destination '${{ matrix.destination }}' \
+            test 2>&1 \
+            | xcbeautify
+      - name: Build and Run aws-sdk-swift Protocol Tests
+        run: |
+          cd ../aws-sdk-swift/codegen
+          set -o pipefail && \
+          NSUnbufferedIO=YES xcodebuild \
+            -scheme aws-sdk-swift-protocol-tests-Package \
+            -testPlan ProtocolTestPlan \
             -destination '${{ matrix.destination }}' \
             test 2>&1 \
             | xcbeautify
@@ -311,8 +321,12 @@ jobs:
         run: |
           cd ../aws-sdk-swift
           ./scripts/ci_steps/prepare_protocol_and_unit_tests.sh
-      - name: Build and Run aws-sdk-swift Protocol & Unit Tests
+      - name: Build and Run aws-sdk-swift Unit Tests
         run: |
           cd ../aws-sdk-swift
+          swift test
+      - name: Build and Run aws-sdk-swift Protocol Tests
+        run: |
+          cd ../aws-sdk-swift/codegen
           swift test
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -327,6 +327,9 @@ jobs:
           swift test
       - name: Build and Run aws-sdk-swift Protocol Tests
         run: |
+          export AWS_REGION=us-west-2
+          export AWS_ACCESS_KEY_ID=test-key-id
+          export AWS_SECRET_ACCESS_KEY=test-secret-access-key
           cd ../aws-sdk-swift/codegen
           swift test
 


### PR DESCRIPTION
## Issue \#

## Description of changes
The downstream jobs currently run only unit tests, not protocol tests.  Likely protocol tests were dropped when they were split from the SDK's main package.swift to their own manifest.

Restore protocol tests during downstream jobs, to better test for regressions.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.