### PR TITLE
chore: Update to aws-crt-swift 0.44.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
     ],
     dependencies: {
         var dependencies: [Package.Dependency] = [
-            .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.43.0"),
+            .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.44.0"),
             .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         ]
         let isDocCEnabled = ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_ENABLE_DOCC"] != nil


### PR DESCRIPTION
## Description of changes
Upgrade aws-crt-swift to [0.44.0](https://github.com/awslabs/aws-crt-swift/releases/tag/v0.44.0)

This version lifts the upper limit on event stream message size from 16MB to 256MB.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.