### PR TITLE
chore: Protocol tests set their own AWS credentials

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -192,7 +192,6 @@ jobs:
           set -o pipefail && \
           NSUnbufferedIO=YES xcodebuild \
             -scheme aws-sdk-swift-protocol-tests-Package \
-            -testPlan ProtocolTestPlan \
             -destination '${{ matrix.destination }}' \
             test 2>&1 \
             | xcbeautify

--- a/Package.swift
+++ b/Package.swift
@@ -140,7 +140,7 @@ let package = Package(
         ),
         .target(
             name: "SmithyTestUtil",
-            dependencies: ["ClientRuntime", "SmithyHTTPAPI"]
+            dependencies: ["ClientRuntime", "SmithyHTTPAPI", "SmithyIdentity"]
         ),
         .target(
             name: "SmithyIdentity",

--- a/Sources/SmithyTestUtil/DummyIdentityResolver.swift
+++ b/Sources/SmithyTestUtil/DummyIdentityResolver.swift
@@ -1,0 +1,17 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import struct SmithyIdentity.StaticAWSCredentialIdentityResolver
+
+public func dummyIdentityResolver() throws -> StaticAWSCredentialIdentityResolver {
+    try StaticAWSCredentialIdentityResolver(
+        .init(
+            accessKey: "dummy-aws-access-key-id",
+            secret: "dummy-aws-secret-access-key"
+        )
+    )
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
@@ -15,7 +15,6 @@ import software.amazon.smithy.swift.codegen.integration.serde.readwrite.requestW
 import software.amazon.smithy.swift.codegen.model.RecursiveShapeBoxer
 import software.amazon.smithy.swift.codegen.model.toLowerCamelCase
 import software.amazon.smithy.swift.codegen.swiftmodules.SmithyHTTPAPITypes
-import software.amazon.smithy.swift.codegen.swiftmodules.SmithyIdentityTypes
 import software.amazon.smithy.swift.codegen.swiftmodules.SmithyStreamsTypes
 import software.amazon.smithy.swift.codegen.swiftmodules.SmithyTestUtilTypes
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
@@ -17,6 +17,7 @@ import software.amazon.smithy.swift.codegen.model.toLowerCamelCase
 import software.amazon.smithy.swift.codegen.swiftmodules.SmithyHTTPAPITypes
 import software.amazon.smithy.swift.codegen.swiftmodules.SmithyIdentityTypes
 import software.amazon.smithy.swift.codegen.swiftmodules.SmithyStreamsTypes
+import software.amazon.smithy.swift.codegen.swiftmodules.SmithyTestUtilTypes
 
 open class HttpProtocolUnitTestRequestGenerator protected constructor(builder: Builder) :
     HttpProtocolUnitTestGenerator<HttpRequestTestCase>(builder) {
@@ -80,16 +81,7 @@ open class HttpProtocolUnitTestRequestGenerator protected constructor(builder: B
         val region = "us-west-2"
 
         writer.openBlock("let config = try await \$L.Config(", ")", clientName) {
-            writer.openBlock(
-                "awsCredentialIdentityResolver: try \$N(",
-                "),",
-                SmithyIdentityTypes.StaticAWSCredentialIdentityResolver,
-            ) {
-                writer.openBlock(".init(", ")") {
-                    writer.write("accessKey: \$S,", "dummy-aws-access-key-id")
-                    writer.write("secret: \$S", "dummy-aws-secret-access-key")
-                }
-            }
+            writer.write("awsCredentialIdentityResolver: try \$N(),", SmithyTestUtilTypes.dummyIdentityResolver)
             writer.write("region: \$S,", region)
             writer.write("signingRegion: \$S,", region)
             if (!ctx.service.getTrait(EndpointRuleSetTrait::class.java).isPresent) {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/swiftmodules/SmithyIdentityTypes.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/swiftmodules/SmithyIdentityTypes.kt
@@ -9,6 +9,7 @@ object SmithyIdentityTypes {
     val BearerTokenIdentityResolver = runtimeSymbol("BearerTokenIdentityResolver", SwiftDeclaration.PROTOCOL)
     val BearerTokenIdentity = runtimeSymbol("BearerTokenIdentity", SwiftDeclaration.STRUCT)
     val StaticBearerTokenIdentityResolver = runtimeSymbol("StaticBearerTokenIdentityResolver", SwiftDeclaration.STRUCT)
+    val StaticAWSCredentialIdentityResolver = runtimeSymbol("StaticAWSCredentialIdentityResolver", SwiftDeclaration.STRUCT)
 }
 
 private fun runtimeSymbol(name: String, declaration: SwiftDeclaration? = null): Symbol = SwiftSymbol.make(

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/swiftmodules/SmithyIdentityTypes.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/swiftmodules/SmithyIdentityTypes.kt
@@ -9,7 +9,6 @@ object SmithyIdentityTypes {
     val BearerTokenIdentityResolver = runtimeSymbol("BearerTokenIdentityResolver", SwiftDeclaration.PROTOCOL)
     val BearerTokenIdentity = runtimeSymbol("BearerTokenIdentity", SwiftDeclaration.STRUCT)
     val StaticBearerTokenIdentityResolver = runtimeSymbol("StaticBearerTokenIdentityResolver", SwiftDeclaration.STRUCT)
-    val StaticAWSCredentialIdentityResolver = runtimeSymbol("StaticAWSCredentialIdentityResolver", SwiftDeclaration.STRUCT)
 }
 
 private fun runtimeSymbol(name: String, declaration: SwiftDeclaration? = null): Symbol = SwiftSymbol.make(

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/swiftmodules/SmithyTestUtilTypes.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/swiftmodules/SmithyTestUtilTypes.kt
@@ -1,17 +1,19 @@
 package software.amazon.smithy.swift.codegen.swiftmodules
 
 import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.swift.codegen.SwiftDeclaration
 import software.amazon.smithy.swift.codegen.SwiftDependency
-import software.amazon.smithy.swift.codegen.model.buildSymbol
 
 object SmithyTestUtilTypes {
     val TestInitializer = runtimeSymbol("TestInitializer")
     val TestBaseError = runtimeSymbol("TestBaseError")
-    val SelectNoAuthScheme = runtimeSymbol("SelectNoAuthScheme")
+    val dummyIdentityResolver = runtimeSymbol("dummyIdentityResolver", SwiftDeclaration.FUNC)
 }
 
-private fun runtimeSymbol(name: String): Symbol = buildSymbol {
-    this.name = name
-    this.namespace = SwiftDependency.SMITHY_TEST_UTIL.target
-    dependency(SwiftDependency.SMITHY_TEST_UTIL)
-}
+private fun runtimeSymbol(name: String, declaration: SwiftDeclaration? = null): Symbol = SwiftSymbol.make(
+    name,
+    declaration,
+    SwiftDependency.SMITHY_TEST_UTIL,
+    emptyList(),
+    emptyList(),
+)


### PR DESCRIPTION
## Description of changes
Companion `aws-sdk-swift` PR: https://github.com/awslabs/aws-sdk-swift/pull/1784

Protocol tests are now generated with static, dummy credentials which allow the test to succeed no matter what credentials (or no credentials at all) are configured on the test host system.  This will simplify test setup on CI & build systems, and allow us to run protocol tests on sandboxed platforms without special config.
- `SmithyTestUtil` now has a function which creates a static identity resolver with dummy AWS credentials.
- Request protocol tests are generated with client config that injects these static credentials.
- Client config codegen is also cleaned up by setting all client config fields at initialization.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.