### PR TITLE
chore: Repo sync GH workflow

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,0 +1,25 @@
+name: Sync Staging Repo
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout smithy-swift
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Add staging repo as remote
+        run: |
+          git remote add staging-repo https://github.com/awslabs/private-smithy-swift-staging.git
+      - name: Set up auth
+        run: |
+          git config --global url."https://${{ secrets.REPO_SYNC_AUTOMATION_USER_TOKEN }}@github.com".insteadOf "https://github.com"
+      - name: Push changes to staging repo
+        run: |
+          git push staging-repo main


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
1934

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Adds a GitHub workflow that syncs staging repo's main branch with public repo's main branch on either of these conditions:
  - A new commit is made to public repo's main branch
  - It's triggered manually via GitHub UI

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.