### PR TITLE
chore: Bump aws-crt-swift version to 0.40.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
     ],
     dependencies: {
         var dependencies: [Package.Dependency] = [
-            .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.39.0"),
+            .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.40.0"),
             .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         ]
         let isDocCEnabled = ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_ENABLE_DOCC"] != nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- New v0.40.0 of aws-crt-swift fixes a bug with the underlying sts assume role credentials provider where initialization would throw error due to missing bootstrap argument. Link to release: https://github.com/awslabs/aws-crt-swift/releases/tag/v0.40.0


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.