### PR TITLE
fix: Add date-time timestamp handling to ShapeValueGenerator

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ShapeValueGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ShapeValueGenerator.kt
@@ -22,12 +22,14 @@ import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeType
 import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.shapes.TimestampShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.StreamingTrait
 import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.model.toMemberNames
 import software.amazon.smithy.swift.codegen.swiftmodules.SmithyStreamsTypes
+import software.amazon.smithy.swift.codegen.swiftmodules.SmithyTimestampsTypes
 import software.amazon.smithy.swift.codegen.swiftmodules.SmithyTypes
 import software.amazon.smithy.swift.codegen.utils.toLowerCamelCase
 import software.amazon.smithy.utils.StringUtils.lowerCase
@@ -243,6 +245,14 @@ class ShapeValueGenerator(
 
         override fun stringNode(node: StringNode) {
             when (currShape) {
+                is TimestampShape -> {
+                    val value = node.expectStringNode().value
+                    writer.writeInline(
+                        "\$N(format: .dateTime).date(from: \$S)",
+                        SmithyTimestampsTypes.TimestampFormatter,
+                        value
+                    )
+                }
                 is DoubleShape, is FloatShape -> {
                     val symbol = generator.symbolProvider.toSymbol(currShape)
                     val value = when (node.value.toString()) {

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/codegencomponents/ShapeValueGeneratorTest.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/codegencomponents/ShapeValueGeneratorTest.kt
@@ -162,13 +162,20 @@ Set<Swift.String>(arrayLiteral:
         val member2 = MemberShape.builder().id("foo.bar#MyStruct\$boolMember").target("smithy.api#Boolean").build()
         val member3 = MemberShape.builder().id("foo.bar#MyStruct\$intMember").target("smithy.api#Integer").build()
 
-        val nestedMember1 = MemberShape.builder().id("foo.bar#Nested\$tsMember").target("smithy.api#Timestamp").build()
+        val nestedMember1 = MemberShape.builder().id("foo.bar#Nested\$epochSecondsMember").target("smithy.api#Timestamp").build()
         val nested = StructureShape.builder()
             .id("foo.bar#Nested")
             .addMember(nestedMember1)
             .build()
 
+        val nestedMember2 = MemberShape.builder().id("foo.bar#Nested2\$dateTimeMember").target("smithy.api#Timestamp").build()
+        val nested2 = StructureShape.builder()
+            .id("foo.bar#Nested2")
+            .addMember(nestedMember2)
+            .build()
+
         val member4 = MemberShape.builder().id("foo.bar#MyStruct\$structMember").target("foo.bar#Nested").build()
+        val member9 = MemberShape.builder().id("foo.bar#MyStruct\$structMember2").target("foo.bar#Nested2").build()
 
         val enumTrait = EnumTrait.builder()
             .addEnum(EnumDefinition.builder().value("fooey").name("FOO").build())
@@ -195,10 +202,12 @@ Set<Swift.String>(arrayLiteral:
             .addMember(member6)
             .addMember(member7)
             .addMember(member8)
+            .addMember(member9)
             .build()
         val model = Model.assembler()
             .addShapes(struct, member1, member2, member3)
             .addShapes(member4, nested, nestedMember1)
+            .addShapes(member9, nested2, nestedMember2)
             .addShapes(member5, enumShape)
             .addShapes(member6, member7, member8)
             .assemble()
@@ -216,7 +225,13 @@ Set<Swift.String>(arrayLiteral:
             .withMember(
                 "structMember",
                 Node.objectNodeBuilder()
-                    .withMember("tsMember", 11223344)
+                    .withMember("epochSecondsMember", 11223344)
+                    .build()
+            )
+            .withMember(
+                "structMember2",
+                Node.objectNodeBuilder()
+                    .withMember("dateTimeMember", "1970-01-01T00:00:00Z")
                     .build()
             )
             .withMember("enumMember", "fooey")
@@ -238,7 +253,10 @@ MyStruct(
     nullMember: nil,
     stringMember: "v1",
     structMember: Nested(
-        tsMember: Date(timeIntervalSince1970: 11223344)
+        epochSecondsMember: Date(timeIntervalSince1970: 11223344)
+    ),
+    structMember2: Nested2(
+        dateTimeMember: SmithyTimestamps.TimestampFormatter(format: .dateTime).date(from: "1970-01-01T00:00:00Z")
     )
 )
         """.trimIndent()


### PR DESCRIPTION
SDK CI PR for changes in this PR: https://github.com/awslabs/aws-sdk-swift/pull/1826

<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- The `ShapeValueGenerator` is used to codegen input parameters for an input struct in protocol test codegen and smoke test codegen. `ShapeValueGenerator` currently only handles `epoch-seconds` (aka Unix time) timestamp format. This PR adds support for `date-time` as defined by RFC3339.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.