### PR TITLE
fix: Retry URLSession timeout error

### DIFF
--- a/Sources/ClientRuntime/Retries/DefaultRetryErrorInfoProvider.swift
+++ b/Sources/ClientRuntime/Retries/DefaultRetryErrorInfoProvider.swift
@@ -18,28 +18,29 @@ public enum DefaultRetryErrorInfoProvider: RetryErrorInfoProvider, Sendable {
     /// - Parameter error: The error to be triaged for retry info
     /// - Returns: `RetryErrorInfo` for the passed error, or `nil` if the error should not be retried.
     public static func errorInfo(for error: Error) -> RetryErrorInfo? {
-        var hint: TimeInterval?
         let retryableStatusCodes: [HTTPStatusCode] = [
             .internalServerError,  // 500
             .badGateway,           // 502
             .serviceUnavailable,   // 503
             .gatewayTimeout,       // 504
         ]
-        if let retryAfterString = (error as? HTTPError)?.httpResponse.headers.value(for: "x-retry-after") {
-            hint = TimeInterval(retryAfterString)
-        }
         if let modeledError = error as? ModeledError {
             let type = type(of: modeledError)
             guard type.isRetryable else { return nil }
             let errorType: RetryErrorType = type.isThrottling ? .throttling : type.fault.retryErrorType
-            return .init(errorType: errorType, retryAfterHint: hint, isTimeout: false)
+            return .init(errorType: errorType, retryAfterHint: nil, isTimeout: false)
         } else if let code = (error as? HTTPError)?.httpResponse.statusCode, retryableStatusCodes.contains(code) {
-            return .init(errorType: .serverError, retryAfterHint: hint, isTimeout: false)
+            return .init(errorType: .serverError, retryAfterHint: nil, isTimeout: false)
         } else if (error as NSError).domain == NSURLErrorDomain, (error as NSError).code == -1005 {
             // Domain == "NSURLErrorDomain"
             // NSURLErrorNetworkConnectionLost =         -1005
             // "The network connection was lost."
             return .init(errorType: .transient, retryAfterHint: nil, isTimeout: false)
+        } else if (error as NSError).domain == NSURLErrorDomain, (error as NSError).code == -1001 {
+            // Domain == "NSURLErrorDomain"
+            // NSURLErrorTimedOut =             -1001
+            // "The request timed out."
+            return .init(errorType: .transient, retryAfterHint: nil, isTimeout: true)
         }
         return nil
     }

--- a/Tests/SmithyRetriesTests/DefaultRetryErrorInfoProviderTests.swift
+++ b/Tests/SmithyRetriesTests/DefaultRetryErrorInfoProviderTests.swift
@@ -130,15 +130,9 @@ final class DefaultRetryErrorInfoProviderTests: XCTestCase {
         XCTAssertEqual(errorInfo, .init(errorType: .transient, retryAfterHint: nil, isTimeout: false))
     }
 
-    // MARK: - Retry after hint
-
-    func test_errorInfo_returnsRetryAfterDelayWhenRetryAfterHeaderIsSet() {
-
-        struct RetryAfterError: Error, HTTPError {
-            var httpResponse = HTTPResponse(headers: Headers(["x-retry-after": String(0.027)]), statusCode: .internalServerError)
-        }
-
-        let errorInfo = DefaultRetryErrorInfoProvider.errorInfo(for: RetryAfterError())
-        XCTAssertEqual(errorInfo?.retryAfterHint, 0.027)
+    func test_errorInfo_returnsRetryAfterNetworkTimeout() {
+        let timedOut = NSError(domain: NSURLErrorDomain, code: -1001)
+        let errorInfo = DefaultRetryErrorInfoProvider.errorInfo(for: timedOut)
+        XCTAssertEqual(errorInfo, .init(errorType: .transient, retryAfterHint: nil, isTimeout: true))
     }
 }


### PR DESCRIPTION
## Description of changes
URLSession will throw this error on connection timeout:
```
Error Domain=NSURLErrorDomain Code=-1001 "The request timed out." 
```

Retry it as a transient error.

Also: remove support for the `retry-after` header, which was previously removed from the SDK.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.