### PR TITLE
fix: Silenced network error in CRTClientEngine onStreamComplete callback

### DIFF
--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
@@ -571,6 +571,7 @@ public class CRTClientEngine: HTTPClient {
             case .failure(let error):
                 self.logger.error("Response encountered an error: \(error)")
                 stream.closeWithError(error)
+                continuation.resume(throwing: error)
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
- https://github.com/awslabs/aws-sdk-swift/issues/1943

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Adds back `continuation.resume(throwing:)` to `onStreamComplete` callback in `CRTClientEngine`. The continuation resumption was removed in this previous PR: https://github.com/smithy-lang/smithy-swift/pull/922. At the time of removal, the logic was that by the time `onStreamComplete` callback is reached, the continuation must have been resumed in the `onResponse` callback since `onResponse` callback gets called as soon as we get headers from the service. But on transient network errors, only the `onStreamComplete` could get called & `onResponse` could be skipped. This causes continuation to never get resumed, silencing error & essentially "freezing" a thread.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.