### PR TITLE
fix: Don't unwrap unneeded value during event marshal

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/events/MessageMarshallableGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/events/MessageMarshallableGenerator.kt
@@ -67,7 +67,7 @@ class MessageMarshallableGenerator(
                                 if (unbound.isNotEmpty() || eventHeaderBindings.isNotEmpty() || eventPayloadBinding != null) {
                                     write("case .\$L(let value):", memberName)
                                 } else {
-                                    writer.write("case .\$L:", memberName)
+                                    write("case .\$L:", memberName)
                                 }
                                 indent()
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/events/MessageMarshallableGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/events/MessageMarshallableGenerator.kt
@@ -55,14 +55,14 @@ class MessageMarshallableGenerator(
                                 // Unbound, header-bound, and payload-bound members require access to
                                 // the event value for serialization, so unwrap value when
                                 // those members exist.  The actual members will be written below.
-                                val unbound = variant.members().filterNot {
-                                    it.hasTrait<EventHeaderTrait>() || it.hasTrait<EventPayloadTrait>()
+                                val eventHeaderBindings = variant.members().filter {
+                                    it.hasTrait<EventHeaderTrait>()
                                 }
                                 val eventPayloadBinding = variant.members().firstOrNull {
                                     it.hasTrait<EventPayloadTrait>()
                                 }
-                                val eventHeaderBindings = variant.members().filter {
-                                    it.hasTrait<EventHeaderTrait>()
+                                val unbound = variant.members().filterNot {
+                                    it.hasTrait<EventHeaderTrait>() || it.hasTrait<EventPayloadTrait>()
                                 }
                                 if (unbound.isNotEmpty() || eventHeaderBindings.isNotEmpty() || eventPayloadBinding != null) {
                                     write("case .\$L(let value):", memberName)

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/EventStreamTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/EventStreamTests.kt
@@ -42,7 +42,7 @@ extension EventStreamTestClientTypes.TestStream {
                 headers.append(.init(name: ":event-type", value: .string("MessageWithUnion")))
                 headers.append(.init(name: ":content-type", value: .string("application/json")))
                 payload = try SmithyJSON.Writer.write(value.someUnion, rootNodeInfo: "", with: EventStreamTestClientTypes.TestUnion.write(value:to:))
-            case .messagewithheaders:
+            case .messagewithheaders(let value):
                 headers.append(.init(name: ":event-type", value: .string("MessageWithHeaders")))
                 if let headerValue = value.blob {
                     headers.append(.init(name: "blob", value: .byteArray(headerValue)))

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/EventStreamTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/EventStreamTests.kt
@@ -42,7 +42,7 @@ extension EventStreamTestClientTypes.TestStream {
                 headers.append(.init(name: ":event-type", value: .string("MessageWithUnion")))
                 headers.append(.init(name: ":content-type", value: .string("application/json")))
                 payload = try SmithyJSON.Writer.write(value.someUnion, rootNodeInfo: "", with: EventStreamTestClientTypes.TestUnion.write(value:to:))
-            case .messagewithheaders(let value):
+            case .messagewithheaders:
                 headers.append(.init(name: ":event-type", value: .string("MessageWithHeaders")))
                 if let headerValue = value.blob {
                     headers.append(.init(name: "blob", value: .byteArray(headerValue)))


### PR DESCRIPTION
## Description of changes
Quiets a warning that occurs when an event to be marshalled is unwrapped but not accessed.

Also adds some comments to help clear up what's going on in the `marshal` generated code.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.