### PR TITLE
fix: Allow customization of HTTP body members per-protocol

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HTTPBindingProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HTTPBindingProtocolGenerator.kt
@@ -24,6 +24,7 @@ import software.amazon.smithy.model.shapes.TimestampShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.ErrorTrait
+import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.model.traits.HttpHeaderTrait
 import software.amazon.smithy.model.traits.HttpLabelTrait
 import software.amazon.smithy.model.traits.HttpPayloadTrait
@@ -68,7 +69,6 @@ import software.amazon.smithy.swift.codegen.model.hasEventStreamMember
 import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.model.isInputEventStream
 import software.amazon.smithy.swift.codegen.model.isOutputEventStream
-import software.amazon.smithy.swift.codegen.model.targetOrSelf
 import software.amazon.smithy.swift.codegen.supportsStreamingAndIsRPC
 import software.amazon.smithy.swift.codegen.swiftmodules.ClientRuntimeTypes
 import software.amazon.smithy.swift.codegen.utils.ModelFileUtils
@@ -76,16 +76,16 @@ import software.amazon.smithy.utils.OptionalUtils
 import java.util.Optional
 import java.util.logging.Logger
 
-private val Shape.isStreaming: Boolean
+val Shape.isEventStreaming: Boolean
     get() = hasTrait<StreamingTrait>() && isUnionShape
 
 /**
  * Checks to see if shape is in the body of the http request
  */
 fun Shape.isInHttpBody(): Boolean {
-    // TODO fix the edge case: a shape which is an operational input (i.e. has members bound to HTTP semantics) could be re-used elsewhere not as an operation input which means everything is in the body
     val hasNoHttpTraitsOutsideOfPayload =
-        !this.hasTrait(HttpLabelTrait::class.java) &&
+        !this.hasTrait(HostLabelTrait::class.java) &&
+            !this.hasTrait(HttpLabelTrait::class.java) &&
             !this.hasTrait(HttpHeaderTrait::class.java) &&
             !this.hasTrait(HttpPrefixHeadersTrait::class.java) &&
             !this.hasTrait(HttpQueryTrait::class.java) &&
@@ -171,19 +171,7 @@ abstract class HTTPBindingProtocolGenerator(
                     .definitionFile(filename)
                     .name(symbolName)
                     .build()
-            var httpBodyMembers =
-                shape
-                    .members()
-                    .filter { it.isInHttpBody() }
-                    .toList()
-            if (supportsStreamingAndIsRPC(ctx.protocol)) {
-                // For RPC protocols that support event streaming, we need to send initial request
-                // with streaming member excluded during encoding the input struct.
-                httpBodyMembers =
-                    httpBodyMembers.filter {
-                        !it.targetOrSelf(ctx.model).isStreaming
-                    }
-            }
+            val httpBodyMembers = httpBodyMembers(ctx, shape)
             if (httpBodyMembers.isNotEmpty() || shouldRenderEncodableConformance) {
                 ctx.delegator.useShapeWriter(encodeSymbol) { writer ->
                     writer.openBlock(
@@ -208,7 +196,7 @@ abstract class HTTPBindingProtocolGenerator(
     override fun generateCodableConformanceForNestedTypes(ctx: ProtocolGenerator.GenerationContext) {
         val nestedShapes =
             resolveShapesNeedingCodableConformance(ctx)
-                .filter { !it.isStreaming }
+                .filter { !it.isEventStreaming }
         for (shape in nestedShapes) {
             renderCodableExtension(ctx, shape)
         }
@@ -567,6 +555,11 @@ abstract class HTTPBindingProtocolGenerator(
             messageUnmarshallableGenerator.render(streamingMember)
         }
     }
+
+    abstract fun httpBodyMembers(
+        ctx: ProtocolGenerator.GenerationContext,
+        shape: Shape,
+    ): List<MemberShape>
 }
 
 class DefaultServiceConfig(

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HTTPBindingProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HTTPBindingProtocolGenerator.kt
@@ -24,7 +24,6 @@ import software.amazon.smithy.model.shapes.TimestampShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.ErrorTrait
-import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.model.traits.HttpHeaderTrait
 import software.amazon.smithy.model.traits.HttpLabelTrait
 import software.amazon.smithy.model.traits.HttpPayloadTrait
@@ -84,8 +83,7 @@ val Shape.isEventStreaming: Boolean
  */
 fun Shape.isInHttpBody(): Boolean {
     val hasNoHttpTraitsOutsideOfPayload =
-        !this.hasTrait(HostLabelTrait::class.java) &&
-            !this.hasTrait(HttpLabelTrait::class.java) &&
+        !this.hasTrait(HttpLabelTrait::class.java) &&
             !this.hasTrait(HttpHeaderTrait::class.java) &&
             !this.hasTrait(HttpPrefixHeadersTrait::class.java) &&
             !this.hasTrait(HttpQueryTrait::class.java) &&

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/protocols/rpcv2cbor/RpcV2CborProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/protocols/rpcv2cbor/RpcV2CborProtocolGenerator.kt
@@ -5,7 +5,6 @@ import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.model.traits.StreamingTrait
 import software.amazon.smithy.model.traits.UnitTypeTrait
 import software.amazon.smithy.protocol.traits.Rpcv2CborTrait
@@ -98,9 +97,6 @@ class RpcV2CborProtocolGenerator(
     ): List<MemberShape> =
         shape
             .members()
-            // The only place an input member can be bound to in RPCV2CBOR other than the body
-            // is the host prefix, using the host label trait.
-            .filter { !it.hasTrait<HostLabelTrait>() }
             .toList()
 
     /**

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/protocols/rpcv2cbor/RpcV2CborProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/protocols/rpcv2cbor/RpcV2CborProtocolGenerator.kt
@@ -1,8 +1,11 @@
 package software.amazon.smithy.swift.codegen.protocols.rpcv2cbor
 
 import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.model.traits.StreamingTrait
 import software.amazon.smithy.model.traits.UnitTypeTrait
 import software.amazon.smithy.protocol.traits.Rpcv2CborTrait
@@ -88,6 +91,17 @@ class RpcV2CborProtocolGenerator(
             operationMiddleware.appendMiddleware(operation, ContentLengthMiddleware(ctx.model, true, false, false))
         }
     }
+
+    override fun httpBodyMembers(
+        ctx: ProtocolGenerator.GenerationContext,
+        shape: Shape,
+    ): List<MemberShape> =
+        shape
+            .members()
+            // The only place an input member can be bound to in RPCV2CBOR other than the body
+            // is the host prefix, using the host label trait.
+            .filter { !it.hasTrait<HostLabelTrait>() }
+            .toList()
 
     /**
      * @return whether the operation input does _not_ target the unit shape ([UnitTypeTrait.UNIT])

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPAWSJson11ProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPAWSJson11ProtocolGenerator.kt
@@ -11,7 +11,6 @@ import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.model.traits.HttpTrait
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.integration.DefaultHTTPProtocolCustomizations
@@ -24,7 +23,6 @@ import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResp
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.isEventStreaming
 import software.amazon.smithy.swift.codegen.integration.protocols.core.StaticHttpBindingResolver
-import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.model.targetOrSelf
 import software.amazon.smithy.swift.codegen.requestandresponse.TestHttpProtocolClientGeneratorFactory
 
@@ -100,9 +98,6 @@ class MockHTTPAWSJson11ProtocolGenerator : HTTPBindingProtocolGenerator(MockAWSJ
     ): List<MemberShape> =
         shape
             .members()
-            // The only place an input member can be bound to in AWS JSON other than the body
-            // is the host prefix, using the host label trait.
-            .filter { !it.hasTrait<HostLabelTrait>() }
             // For RPC protocols that support event streaming, we need to send initial request
             // with streaming member excluded during encoding the input struct.
             .filter { !it.targetOrSelf(ctx.model).isEventStreaming }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPEC2QueryProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPEC2QueryProtocolGenerator.kt
@@ -11,7 +11,6 @@ import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.model.traits.HttpTrait
 import software.amazon.smithy.swift.codegen.integration.DefaultHTTPProtocolCustomizations
 import software.amazon.smithy.swift.codegen.integration.HTTPBindingProtocolGenerator
@@ -22,7 +21,6 @@ import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestRequ
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.protocols.core.StaticHttpBindingResolver
-import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.requestandresponse.TestHttpProtocolClientGeneratorFactory
 
 class MockEC2QueryHTTPProtocolCustomizations : DefaultHTTPProtocolCustomizations()
@@ -88,8 +86,5 @@ class MockHTTPEC2QueryProtocolGenerator : HTTPBindingProtocolGenerator(MockEC2Qu
     ): List<MemberShape> =
         shape
             .members()
-            // The only place an input member can be bound to in EC2Query other than the body
-            // is the host prefix, using the host label trait.
-            .filter { !it.hasTrait<HostLabelTrait>() }
             .toList()
 }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPEC2QueryProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPEC2QueryProtocolGenerator.kt
@@ -7,8 +7,11 @@ package software.amazon.smithy.swift.codegen.protocolgeneratormocks
 
 import software.amazon.smithy.aws.traits.protocols.Ec2QueryTrait
 import software.amazon.smithy.model.pattern.UriPattern
+import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.model.traits.HttpTrait
 import software.amazon.smithy.swift.codegen.integration.DefaultHTTPProtocolCustomizations
 import software.amazon.smithy.swift.codegen.integration.HTTPBindingProtocolGenerator
@@ -19,6 +22,7 @@ import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestRequ
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.protocols.core.StaticHttpBindingResolver
+import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.requestandresponse.TestHttpProtocolClientGeneratorFactory
 
 class MockEC2QueryHTTPProtocolCustomizations : DefaultHTTPProtocolCustomizations()
@@ -77,4 +81,15 @@ class MockHTTPEC2QueryProtocolGenerator : HTTPBindingProtocolGenerator(MockEC2Qu
             getProtocolHttpBindingResolver(ctx, defaultContentType),
         ).generateProtocolTests()
     }
+
+    override fun httpBodyMembers(
+        ctx: ProtocolGenerator.GenerationContext,
+        shape: Shape,
+    ): List<MemberShape> =
+        shape
+            .members()
+            // The only place an input member can be bound to in EC2Query other than the body
+            // is the host prefix, using the host label trait.
+            .filter { !it.hasTrait<HostLabelTrait>() }
+            .toList()
 }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPRPCv2CBORProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPRPCv2CBORProtocolGenerator.kt
@@ -5,8 +5,11 @@ package software.amazon.smithy.swift.codegen.protocolgeneratormocks
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.protocol.traits.Rpcv2CborTrait
 import software.amazon.smithy.swift.codegen.integration.DefaultHTTPProtocolCustomizations
 import software.amazon.smithy.swift.codegen.integration.HTTPBindingProtocolGenerator
@@ -15,6 +18,7 @@ import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestErro
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestRequestGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
+import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.requestandresponse.TestHttpProtocolClientGeneratorFactory
 
 class MockRPCv2CBORProtocolCustomizations : DefaultHTTPProtocolCustomizations()
@@ -53,4 +57,15 @@ class MockHTTPRPCv2CBORProtocolGenerator : HTTPBindingProtocolGenerator(MockRPCv
             getProtocolHttpBindingResolver(ctx, defaultContentType),
         ).generateProtocolTests()
     }
+
+    override fun httpBodyMembers(
+        ctx: ProtocolGenerator.GenerationContext,
+        shape: Shape,
+    ): List<MemberShape> =
+        shape
+            .members()
+            // The only place an input member can be bound to in RPCV2CBOR other than the body
+            // is the host prefix, using the host label trait.
+            .filter { !it.hasTrait<HostLabelTrait>() }
+            .toList()
 }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPRPCv2CBORProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPRPCv2CBORProtocolGenerator.kt
@@ -9,7 +9,6 @@ import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.protocol.traits.Rpcv2CborTrait
 import software.amazon.smithy.swift.codegen.integration.DefaultHTTPProtocolCustomizations
 import software.amazon.smithy.swift.codegen.integration.HTTPBindingProtocolGenerator
@@ -18,7 +17,6 @@ import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestErro
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestRequestGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.requestandresponse.TestHttpProtocolClientGeneratorFactory
 
 class MockRPCv2CBORProtocolCustomizations : DefaultHTTPProtocolCustomizations()
@@ -64,8 +62,5 @@ class MockHTTPRPCv2CBORProtocolGenerator : HTTPBindingProtocolGenerator(MockRPCv
     ): List<MemberShape> =
         shape
             .members()
-            // The only place an input member can be bound to in RPCV2CBOR other than the body
-            // is the host prefix, using the host label trait.
-            .filter { !it.hasTrait<HostLabelTrait>() }
             .toList()
 }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPRestJsonProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPRestJsonProtocolGenerator.kt
@@ -6,7 +6,9 @@ package software.amazon.smithy.swift.codegen.protocolgeneratormocks
  */
 
 import software.amazon.smithy.aws.traits.protocols.RestJson1Trait
+import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.swift.codegen.integration.DefaultHTTPProtocolCustomizations
 import software.amazon.smithy.swift.codegen.integration.HTTPBindingProtocolGenerator
@@ -15,6 +17,7 @@ import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestErro
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestRequestGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
+import software.amazon.smithy.swift.codegen.integration.isInHttpBody
 import software.amazon.smithy.swift.codegen.requestandresponse.TestHttpProtocolClientGeneratorFactory
 
 class MockRestJsonHTTPProtocolCustomizations : DefaultHTTPProtocolCustomizations()
@@ -53,4 +56,13 @@ class MockHTTPRestJsonProtocolGenerator : HTTPBindingProtocolGenerator(MockRestJ
             getProtocolHttpBindingResolver(ctx, defaultContentType),
         ).generateProtocolTests()
     }
+
+    override fun httpBodyMembers(
+        ctx: ProtocolGenerator.GenerationContext,
+        shape: Shape,
+    ): List<MemberShape> =
+        shape
+            .members()
+            .filter { it.isInHttpBody() }
+            .toList()
 }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPRestXMLProtocolGenerator.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/protocolgeneratormocks/MockHTTPRestXMLProtocolGenerator.kt
@@ -6,7 +6,9 @@ package software.amazon.smithy.swift.codegen.protocolgeneratormocks
  */
 
 import software.amazon.smithy.aws.traits.protocols.RestXmlTrait
+import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.swift.codegen.integration.DefaultHTTPProtocolCustomizations
 import software.amazon.smithy.swift.codegen.integration.HTTPBindingProtocolGenerator
@@ -15,6 +17,7 @@ import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestErro
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestRequestGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolUnitTestResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
+import software.amazon.smithy.swift.codegen.integration.isInHttpBody
 import software.amazon.smithy.swift.codegen.requestandresponse.TestHttpProtocolClientGeneratorFactory
 
 class MockRestXMLHTTPProtocolCustomizations : DefaultHTTPProtocolCustomizations()
@@ -53,4 +56,13 @@ class MockHTTPRestXMLProtocolGenerator : HTTPBindingProtocolGenerator(MockRestXM
             getProtocolHttpBindingResolver(ctx, defaultContentType),
         ).generateProtocolTests()
     }
+
+    override fun httpBodyMembers(
+        ctx: ProtocolGenerator.GenerationContext,
+        shape: Shape,
+    ): List<MemberShape> =
+        shape
+            .members()
+            .filter { it.isInHttpBody() }
+            .toList()
 }


### PR DESCRIPTION
## Description of changes
- `HTTPBindingProtocolGenerator` has a new, abstract method `httpBodyMembers()` that can be precisely defined by each Smithy protocol.
- RPCv2CBOR & all the mock protocol generators define this method for their needs.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.