### PR TITLE
chore: Disable Github CI on Amazon Linux 2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -237,6 +237,10 @@ jobs:
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
+      - name: Setup Node 16
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
       - name: Checkout Sources
         uses: actions/checkout@v3
       - name: Install openssl

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -228,19 +228,13 @@ jobs:
       fail-fast: false
       matrix:
         swift:
-          - 5.9-amazonlinux2
           - 5.9-focal
-          - 6.0-amazonlinux2
           - 6.0-jammy
     container:
       image: swift:${{ matrix.swift }}
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
-      - name: Setup Node 16
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16
       - name: Checkout Sources
         uses: actions/checkout@v3
       - name: Install openssl
@@ -286,9 +280,7 @@ jobs:
       fail-fast: false
       matrix:
         swift:
-          - 5.9-amazonlinux2
           - 5.9-focal
-          - 6.0-amazonlinux2
           - 6.0-jammy
     container:
       image: swift:${{ matrix.swift }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -238,7 +238,7 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Setup Node 16
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: Checkout Sources

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -238,7 +238,7 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Setup Node 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: 16
       - name: Checkout Sources


### PR DESCRIPTION
## Description of changes
[Github Runner v2.321.0](https://github.com/actions/runner/releases/tag/v2.321.0) removed Node 16.  Since AL2 is not compatible with Node 20 due to the glibc version it uses, several important Github Actions may no longer run on AL2.

This PR disables CI on AL2.  Linux is still covered by running Ubuntu tests.  It is likely that we will not be able to test Amazon Linux on Github again until Swift adopts a newer version of Amazon Linux, i.e. 2023.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.