### PR TITLE
chore: Move HTTP status code test out of SmithyTestUtil

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -280,5 +280,9 @@ let package = Package(
             name: "SmithyRetriesTests",
             dependencies: ["ClientRuntime", "SmithyRetriesAPI", "SmithyRetries", "SmithyTestUtil"]
         ),
+        .testTarget(
+            name: "SmithyHTTPAPITests",
+            dependencies: ["SmithyHTTPAPI"]
+        ),
     ].compactMap { $0 }
 )

--- a/Sources/SmithyTestUtil/NetworkingTestUtils.swift
+++ b/Sources/SmithyTestUtil/NetworkingTestUtils.swift
@@ -57,11 +57,4 @@ open class NetworkingTestUtils: XCTestCase {
         endpoint = Endpoint(host: host, path: path, queryItems: queryItems, headers: headers)
         return endpoint
     }
-
-    open func testHttpStatusCodeDescriptionWorks() {
-        let httpStatusCode = HTTPStatusCode.ok
-        let httpStatusCodeDescription = httpStatusCode.description
-
-        XCTAssertNotNil(httpStatusCodeDescription)
-    }
 }

--- a/Tests/SmithyHTTPAPITests/HttpStatusCodeTests.swift
+++ b/Tests/SmithyHTTPAPITests/HttpStatusCodeTests.swift
@@ -1,0 +1,19 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import SmithyHTTPAPI
+
+class HttpStatusCodeTests: XCTestCase {
+
+    open func testHttpStatusCodeDescriptionWorks() {
+        let httpStatusCode = HTTPStatusCode.ok
+        let httpStatusCodeDescription = httpStatusCode.description
+
+        XCTAssertNotNil(httpStatusCodeDescription)
+    }
+}


### PR DESCRIPTION
## Description of changes
I noticed that the `testHttpStatusCodeDescriptionWorks` unit test is located in `SmithyTestUtil`.  As a result, that test runs along with any set of unit tests that `SmithyTestUtil` is linked to.

Since the `HttpStatusCode` type is in the `SmithyHTTPAPI` module, I have created a `SmithyHTTPAPITests` test bundle and placed that test there, which is the correct place for that test to be located.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.