### PR TITLE
fix: Fix StreamableHttpBody's isEndOfStream bug

### DIFF
--- a/Sources/SmithyStreams/StreamableHttpBody.swift
+++ b/Sources/SmithyStreams/StreamableHttpBody.swift
@@ -111,10 +111,15 @@ public class StreamableHttpBody: IStreamable {
     }
 
     public func isEndOfStream() -> Bool {
-        do {
-            return try self.position >= self.length()
-        } catch {
-            return false
+        switch body {
+        case .data(let data):
+            guard let data = data else { return true }
+            return position >= data.endIndex
+        case .stream(let stream):
+            guard let length = stream.length else { return false }
+            return stream.position >= length
+        case .noStream:
+            return true
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
aws-sdk-swift PR for running integ tests against this change: 
- https://github.com/awslabs/aws-sdk-swift/pull/1935
## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Fixes a bug where chunked streaming Data payload gets cut prematurely due to wrong isEndOfStream implementation

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.