### PR TITLE
chore: Run Xcode 16.1 as latest Xcode on CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,39 +17,52 @@ jobs:
       matrix:
         # This matrix runs tests on iOS sim & Mac, on oldest & newest supported Xcodes
         runner:
-          - macos-13
+          - macos-14
           - macos-15
         xcode:
           - Xcode_15.2
-          - Xcode_16
+          - Xcode_16.1
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=iOS Simulator,OS=18.0,name=iPhone 16'
+          - 'platform=iOS Simulator,OS=18.1,name=iPhone 16'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
-          - 'platform=tvOS Simulator,OS=18.0,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - 'platform=tvOS Simulator,OS=18.1,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
+          - 'platform=visionOS Simulator,OS=2.1,name=Apple Vision Pro'
           - 'platform=macOS'
         exclude:
           # Don't run old macOS with new Xcode
-          - runner: macos-13
-            xcode: Xcode_16
+          - runner: macos-14
+            xcode: Xcode_16.1
           # Don't run new macOS with old Xcode
           - runner: macos-15
             xcode: Xcode_15.2
-          # Don't run old iOS/tvOS simulator with new Xcode
-          - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-            xcode: Xcode_16
+          # Don't run old simulators with new Xcode
           - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_16
-          # Don't run new iOS/tvOS simulator with old Xcode
-          - destination: 'platform=iOS Simulator,OS=18.0,name=iPhone 16'
+            xcode: Xcode_16.1
+          - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
+            xcode: Xcode_16.1
+          - destination: 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
+            xcode: Xcode_16.1
+          # Don't run new simulators with old Xcode
+          - destination: 'platform=tvOS Simulator,OS=18.1,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
-          - destination: 'platform=tvOS Simulator,OS=18.0,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - destination: 'platform=iOS Simulator,OS=18.1,name=iPhone 16'
+            xcode: Xcode_15.2
+          - destination: 'platform=visionOS Simulator,OS=2.1,name=Apple Vision Pro'
             xcode: Xcode_15.2
     steps:
       - name: Configure Xcode
         run: |
           sudo xcode-select -s /Applications/${{ matrix.xcode }}.app
           xcode-select -p
+      - name: Install visionOS sim if needed
+        if: ${{ contains(matrix.destination, 'platform=visionOS') }}
+        run: |
+          sudo xcodebuild -runFirstLaunch
+          sudo xcrun simctl list
+          sudo xcodebuild -downloadPlatform visionOS
+          sudo xcodebuild -runFirstLaunch
       - name: Checkout smithy-swift
         uses: actions/checkout@v4
       - name: Cache Gradle
@@ -96,39 +109,52 @@ jobs:
       matrix:
         # This matrix runs tests on iOS sim & Mac, on oldest & newest supported Xcodes
         runner:
-          - macos-13
+          - macos-14
           - macos-15
         xcode:
           - Xcode_15.2
-          - Xcode_16
+          - Xcode_16.1
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=iOS Simulator,OS=18.0,name=iPhone 16'
+          - 'platform=iOS Simulator,OS=18.1,name=iPhone 16'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
-          - 'platform=tvOS Simulator,OS=18.0,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - 'platform=tvOS Simulator,OS=18.1,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
+          - 'platform=visionOS Simulator,OS=2.1,name=Apple Vision Pro'
           - 'platform=macOS'
         exclude:
           # Don't run old macOS with new Xcode
-          - runner: macos-13
-            xcode: Xcode_16
+          - runner: macos-14
+            xcode: Xcode_16.1
           # Don't run new macOS with old Xcode
           - runner: macos-15
             xcode: Xcode_15.2
-          # Don't run old iOS/tvOS simulator with new Xcode
-          - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-            xcode: Xcode_16
+          # Don't run old simulators with new Xcode
           - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_16
-          # Don't run new iOS/tvOS simulator with old Xcode
-          - destination: 'platform=iOS Simulator,OS=18.0,name=iPhone 16'
+            xcode: Xcode_16.1
+          - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
+            xcode: Xcode_16.1
+          - destination: 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
+            xcode: Xcode_16.1
+          # Don't run new simulators with old Xcode
+          - destination: 'platform=tvOS Simulator,OS=18.1,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
-          - destination: 'platform=tvOS Simulator,OS=18.0,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - destination: 'platform=iOS Simulator,OS=18.1,name=iPhone 16'
+            xcode: Xcode_15.2
+          - destination: 'platform=visionOS Simulator,OS=2.1,name=Apple Vision Pro'
             xcode: Xcode_15.2
     steps:
       - name: Configure Xcode
         run: |
           sudo xcode-select -s /Applications/${{ matrix.xcode }}.app
           xcode-select -p
+      - name: Install visionOS sim if needed
+        if: ${{ contains(matrix.destination, 'platform=visionOS') }}
+        run: |
+          sudo xcodebuild -runFirstLaunch
+          sudo xcrun simctl list
+          sudo xcodebuild -downloadPlatform visionOS
+          sudo xcodebuild -runFirstLaunch
       - name: Checkout smithy-swift
         uses: actions/checkout@v4
       - name: Select aws-sdk-swift branch


### PR DESCRIPTION
## Description of changes
- Use macOS 14 instead of 13 for min Xcode
- Use macOS 15 + Xcode 16.1 for max Xcode
- Run tests on visionOS as well as iOS & tvOS

Note: all workflow config in this PR is just copied from the same section in https://github.com/awslabs/aws-sdk-swift/pull/1807

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.