### PR TITLE
fix: Disambiguate .none default values

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/member/MemberShapeDecodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/member/MemberShapeDecodeGenerator.kt
@@ -219,7 +219,7 @@ open class MemberShapeDecodeGenerator(
             }
             // Provide a default value dependent on the type.
             return when (targetShape) {
-                is EnumShape -> " ?? .${enumDefaultValue(targetShape, it.expectStringNode().value)}"
+                is EnumShape -> " ?? ${enumDefaultValue(writer, targetShape, it.expectStringNode().value)}"
                 is IntEnumShape -> intEnumDefaultValue(it)
                 is StringShape -> " ?? \"${it.expectStringNode().value}\""
                 is ByteShape -> " ?? ${it.expectNumberNode().value}"
@@ -250,14 +250,18 @@ open class MemberShapeDecodeGenerator(
     // > enum: can be set to any valid string _value_ of the enum.
     // So, find the member with the default value, then render it as a Swift enum case.
     private fun enumDefaultValue(
+        writer: SwiftWriter,
         enumShape: EnumShape,
         value: String,
     ): String {
-        val matchingMember =
-            enumShape.members().first { member ->
-                value == member.expectTrait<EnumValueTrait>().expectStringValue()
-            }
-        return swiftEnumCaseName(matchingMember.memberName, value)
+        val matchingMember = enumShape.members().first { member ->
+            value == member.expectTrait<EnumValueTrait>().expectStringValue()
+        }
+        return writer.format(
+            "\$N.\$L",
+            ctx.symbolProvider.toSymbol(enumShape),
+            swiftEnumCaseName(matchingMember.memberName, value),
+        )
     }
 
     private fun intEnumDefaultValue(node: Node): String =


### PR DESCRIPTION
## Description of changes
Default values for enum-typed model properties can be ambiguous when the enum includes a case named `.none` because the compiler cannot currently differentiate between the enum's `.none` value and the `Optional.none` value.  To make matters worse, the compiler assumes `Optional.none` is the desired outcome, which is not what we actually want.

To allow the compiler to correctly resolve which `.none` to use, render enum-typed default values with the fully-qualified type name, i.e. render `AWSService.CustomEnum.none` as the default value instead of merely `.none`.  This namespace is added for all enum default values, not exclusively for the ones named `.none`.

This PR affects rendered code for 14 current AWS services, although only one of those has an enum case named `.none`.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.