### PR TITLE
chore: Bump CRT version to 0.51.0 from 0.48.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
     ],
     dependencies: {
         var dependencies: [Package.Dependency] = [
-            .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.48.0"),
+            .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.51.0"),
             .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         ]
         let isDocCEnabled = ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_ENABLE_DOCC"] != nil

--- a/Sources/SmithyStreams/FileStream.swift
+++ b/Sources/SmithyStreams/FileStream.swift
@@ -140,3 +140,24 @@ public final class FileStream: Stream, @unchecked Sendable {
         close()
     }
 }
+
+fileprivate extension FileHandle {
+    func length() throws -> UInt64 {
+        let length: UInt64
+        let savedPos: UInt64
+        if #available(macOS 11, tvOS 13.4, iOS 13.4, watchOS 6.2, *) {
+            savedPos = try offset()
+            try seekToEnd()
+            length = try offset()
+        } else {
+            savedPos = offsetInFile
+            seekToEndOfFile()
+            length = offsetInFile
+        }
+        guard length != savedPos else {
+            return length
+        }
+        try self.seek(toOffset: savedPos)
+        return length
+    }
+}

--- a/Sources/SmithyStreams/StreamableHttpBody.swift
+++ b/Sources/SmithyStreams/StreamableHttpBody.swift
@@ -109,4 +109,8 @@ public class StreamableHttpBody: IStreamable {
             return nil
         }
     }
+
+    public func isEndOfStream() -> Bool {
+        return false
+    }
 }

--- a/Sources/SmithyStreams/StreamableHttpBody.swift
+++ b/Sources/SmithyStreams/StreamableHttpBody.swift
@@ -111,6 +111,10 @@ public class StreamableHttpBody: IStreamable {
     }
 
     public func isEndOfStream() -> Bool {
-        return false
+        do {
+            return try self.position >= self.length()
+        } catch {
+            return false
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Corresponding aws-sdk-swift PR: https://github.com/awslabs/aws-sdk-swift/pull/1927

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
2819

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- CRT 0.51.0 removes FileHandle's conformance to IStreamable which used to contain 3 methods, one of which is `length()`.  The `length()` function was the only thing we were using; so conformance was removed by CRT and that method is moved to SDK side.
- `isEndOfStream()` is added as corresponding change to CRT-side bug fix. The fix addresses CRT HTTP client issue where it used to send empty frame after every nonempty data frame in HTTP/2 connection.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.