### PR TITLE
chore: Make LogAgent conform to Sendable

### DIFF
--- a/Sources/Smithy/Logging/LogAgent.swift
+++ b/Sources/Smithy/Logging/LogAgent.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-public protocol LogAgent {
+public protocol LogAgent: Sendable {
     /// name of the struct or class where the logger was instantiated from
     var name: String { get }
 

--- a/Sources/Smithy/Logging/LogAgentLevel.swift
+++ b/Sources/Smithy/Logging/LogAgentLevel.swift
@@ -8,7 +8,7 @@
 import Logging
 
 /// Wrapper for Logger.Level; used by LogAgent and SwiftLogger.
-public enum LogAgentLevel: String, Codable, CaseIterable {
+public enum LogAgentLevel: String, Codable, CaseIterable, Sendable {
     case trace
     case debug
     case info

--- a/Tests/ClientRuntimeTests/NetworkingTests/URLSession/FoundationStreamBridgeTests.swift
+++ b/Tests/ClientRuntimeTests/NetworkingTests/URLSession/FoundationStreamBridgeTests.swift
@@ -104,7 +104,7 @@ class FoundationStreamBridgeTests: XCTestCase {
     }
 }
 
-private class TestLogger: LogAgent {
+private class TestLogger: LogAgent, @unchecked Sendable {
     var name: String
 
     var messages: [(level: LogAgentLevel, message: String)] = []

--- a/Tests/ClientRuntimeTests/OrchestratorTests/OrchestratorTests.swift
+++ b/Tests/ClientRuntimeTests/OrchestratorTests/OrchestratorTests.swift
@@ -58,7 +58,7 @@ class OrchestratorTests: XCTestCase {
         }
     }
 
-    class TraceLogger: LogAgent {
+    class TraceLogger: LogAgent, @unchecked Sendable {
         var trace: Trace = Trace()
         var name: String = "TestTraceLogger"
         var level: LogAgentLevel = .debug


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Companion PR: https://github.com/awslabs/aws-sdk-swift/pull/1908

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Make `LogAgent` protocol conform to `Sendable`. This makes `SwiftLogger` struct `Sendable`, removing the need for `@preconcurrency` prefix for import when customers try to use the logger in concurrent context.
- Makes the test logger implementations with @unchecked Sendable; they contain mutable string array that stores logged messages for validating test results. Since tests don't need concurrency safety, just marked as unchecked.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.