### PR TITLE
fix: Fix FileStream initializer that causes out of memory exception

### DIFF
--- a/Sources/SmithyStreams/FileStream.swift
+++ b/Sources/SmithyStreams/FileStream.swift
@@ -41,7 +41,7 @@ public final class FileStream: Stream, @unchecked Sendable {
     /// Initializes a new `FileStream` instance.
     public init(fileHandle: FileHandle) {
         self.fileHandle = fileHandle
-        self.position = fileHandle.availableData.startIndex
+        self.position = Int(fileHandle.offsetInFile)
     }
 
     /// Reads up to `count` bytes from the stream.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
AWS SDK CI PR: https://github.com/awslabs/aws-sdk-swift/pull/1888

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- If the `FileHandle` provided to `FileStream` initializer points to a large file, say a 5TB file, program crashes due to out of memory exception because the initializer fetches the entire available data of the file just to get the current position of the provided file handle. Instead, just use the `offsetInFile` property.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.