### PR TITLE
fix: Fix silent failure with CRT HTTP client when response stream has an error

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
@@ -536,14 +536,11 @@ public class CRTClientEngine: HTTPClient {
             switch result {
             case .success(let statusCode):
                 response.statusCode = makeStatusCode(statusCode)
+                stream.close()
             case .failure(let error):
                 self.logger.error("Response encountered an error: \(error)")
-                continuation.safeResume(error: error)
+                stream.closeWithError(error)
             }
-
-            // closing the stream is required to signal to the caller that the response is complete
-            // and no more data will be received in this stream
-            stream.close()
         }
 
         requestOptions.http2ManualDataWrites = http2ManualDataWrites


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
CI PR in SDK: https://github.com/awslabs/aws-sdk-swift/pull/1919

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Bug found as part of investigating why the integration test in the PR https://github.com/awslabs/aws-sdk-swift/pull/1917 throws an error in CRT HTTP client but doesn't fail the test case.
- Ran the same integ test with the change in this PR and error gets thrown up and fails the test case as expected.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.