### PR TITLE
fix: Retry handling for streamed request bodies

### DIFF
--- a/Sources/ClientRuntime/Orchestrator/Orchestrator.swift
+++ b/Sources/ClientRuntime/Orchestrator/Orchestrator.swift
@@ -265,6 +265,13 @@ public struct Orchestrator<
             // If we can't get errorInfo, we definitely can't retry
             guard let errorInfo = retryErrorInfoProvider(error) else { return }
 
+            // If the body is a nonseekable stream, we also can't retry
+            do {
+                guard try readyBodyForRetry(request: copiedRequest) else { return }
+            } catch {
+                return
+            }
+
             // When refreshing fails it throws, indicating we're done retrying
             do {
                 try await strategy.refreshRetryTokenForRetry(tokenToRenew: token, errorInfo: errorInfo)
@@ -274,6 +281,21 @@ public struct Orchestrator<
 
             context.updateRequest(updated: copiedRequest)
             await startAttempt(context: context, strategy: strategy, token: token, attemptCount: attemptCount + 1)
+        }
+    }
+
+    /// Readies the body for retry, and indicates whether the body may be retried
+    /// - Parameter request: The request to be retried
+    /// - Returns: `true` if the body of the request was rewound or does not need rewind, `false` otherwise.
+    private func readyBodyForRetry(request: RequestType) throws -> Bool {
+        switch request.body {
+        case .stream(let stream):
+            if stream.isSeekable {
+                try stream.seek(toOffset: 0)
+            }
+            return stream.isSeekable
+        case .data, .noStream:
+            return true
         }
     }
 


### PR DESCRIPTION
## Description of changes
This change ensures that retry is only used when a request body is reusable, and that the request body is prepared for reuse if needed.
- When a request body is a seekable stream, rewind the stream to the beginning before retrying.  Do not retry if rewind is not successful.
- When a request body is a non-seekable stream, do not attempt to retry; fail the request immediately instead.
- Non-streamed request bodies (i.e. in-memory Data and empty bodies) are always retryable.

Additionally, unit tests are added to `Orchestrator` to verify correct retry behavior.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.