### PR TITLE
fix!: Represent TCP port as UInt16

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
@@ -43,7 +43,7 @@ public class CRTClientEngine: HTTPClient {
         private struct ConnectionPoolID: Hashable {
             private let protocolType: URIScheme?
             private let host: String
-            private let port: Int16
+            private let port: UInt16
 
             init(endpoint: Endpoint) {
                 self.protocolType = endpoint.uri.scheme

--- a/Sources/Smithy/URI.swift
+++ b/Sources/Smithy/URI.swift
@@ -11,9 +11,9 @@ public struct URI: Hashable {
     public let scheme: URIScheme
     public let path: String
     public let host: String
-    public let port: Int16?
-    public var defaultPort: Int16 {
-        Int16(scheme.port)
+    public let port: UInt16?
+    public var defaultPort: UInt16 {
+        UInt16(scheme.port)
     }
     public let queryItems: [URIQueryItem]
     public let username: String?
@@ -29,7 +29,7 @@ public struct URI: Hashable {
     fileprivate init(scheme: URIScheme,
                      path: String,
                      host: String,
-                     port: Int16?,
+                     port: UInt16?,
                      queryItems: [URIQueryItem],
                      username: String? = nil,
                      password: String? = nil,
@@ -122,7 +122,7 @@ public final class URIBuilder {
     }
 
     @discardableResult
-    public func withPort(_ value: Int16?) -> URIBuilder {
+    public func withPort(_ value: UInt16?) -> URIBuilder {
         self.urlComponents.port = value.map { Int($0) }
         return self
     }
@@ -209,7 +209,7 @@ public final class URIBuilder {
         return URI(scheme: URIScheme(rawValue: self.urlComponents.scheme!)!,
                    path: self.urlComponents.percentEncodedPath,
                    host: self.urlComponents.percentEncodedHost!,
-                   port: self.urlComponents.port.map { Int16($0) },
+                   port: self.urlComponents.port.map { UInt16($0) },
                    queryItems: self.urlComponents.percentEncodedQueryItems?.map {
                         URIQueryItem(name: $0.name, value: $0.value)
                    } ?? [],

--- a/Sources/SmithyHTTPAPI/Endpoint.swift
+++ b/Sources/SmithyHTTPAPI/Endpoint.swift
@@ -15,7 +15,7 @@ public struct Endpoint: Hashable {
     public var queryItems: [URIQueryItem] { uri.queryItems }
     public var path: String { uri.path }
     public var host: String { uri.host }
-    public var port: Int16? { uri.port }
+    public var port: UInt16? { uri.port }
     public var url: URL? { uri.url }
     private let properties: [String: AnyHashable]
 
@@ -54,7 +54,7 @@ public struct Endpoint: Hashable {
 
     public init(host: String,
                 path: String = "/",
-                port: Int16 = 443,
+                port: UInt16 = 443,
                 queryItems: [URIQueryItem]? = nil,
                 headers: Headers = Headers(),
                 protocolType: URIScheme? = .https) {

--- a/Sources/SmithyHTTPAPI/HTTPRequest.swift
+++ b/Sources/SmithyHTTPAPI/HTTPRequest.swift
@@ -152,7 +152,7 @@ public final class HTTPRequestBuilder: RequestMessageBuilder {
     public private(set) var path: String = "/"
     public private(set) var body: ByteStream = .noStream
     public private(set) var queryItems = [URIQueryItem]()
-    public private(set) var port: Int16?
+    public private(set) var port: UInt16?
     public private(set) var protocolType: URIScheme = .https
     public private(set) var trailingHeaders: Headers = Headers()
 
@@ -242,7 +242,7 @@ public final class HTTPRequestBuilder: RequestMessageBuilder {
     }
 
     @discardableResult
-    public func withPort(_ value: Int16?) -> HTTPRequestBuilder {
+    public func withPort(_ value: UInt16?) -> HTTPRequestBuilder {
         self.port = value
         return self
     }

--- a/Sources/SmithyTestUtil/RequestTestUtil/ExpectedSdkHttpRequest.swift
+++ b/Sources/SmithyTestUtil/RequestTestUtil/ExpectedSdkHttpRequest.swift
@@ -53,7 +53,7 @@ public class ExpectedSdkHttpRequestBuilder {
     var queryItems = [URIQueryItem]()
     var forbiddenQueryItems = [URIQueryItem]()
     var requiredQueryItems = [URIQueryItem]()
-    var port: Int16 = 443
+    var port: UInt16 = 443
     var protocolType: URIScheme = .https
 
     // We follow the convention of returning the builder object
@@ -127,7 +127,7 @@ public class ExpectedSdkHttpRequestBuilder {
     }
 
     @discardableResult
-    public func withPort(_ value: Int16) -> ExpectedSdkHttpRequestBuilder {
+    public func withPort(_ value: UInt16) -> ExpectedSdkHttpRequestBuilder {
         self.port = value
         return self
     }


### PR DESCRIPTION
## Description of changes
[BREAKING] Changes the type for port number from `Int16` to `UInt16`.  TCP port may be from 0-65535 which is beyond the range of `Int16`.

This affects public interfaces for URI, Endpoint, HTTPRequest, and their associated builder types.

The change is breaking because port number is exposed as a property of several public types and parameters to public functions.  The change is being made nonetheless because it is a significant impediment to not allow use of all possible TCP ports.

## Scope
- [x] Breaking bug fix (breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.