### PR TITLE
fix: ANY_STRING_EQUALS waiter matcher match on one string

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/waiters/WaiterAcceptorGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/waiters/WaiterAcceptorGenerator.kt
@@ -124,7 +124,7 @@ class WaiterAcceptorGenerator(
                 )
             PathComparator.ALL_STRING_EQUALS ->
                 writer.write(
-                    "return (\$L?.count ?? 0) > 1 && (\$L?.allSatisfy { \$N.compare($$0, ==, \$S) } ?? false)",
+                    "return (\$L?.count ?? 0) >= 1 && (\$L?.allSatisfy { \$N.compare($$0, ==, \$S) } ?? false)",
                     actual.name,
                     actual.name,
                     SmithyWaitersAPITypes.JMESUtils,


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1981

## Description of changes
Fixes a bug where the `ALL_STRING_EQUALS` string matcher fails when there is one element in a list of Strings.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.