### PR TITLE
fix: Fix service name rendered on API reference docs

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ServiceGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ServiceGenerator.kt
@@ -24,6 +24,7 @@ class ServiceGenerator() {
          * Renders the definition of operation, followed by no CR
          */
         fun renderOperationDefinition(
+            serviceName: String,
             model: Model,
             service: ServiceShape,
             symbolProvider: SymbolProvider,
@@ -42,7 +43,7 @@ class ServiceGenerator() {
             val outputShape = opIndex.getOutput(op).get()
             val outputShapeName = symbolProvider.toSymbol(outputShape).name
 
-            renderOperationDoc(model, service, op, writer)
+            renderOperationDoc(serviceName, model, service, op, writer)
 
             val accessSpecifier = if (insideProtocol) "" else "public "
 
@@ -58,8 +59,14 @@ class ServiceGenerator() {
         /**
          * Helper method for generating in-line documentation for operation
          */
-        private fun renderOperationDoc(model: Model, service: ServiceShape, op: OperationShape, writer: SwiftWriter) {
-            writer.writeDocs("Performs the \\`${op.id.name}\\` operation on the \\`${service.id.name}\\` service.")
+        private fun renderOperationDoc(
+            serviceName: String,
+            model: Model,
+            service: ServiceShape,
+            op: OperationShape,
+            writer: SwiftWriter
+        ) {
+            writer.writeDocs("Performs the \\`${op.id.name}\\` operation on the \\`${serviceName}\\` service.")
             writer.writeDocs("")
             writer.writeShapeDocs(op)
             writer.writeAvailableAttribute(model, op)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolClientGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolClientGenerator.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.swift.codegen.middleware.MiddlewareExecutionGenera
 import software.amazon.smithy.swift.codegen.middleware.OperationMiddleware
 import software.amazon.smithy.swift.codegen.model.toUpperCamelCase
 import software.amazon.smithy.swift.codegen.swiftmodules.SmithyTypes
+import software.amazon.smithy.swift.codegen.utils.toUpperCamelCase
 
 /**
  * Renders an implementation of a service interface for HTTP protocol
@@ -46,7 +47,8 @@ open class HttpProtocolClientGenerator(
 
         writer.openBlock("extension \$L {", "}", serviceSymbol.name) {
             operations.forEach {
-                ServiceGenerator.renderOperationDefinition(model, serviceShape, symbolProvider, writer, operationsIndex, it)
+                val serviceName = ctx.settings.sdkId.toUpperCamelCase()
+                ServiceGenerator.renderOperationDefinition(serviceName, model, serviceShape, symbolProvider, writer, operationsIndex, it)
                 writer.openBlock(" {", "}") {
                     val operationStackName = "operation"
                     val generator = MiddlewareExecutionGenerator(ctx, writer, httpBindingResolver, httpProtocolCustomizable, operationMiddleware, operationStackName)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
- https://github.com/awslabs/aws-sdk-swift/issues/1849

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Fixes where the name for the service in operation docs in API reference doc is sourced from 


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.