### PR TITLE
fix: StreamableHttpBody streams sliced Data correctly

### DIFF
--- a/Tests/ClientRuntimeTests/NetworkingTests/Streaming/StreamableHttpBodyTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/Streaming/StreamableHttpBodyTests.swift
@@ -12,60 +12,73 @@ import AwsCommonRuntimeKit
 
 final class StreamableHttpBodyTests: XCTestCase {
 
-    let testData = Data([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A])
+    let testData = Data([
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A
+    ])
 
-    func testRead() throws {
-        let sut = StreamableHttpBody(body: .data(testData))
+    func test_streamWholeData() throws {
+        try read(data: Data(testData[..<11]))
+        try seek(data: Data(testData[11...]))
+    }
+
+    func test_streamSlicedData() throws {
+        try read(data: testData[..<11])
+        try seek(data: testData[11...])
+    }
+
+    private func read(data: Data, file: StaticString = #file, line: UInt = #line) throws {
+        let sut = StreamableHttpBody(body: .data(data))
 
         // read first 4 bytes
         let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: 4)
         let bytesRead1 = try sut.read(buffer: buffer)
         let bytes1 = Data(bytes: buffer.baseAddress!, count: bytesRead1!)
-        XCTAssertEqual(bytesRead1, 4)
-        XCTAssertEqual(bytes1, Data([0x00, 0x01, 0x02, 0x03]))
+        XCTAssertEqual(bytesRead1, 4, file: file, line: line)
+        XCTAssertEqual(bytes1, Data([0x00, 0x01, 0x02, 0x03]), file: file, line: line)
 
         // read next 4 bytes from current position
         let bytesRead2 = try sut.read(buffer: buffer)
         let bytes2 = Data(bytes: buffer.baseAddress!, count: bytesRead2!)
-        XCTAssertEqual(bytesRead2, 4)
-        XCTAssertEqual(bytes2, Data([0x04, 0x05, 0x06, 0x07]))
+        XCTAssertEqual(bytesRead2, 4, file: file, line: line)
+        XCTAssertEqual(bytes2, Data([0x04, 0x05, 0x06, 0x07]), file: file, line: line)
 
         // read next 4 bytes from current position
         // this should only read 3 bytes since we are at the end of the stream
         let bytesRead3 = try sut.read(buffer: buffer)
         let bytes3 = Data(bytes: buffer.baseAddress!, count: bytesRead3!)
-        XCTAssertEqual(bytesRead3, 3)
-        XCTAssertEqual(bytes3, Data([0x08, 0x09, 0x0A]))
+        XCTAssertEqual(bytesRead3, 3, file: file, line: line)
+        XCTAssertEqual(bytes3, Data([0x08, 0x09, 0x0A]), file: file, line: line)
 
         // read next 4 bytes from current position
         // this should return nil since we are at the end of the stream
         let bytesRead4 = try sut.read(buffer: buffer)
-        XCTAssertNil(bytesRead4)
+        XCTAssertNil(bytesRead4, file: file, line: line)
     }
 
-    func testSeek() throws {
-        let sut = StreamableHttpBody(body: .data(testData))
+    private func seek(data: Data, file: StaticString = #file, line: UInt = #line) throws {
+        let sut = StreamableHttpBody(body: .data(data))
 
         // read first 4 bytes
         let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: 4)
         let bytesRead1 = try sut.read(buffer: buffer)
         let bytes1 = Data(bytes: buffer.baseAddress!, count: bytesRead1!)
-        XCTAssertEqual(bytesRead1!, 4)
-        XCTAssertEqual(bytes1, Data([0x00, 0x01, 0x02, 0x03]))
+        XCTAssertEqual(bytesRead1!, 4, file: file, line: line)
+        XCTAssertEqual(bytes1, Data([0x00, 0x01, 0x02, 0x03]), file: file, line: line)
 
         // seek to offset 2 and read 4 bytes
         try sut.seek(offset: 2, streamSeekType: .begin)
         let bytesRead2 = try sut.read(buffer: buffer)
         let bytes2 = Data(bytes: buffer.baseAddress!, count: bytesRead2!)
-        XCTAssertEqual(bytesRead2!, 4)
-        XCTAssertEqual(bytes2, Data([0x02, 0x03, 0x04, 0x05]))
+        XCTAssertEqual(bytesRead2!, 4, file: file, line: line)
+        XCTAssertEqual(bytes2, Data([0x02, 0x03, 0x04, 0x05]), file: file, line: line)
 
         // seek to offset 8 and read 3 bytes
         // this should only read 3 bytes since we are at the end of the stream
         try sut.seek(offset: 8, streamSeekType: .begin)
         let bytesRead3 = try sut.read(buffer: buffer)
         let bytes3 = Data(bytes: buffer.baseAddress!, count: bytesRead3!)
-        XCTAssertEqual(bytesRead3!, 3)
-        XCTAssertEqual(bytes3, Data([0x08, 0x09, 0x0A]))
+        XCTAssertEqual(bytesRead3!, 3, file: file, line: line)
+        XCTAssertEqual(bytes3, Data([0x08, 0x09, 0x0A]), file: file, line: line)
     }
 }


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1824

## Description of changes
- Fix the calculation of the number of bytes to read so that it is correct when Data is not zero-indexed (i.e. when it is "sliced" from a parent Data)
- Add tests to show that sliced data can be streamed

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.