### PR TITLE
fix: Make default HTTP client provider use the customer-provided config if present

### DIFF
--- a/Sources/ClientRuntime/Config/ClientConfigDefaultsProvider.swift
+++ b/Sources/ClientRuntime/Config/ClientConfigDefaultsProvider.swift
@@ -17,9 +17,11 @@ public typealias RuntimeConfigType
 
 open class ClientConfigDefaultsProvider {
     /// Returns a default `HTTPClient` engine.
-    open class func httpClientEngine() -> HTTPClient {
+    open class func httpClientEngine(
+        _ config: HttpClientConfiguration? = nil
+    ) -> HTTPClient {
         return RuntimeConfigType.makeClient(
-            httpClientConfiguration: RuntimeConfigType.defaultHttpClientConfiguration
+            httpClientConfiguration: config ?? RuntimeConfigType.defaultHttpClientConfiguration
         )
     }
 

--- a/Sources/ClientRuntime/Config/DefaultSDKRuntimeConfiguration.swift
+++ b/Sources/ClientRuntime/Config/DefaultSDKRuntimeConfiguration.swift
@@ -98,9 +98,9 @@ public extension DefaultSDKRuntimeConfiguration {
         let socketTimeout = UInt32(httpClientConfiguration.socketTimeout)
         let config = CRTClientEngineConfig(
             telemetry: httpClientConfiguration.telemetry ?? CRTClientEngine.noOpCrtClientEngineTelemetry,
-          connectTimeoutMs: connectTimeoutMs,
-          crtTlsOptions: httpClientConfiguration.tlsConfiguration as? CRTClientTLSOptions,
-          socketTimeout: socketTimeout
+            connectTimeoutMs: connectTimeoutMs,
+            crtTlsOptions: httpClientConfiguration.tlsConfiguration as? CRTClientTLSOptions,
+            socketTimeout: socketTimeout
         )
         return CRTClientEngine(config: config)
         #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Companion PR: https://github.com/awslabs/aws-sdk-swift/pull/1904

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->


## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Make HTTP client config default provider take in user-provided HTTP client config. Use default config only if user didn't provide any HTTP client config (determined by nil check).
- Also, misc. fix on CRT HTTP client init call indentation.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.