### PR TITLE
feat!: Bump CRT version to 0.37.0 & add CRC64NVME checksum algorithm wrapper

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
     ],
     dependencies: {
         var dependencies: [Package.Dependency] = [
-            .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.36.0"),
+            .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.37.0"),
             .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         ]
         let isDocCEnabled = ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_ENABLE_DOCC"] != nil

--- a/Sources/SmithyChecksums/CRC64NVME.swift
+++ b/Sources/SmithyChecksums/CRC64NVME.swift
@@ -1,0 +1,40 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import protocol SmithyChecksumsAPI.Checksum
+import enum SmithyChecksumsAPI.HashResult
+import struct Foundation.Data
+import AwsCommonRuntimeKit
+
+class CRC64NVME {
+    let checksumName = "crc64nvme"
+    let digestLength: Int = 8 // bytes
+
+    private var previousHash: UInt64
+
+    public init(previousHash: UInt64 = 0) {
+        self.previousHash = previousHash
+    }
+}
+
+extension CRC64NVME: Checksum {
+    func copy() -> any Checksum {
+        return CRC64NVME(previousHash: previousHash)
+    }
+
+    func update(chunk: Data) {
+        self.previousHash = chunk.computeCRC64Nvme(previousCrc64Nvme: previousHash)
+    }
+
+    func reset() {
+        self.previousHash = UInt64()
+    }
+
+    func digest() -> HashResult {
+        return .integer64(previousHash)
+    }
+}

--- a/Sources/SmithyChecksumsAPI/Checksum.swift
+++ b/Sources/SmithyChecksumsAPI/Checksum.swift
@@ -45,4 +45,5 @@ public protocol Checksum {
 public enum HashResult {
     case data(Data)
     case integer(UInt32)
+    case integer64(UInt64)
 }

--- a/Sources/SmithyChecksumsAPI/ChecksumAlgorithm.swift
+++ b/Sources/SmithyChecksumsAPI/ChecksumAlgorithm.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+/// The list of checksum algorithms contained by this enum may expand in future.
 public enum ChecksumAlgorithm {
     case crc32, crc32c, crc64nvme, sha1, sha256, md5
 

--- a/Sources/SmithyChecksumsAPI/ChecksumAlgorithm.swift
+++ b/Sources/SmithyChecksumsAPI/ChecksumAlgorithm.swift
@@ -6,12 +6,13 @@
 //
 
 public enum ChecksumAlgorithm {
-    case crc32, crc32c, sha1, sha256, md5
+    case crc32, crc32c, crc64nvme, sha1, sha256, md5
 
     public func toString() -> String {
         switch self {
         case .crc32: return "crc32"
         case .crc32c: return "crc32c"
+        case .crc64nvme: return "crc64nvme"
         case .sha1: return "sha1"
         case .sha256: return "sha256"
         case .md5: return "md5"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Companion PR: https://github.com/awslabs/aws-sdk-swift/pull/1801

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Bump aws-crt-swift version to 0.37.0 
- Add wrapper for new checksum algorithm CRC64-NVME


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.