### PR TITLE
fix!: Remove mutating 'addInterceptor' methods from client config

### DIFF
--- a/Sources/ClientRuntime/Config/DefaultClientConfiguration.swift
+++ b/Sources/ClientRuntime/Config/DefaultClientConfiguration.swift
@@ -31,10 +31,5 @@ public protocol DefaultClientConfiguration: ClientConfiguration {
     /// If none is provided, only a default logger provider will be used.
     var telemetryProvider: TelemetryProvider { get set }
 
-    /// Adds an `InterceptorProvider` that will be used to provide interceptors for all operations.
-    ///
-    /// - Parameter provider: The `InterceptorProvider` to add.
-    func addInterceptorProvider(_ provider: InterceptorProvider)
-
     /// TODO(plugins): Add Checksum, etc.
 }

--- a/Sources/ClientRuntime/Config/DefaultHttpClientConfiguration.swift
+++ b/Sources/ClientRuntime/Config/DefaultHttpClientConfiguration.swift
@@ -35,9 +35,4 @@ public protocol DefaultHttpClientConfiguration: ClientConfiguration {
     ///
     /// Default resolver will look for the token in the `~/.aws/sso/cache` directory.
     var bearerTokenIdentityResolver: any BearerTokenIdentityResolver { get set }
-
-    /// Adds a `HttpInterceptorProvider` that will be used to provide interceptors for all HTTP operations.
-    ///
-    /// - Parameter provider: The `HttpInterceptorProvider` to add.
-    func addInterceptorProvider(_ provider: HttpInterceptorProvider)
 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftWriter.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftWriter.kt
@@ -106,6 +106,8 @@ class SwiftWriter(
 
     fun addImport(symbol: Symbol) {
         symbol.references.forEach { addImport(it.symbol) }
+        val additionalImports = symbol.getProperty("additionalImports").getOrElse { emptyList<Symbol>() } as List<Symbol>
+        additionalImports.forEach { addImport(it) }
         if (symbol.isBuiltIn || symbol.isServiceNestedNamespace || symbol.namespace.isEmpty()) return
         val spiNames = symbol.getProperty("spiNames").getOrElse { emptyList<String>() } as List<String>
         val decl = symbol.getProperty("decl").getOrNull()?.toString()
@@ -127,8 +129,6 @@ class SwiftWriter(
             addImport(symbol.namespace, internalSPINames = spiNames)
         }
         symbol.dependencies.forEach { addDependency(it) }
-        val additionalImports = symbol.getProperty("additionalImports").getOrElse { emptyList<Symbol>() } as List<Symbol>
-        additionalImports.forEach { addImport(it) }
     }
 
     fun addImport(

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/DefaultClientConfiguration.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/DefaultClientConfiguration.kt
@@ -47,14 +47,4 @@ class DefaultClientConfiguration : ClientConfiguration {
             accessModifier = AccessModifier.PublicPrivateSet
         )
     )
-
-    override fun getMethods(ctx: ProtocolGenerator.GenerationContext): Set<Function> = setOf(
-        Function(
-            name = "addInterceptorProvider",
-            renderBody = { writer -> writer.write("self.interceptorProviders.append(provider)") },
-            parameters = listOf(
-                FunctionParameter.NoLabel("provider", ClientRuntimeTypes.Core.InterceptorProvider)
-            ),
-        )
-    )
 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/DefaultHttpClientConfiguration.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/config/DefaultHttpClientConfiguration.kt
@@ -54,14 +54,4 @@ class DefaultHttpClientConfiguration : ClientConfiguration {
             { it.format("\$N(token: \$N(token: \"\"))", SmithyIdentityTypes.StaticBearerTokenIdentityResolver, SmithyIdentityTypes.BearerTokenIdentity) }
         )
     )
-
-    override fun getMethods(ctx: ProtocolGenerator.GenerationContext): Set<Function> = setOf(
-        Function(
-            name = "addInterceptorProvider",
-            renderBody = { writer -> writer.write("self.httpInterceptorProviders.append(provider)") },
-            parameters = listOf(
-                FunctionParameter.NoLabel("provider", ClientRuntimeTypes.Core.HttpInterceptorProvider)
-            ),
-        )
-    )
 }


### PR DESCRIPTION
## Description of changes
Removes the `addInterceptorProvider` methods from client config for both interceptors & HTTP interceptors.

Interceptors may be added by using the `interceptorProvider` and `httpInterceptorProvider` params on the config initializer.

This is technically a breaking change because it removes a means of adding interceptors to a client config.  Impact is expected to be minimal because (1) customers are likely not providing their own interceptors, and (2) there is an alternate, non-mutating method (described above) to add interceptors.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.