### PR TITLE
fix: Proper formatting of generated structures

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/StructureGenerator.kt
@@ -143,7 +143,8 @@ class StructureGenerator(
         val hasMembers = membersSortedByName.isNotEmpty()
 
         if (hasMembers) {
-            writer.openBlock("public init(", ")") {
+            writer.write("public init(")
+            writer.indent {
                 for ((index, member) in membersSortedByName.withIndex()) {
                     val (memberName, memberSymbol) = memberShapeDataContainer.getOrElse(member) { Pair(null, null) }
                     if (memberName == null || memberSymbol == null) continue
@@ -151,13 +152,15 @@ class StructureGenerator(
                     writer.write("\$L: \$D$terminator", memberName, memberSymbol)
                 }
             }
-            writer.openBlock("{", "}") {
+            writer.write(") {")
+            writer.indent {
                 val path = "properties.".takeIf { error } ?: ""
                 membersSortedByName.forEach {
                     val (memberName, _) = memberShapeDataContainer.getOrElse(it) { return@forEach }
                     writer.write("self.$path\$L = \$L", memberName, memberName)
                 }
             }
+            writer.write("}")
         } else {
             writer.write("public init() { }")
         }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/ServiceRenamesTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/ServiceRenamesTests.kt
@@ -27,8 +27,7 @@ public struct MyTestOperationInput: Swift.Sendable {
 
     public init(
         bar: ExampleClientTypes.RenamedGreeting? = nil
-    )
-    {
+    ) {
         self.bar = bar
     }
 }
@@ -54,8 +53,7 @@ public struct MyTestOperationOutput: Swift.Sendable {
 
     public init(
         baz: ExampleClientTypes.GreetingStruct? = nil
-    )
-    {
+    ) {
         self.baz = baz
     }
 }
@@ -83,8 +81,7 @@ extension ExampleClientTypes {
 
         public init(
             hi: Swift.String? = nil
-        )
-        {
+        ) {
             self.hi = hi
         }
     }
@@ -113,8 +110,7 @@ extension ExampleClientTypes {
 
         public init(
             salutation: Swift.String? = nil
-        )
-        {
+        ) {
             self.salutation = salutation
         }
     }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/basicshapes/StructEncodeGenerationIsolatedTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/basicshapes/StructEncodeGenerationIsolatedTests.kt
@@ -46,8 +46,7 @@ public struct EnumInputInput: Swift.Sendable {
     public init(
         enumHeader: ExampleClientTypes.MyEnum? = nil,
         nestedWithEnum: ExampleClientTypes.NestedEnum? = nil
-    )
-    {
+    ) {
         self.enumHeader = enumHeader
         self.nestedWithEnum = nestedWithEnum
     }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/basicshapes/StructureGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/basicshapes/StructureGeneratorTests.kt
@@ -55,8 +55,7 @@ public struct MyStruct: Swift.Sendable {
         bar: Swift.Int = 0,
         baz: Swift.Int? = nil,
         foo: Swift.String? = nil
-    )
-    {
+    ) {
         self.bar = bar
         self.baz = baz
         self.foo = foo
@@ -110,8 +109,7 @@ public struct PrimitiveTypesInput: Swift.Sendable {
         primitiveShortVal: Swift.Int16 = 0,
         shortVal: Swift.Int16? = nil,
         str: Swift.String? = nil
-    )
-    {
+    ) {
         self.booleanVal = booleanVal
         self.byteVal = byteVal
         self.doubleVal = doubleVal
@@ -154,8 +152,7 @@ public struct RecursiveShapesInputOutputNested1: Swift.Sendable {
     public init(
         foo: Swift.String? = nil,
         nested: RecursiveShapesInputOutputNested2? = nil
-    )
-    {
+    ) {
         self.foo = foo
         self.nested = nested
     }
@@ -168,8 +165,7 @@ public struct RecursiveShapesInputOutputNested2: Swift.Sendable {
     public init(
         bar: Swift.String? = nil,
         recursiveMember: RecursiveShapesInputOutputNested1? = nil
-    )
-    {
+    ) {
         self.bar = bar
         self.recursiveMember = recursiveMember
     }
@@ -181,8 +177,7 @@ public struct RecursiveShapesInputOutput: Swift.Sendable {
 
     public init(
         nested: RecursiveShapesInputOutputNested1? = nil
-    )
-    {
+    ) {
         self.nested = nested
     }
 }
@@ -211,8 +206,7 @@ public struct RecursiveShapesInputOutputNestedList1: Swift.Sendable {
     public init(
         foo: Swift.String? = nil,
         recursiveList: [RecursiveShapesInputOutputNested2]? = nil
-    )
-    {
+    ) {
         self.foo = foo
         self.recursiveList = recursiveList
     }
@@ -225,8 +219,7 @@ public struct RecursiveShapesInputOutputNested2: Swift.Sendable {
     public init(
         bar: Swift.String? = nil,
         recursiveMember: RecursiveShapesInputOutputNested1? = nil
-    )
-    {
+    ) {
         self.bar = bar
         self.recursiveMember = recursiveMember
     }
@@ -238,8 +231,7 @@ public struct RecursiveShapesInputOutputLists: Swift.Sendable {
 
     public init(
         nested: RecursiveShapesInputOutputNested1? = nil
-    )
-    {
+    ) {
         self.nested = nested
     }
 }
@@ -282,8 +274,7 @@ public struct MyError: ClientRuntime.ModeledError, ClientRuntime.ServiceError, C
     public init(
         baz: Swift.Int? = nil,
         message: Swift.String? = nil
-    )
-    {
+    ) {
         self.properties.baz = baz
         self.properties.message = message
     }
@@ -333,8 +324,7 @@ public struct JsonListsInput: Swift.Sendable {
         stringList: [Swift.String]? = nil,
         stringSet: Swift.Set<Swift.String>? = nil,
         timestampList: [Foundation.Date]? = nil
-    )
-    {
+    ) {
         self.booleanList = booleanList
         self.integerList = integerList
         self.nestedStringList = nestedStringList
@@ -382,8 +372,7 @@ public struct JsonMapsInput: Swift.Sendable {
         sparseNumberMap: [Swift.String: Swift.Int?]? = nil,
         sparseStringMap: [Swift.String: Swift.String?]? = nil,
         sparseStructMap: [Swift.String: ExampleClientTypes.GreetingStruct?]? = nil
-    )
-    {
+    ) {
         self.denseBooleanMap = denseBooleanMap
         self.denseNumberMap = denseNumberMap
         self.denseStringMap = denseStringMap
@@ -420,8 +409,7 @@ public struct JsonMapsOutput: Swift.Sendable {
         sparseNumberMap: [Swift.String: Swift.Int?]? = nil,
         sparseStringMap: [Swift.String: Swift.String?]? = nil,
         sparseStructMap: [Swift.String: ExampleClientTypes.GreetingStruct?]? = nil
-    )
-    {
+    ) {
         self.denseBooleanMap = denseBooleanMap
         self.denseNumberMap = denseNumberMap
         self.denseStringMap = denseStringMap

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/codegencomponents/RecursiveShapeBoxerTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/codegencomponents/RecursiveShapeBoxerTests.kt
@@ -57,8 +57,7 @@ public struct RecursiveShapesInput: Swift.Sendable {
 
     public init(
         nested: ExampleClientTypes.RecursiveShapesInputOutputNested1? = nil
-    )
-    {
+    ) {
         self.nested = nested
     }
 }
@@ -74,8 +73,7 @@ public struct RecursiveShapesOutput: Swift.Sendable {
 
     public init(
         nested: ExampleClientTypes.RecursiveShapesInputOutputNested1? = nil
-    )
-    {
+    ) {
         self.nested = nested
     }
 }
@@ -95,8 +93,7 @@ extension ExampleClientTypes {
         public init(
             foo: Swift.String? = nil,
             nested: ExampleClientTypes.RecursiveShapesInputOutputNested2? = nil
-        )
-        {
+        ) {
             self.foo = foo
             self.nested = nested
         }
@@ -116,8 +113,7 @@ extension ExampleClientTypes {
         public init(
             bar: Swift.String? = nil,
             recursiveMember: ExampleClientTypes.RecursiveShapesInputOutputNested1? = nil
-        )
-        {
+        ) {
             self.bar = bar
             self.recursiveMember = recursiveMember
         }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolspecificserde/awsjson11/NestedListEncodeJSONGenerationTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolspecificserde/awsjson11/NestedListEncodeJSONGenerationTests.kt
@@ -26,8 +26,7 @@ public struct ListOfMapsOperationInput: Swift.Sendable {
 
     public init(
         targetMaps: [[Swift.String: [Swift.String]]]? = nil
-    )
-    {
+    ) {
         self.targetMaps = targetMaps
     }
 }


### PR DESCRIPTION
## Description of changes
Fixes formatting of generated structures so that the closing parenthesis of the `init` params and the opening curly brace of the `init` body are on the same line.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.