### PR TITLE
Avoid re-parsing #file values during logging

### DIFF
--- a/Sources/Smithy/Logging/LogAgent.swift
+++ b/Sources/Smithy/Logging/LogAgent.swift
@@ -38,24 +38,26 @@ public enum LogAgentLevel: String, Codable, CaseIterable {
     case fatal
 }
 
+private let currentModule: String = {
+    let filePath = #file
+    let utf8All = filePath.utf8
+    return filePath.utf8.lastIndex(of: UInt8(ascii: "/")).flatMap { lastSlash -> Substring? in
+        utf8All[..<lastSlash].lastIndex(of: UInt8(ascii: "/")).map { secondLastSlash -> Substring in
+            filePath[utf8All.index(after: secondLastSlash) ..< lastSlash]
+        }
+    }.map {
+        String($0)
+    } ?? "n/a"
+}()
+
 public extension LogAgent {
-    internal static func currentModule(filePath: String = #file) -> String {
-        let utf8All = filePath.utf8
-        return filePath.utf8.lastIndex(of: UInt8(ascii: "/")).flatMap { lastSlash -> Substring? in
-            utf8All[..<lastSlash].lastIndex(of: UInt8(ascii: "/")).map { secondLastSlash -> Substring in
-                filePath[utf8All.index(after: secondLastSlash) ..< lastSlash]
-            }
-        }.map {
-            String($0)
-        } ?? "n/a"
-    }
 
     /// Log a message passing with the `.info` log level.
     func info(_ message: String, file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .info,
                  message: message,
                  metadata: nil,
-                 source: Self.currentModule(),
+                 source: currentModule,
                  file: file,
                  function: function,
                  line: line)
@@ -66,7 +68,7 @@ public extension LogAgent {
         self.log(level: .warn,
                  message: message,
                  metadata: nil,
-                 source: Self.currentModule(),
+                 source: currentModule,
                  file: file,
                  function: function,
                  line: line)
@@ -77,7 +79,7 @@ public extension LogAgent {
         self.log(level: .debug,
                  message: message,
                  metadata: nil,
-                 source: Self.currentModule(),
+                 source: currentModule,
                  file: file,
                  function: function,
                  line: line)
@@ -88,7 +90,7 @@ public extension LogAgent {
         self.log(level: .error,
                  message: message,
                  metadata: nil,
-                 source: Self.currentModule(),
+                 source: currentModule,
                  file: file,
                  function: function,
                  line: line)
@@ -99,7 +101,7 @@ public extension LogAgent {
         self.log(level: .trace,
                  message: message,
                  metadata: nil,
-                 source: Self.currentModule(),
+                 source: currentModule,
                  file: file,
                  function: function,
                  line: line)
@@ -110,7 +112,7 @@ public extension LogAgent {
         self.log(level: .fatal,
                  message: message,
                  metadata: nil,
-                 source: Self.currentModule(),
+                 source: currentModule,
                  file: file,
                  function: function,
                  line: line)


### PR DESCRIPTION
This fixes a CPU usage issue with frequent debug logging.

## Issue \#

## Description of changes

I noticed when tracing a large file upload through S3Client that a lot of time was spent inside `LogAgent.currentModule(filePath:)`. I checked and noticed that it's only called from within this file, and only ever used with the static value of `#file` (no callers ever change the parameter).

As such, we can hoist it into a file-private variable and avoid recomputing it frequently. I would like to keep it as a `static let` inside `LogAgent`, but that's not supported on protocols.
![Screenshot 2024-11-15 at 1 18 52 PM](https://github.com/user-attachments/assets/337a5f89-d31d-43a3-abc8-5bc6d68ae653)

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.