### PR TITLE
fix: Add NodeInfo struct for SmithyCBOR

### DIFF
--- a/Sources/SmithyCBOR/NodeInfo.swift
+++ b/Sources/SmithyCBOR/NodeInfo.swift
@@ -1,0 +1,24 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public struct NodeInfo: Equatable {
+
+    /// The name for this CBOR node, or an empty string if none.
+    public let name: String
+
+    public init(_ name: String) {
+        self.name = name
+    }
+}
+
+extension NodeInfo: ExpressibleByStringLiteral {
+    public typealias StringLiteralType = String
+
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+}

--- a/Sources/SmithyCBOR/Reader/Reader.swift
+++ b/Sources/SmithyCBOR/Reader/Reader.swift
@@ -18,8 +18,6 @@ import Foundation
 
 @_spi(SmithyReadWrite)
 public final class Reader: SmithyReader {
-    public typealias NodeInfo = String
-
     public let cborValue: CBORType?
     public let nodeInfo: NodeInfo
     public internal(set) var children: [Reader] = []
@@ -49,12 +47,12 @@ public final class Reader: SmithyReader {
         switch cborValue {
         case .map(let map):
             for (key, value) in map {
-                let child = Reader(nodeInfo: key, cborValue: value, parent: parent)
+                let child = Reader(nodeInfo: .init(key), cborValue: value, parent: parent)
                 children.append(child)
             }
         case .array(let array):
             for (index, value) in array.enumerated() {
-                let child = Reader(nodeInfo: "\(index)", cborValue: value, parent: parent)
+                let child = Reader(nodeInfo: .init("\(index)"), cborValue: value, parent: parent)
                 children.append(child)
             }
         default:
@@ -190,7 +188,7 @@ public final class Reader: SmithyReader {
         guard case .map(let map) = cborValue else { return nil }
         var dict = [String: Value]()
         for (key, _) in map {
-            let reader = self[key]
+            let reader = self[.init(key)]
             do {
                 let value = try valueReadingClosure(reader)
                 dict[key] = value

--- a/Sources/SmithyCBOR/Writer/Writer.swift
+++ b/Sources/SmithyCBOR/Writer/Writer.swift
@@ -18,8 +18,6 @@ import Foundation
 
 @_spi(SmithyReadWrite)
 public final class Writer: SmithyWriter {
-    public typealias NodeInfo = String
-
     let nodeInfo: NodeInfo
     var cborValue: CBORType?
     var children: [Writer] = []
@@ -52,7 +50,7 @@ public final class Writer: SmithyWriter {
                 guard !(child.cborValue == nil && child.children.isEmpty) else {
                     continue
                 }
-                encoder.encode(.text(child.nodeInfo)) // Key for the child
+                encoder.encode(.text(child.nodeInfo.name)) // Key for the child
 
                 if let cborValue = child.cborValue {
                     encoder.encode(cborValue) // Encode the value directly
@@ -159,7 +157,7 @@ public final class Writer: SmithyWriter {
         guard let value else { return }
         var map: [String: CBORType] = [:]
         for (key, val) in value {
-            let writer = self[key]
+            let writer = self[.init(key)]
             try valueWritingClosure(val, writer)
 
             if let cborValue = extractCBORValue(from: writer) {
@@ -202,7 +200,7 @@ public final class Writer: SmithyWriter {
             var childMap: [String: CBORType] = [:]
             for child in writer.children {
                 if let childValue = extractCBORValue(from: child) {
-                    childMap[child.nodeInfo] = childValue
+                    childMap[child.nodeInfo.name] = childValue
                 }
             }
             // Return a map if any children provided a value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Change the type of `nodeInfo` property in SmithyCBOR reader & writer, from `String` to a new `NodeInfo` struct.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.