### PR TITLE
fix: authSchemePreference in config + remove from default resolver

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/AuthSchemeResolverGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/AuthSchemeResolverGenerator.kt
@@ -186,7 +186,7 @@ class AuthSchemeResolverGenerator(
                 // Render switch block
                 renderSwitchBlock(serviceIndex, ctx, writer)
                 // Call reprioritizeAuthOptions and return result
-                write("return self.reprioritizeAuthOptions(authSchemePreference: authSchemePreference, authOptions: validAuthOptions)")
+                write("return self.reprioritizeAuthOptions(authSchemePreference: serviceParams.authSchemePreference, authOptions: validAuthOptions)")
             }
         }
     }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/AuthSchemeResolverGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/AuthSchemeResolverGenerator.kt
@@ -54,6 +54,7 @@ class AuthSchemeResolverGenerator(
                 "}",
                 SmithyHTTPAuthAPITypes.AuthSchemeResolverParams,
             ) {
+                writer.write("public let authSchemePreference: \$N?", SwiftTypes.StringList)
                 write("public let operation: \$N", SwiftTypes.String)
 
                 if (usesRulesBasedAuthResolver(ctx)) {
@@ -147,8 +148,6 @@ class AuthSchemeResolverGenerator(
                 serviceSpecificAuthResolverProtocol,
             ) {
                 write("")
-                renderInit(writer)
-                write("")
                 renderResolveAuthSchemeMethod(serviceIndex, ctx, writer)
                 write("")
                 renderConstructParametersMethod(
@@ -156,19 +155,6 @@ class AuthSchemeResolverGenerator(
                     ctx,
                     writer,
                 )
-            }
-        }
-    }
-
-    private fun renderInit(writer: SwiftWriter) {
-        writer.apply {
-            write("public let authSchemePreference: [String]")
-            write("")
-            openBlock(
-                "public init(authSchemePreference: [String] = []) {",
-                "}",
-            ) {
-                write("self.authSchemePreference = authSchemePreference")
             }
         }
     }
@@ -317,12 +303,13 @@ class AuthSchemeResolverGenerator(
                             SmithyTypes.ClientError,
                         )
                     }
+                    writer.write("let authSchemePreference = context.getAuthSchemePreference()")
                     val paramType = getSdkId(ctx) + SmithyHTTPAuthAPITypes.AuthSchemeResolverParams.name
                     if (hasSigV4) {
                         write("let opRegion = context.getRegion()")
-                        write("return $paramType(operation: opName, region: opRegion)")
+                        write("return $paramType(authSchemePreference: authSchemePreference, operation: opName, region: opRegion)")
                     } else {
-                        write("return $paramType(operation: opName)")
+                        write("return $paramType(authSchemePreference: authSchemePreference, operation: opName)")
                     }
                 }
             }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/AuthSchemeResolverGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/AuthSchemeResolverGenerator.kt
@@ -186,7 +186,9 @@ class AuthSchemeResolverGenerator(
                 // Render switch block
                 renderSwitchBlock(serviceIndex, ctx, writer)
                 // Call reprioritizeAuthOptions and return result
-                write("return self.reprioritizeAuthOptions(authSchemePreference: serviceParams.authSchemePreference, authOptions: validAuthOptions)")
+                write(
+                    "return self.reprioritizeAuthOptions(authSchemePreference: serviceParams.authSchemePreference, authOptions: validAuthOptions)",
+                )
             }
         }
     }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/requestflow/AuthSchemeResolverGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/requestflow/AuthSchemeResolverGeneratorTests.kt
@@ -105,7 +105,7 @@ public struct DefaultExampleAuthSchemeResolver: ExampleAuthSchemeResolver {
         guard let opName = context.getOperation() else {
             throw Smithy.ClientError.dataNotFound("Operation name not configured in middleware context for auth scheme resolver params construction.")
         }
-        authSchemePreference: authSchemePreference,
+        let authSchemePreference = context.getAuthSchemePreference()
         let opRegion = context.getRegion()
         return ExampleAuthSchemeResolverParameters(authSchemePreference: authSchemePreference, operation: opName, region: opRegion)
     }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/requestflow/AuthSchemeResolverGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/requestflow/AuthSchemeResolverGeneratorTests.kt
@@ -21,6 +21,7 @@ class AuthSchemeResolverGeneratorTests {
         contents.shouldSyntacticSanityCheck()
         val expected = """
 public struct ExampleAuthSchemeResolverParameters: SmithyHTTPAuthAPI.AuthSchemeResolverParameters {
+    public let authSchemePreference: [String]?
     public let operation: Swift.String
     // Region is used for SigV4 auth scheme
     public let region: Swift.String?
@@ -33,12 +34,6 @@ public protocol ExampleAuthSchemeResolver: SmithyHTTPAuthAPI.AuthSchemeResolver 
 }
 
 public struct DefaultExampleAuthSchemeResolver: ExampleAuthSchemeResolver {
-
-    public let authSchemePreference: [String]
-
-    public init(authSchemePreference: [String] = []) {
-        self.authSchemePreference = authSchemePreference
-    }
 
     public func resolveAuthScheme(params: SmithyHTTPAuthAPI.AuthSchemeResolverParameters) throws -> [SmithyHTTPAuthAPI.AuthOption] {
         var validAuthOptions = [SmithyHTTPAuthAPI.AuthOption]()
@@ -110,8 +105,9 @@ public struct DefaultExampleAuthSchemeResolver: ExampleAuthSchemeResolver {
         guard let opName = context.getOperation() else {
             throw Smithy.ClientError.dataNotFound("Operation name not configured in middleware context for auth scheme resolver params construction.")
         }
+        authSchemePreference: authSchemePreference,
         let opRegion = context.getRegion()
-        return ExampleAuthSchemeResolverParameters(operation: opName, region: opRegion)
+        return ExampleAuthSchemeResolverParameters(authSchemePreference: authSchemePreference, operation: opName, region: opRegion)
     }
 }
 """

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/requestflow/AuthSchemeResolverGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/requestflow/AuthSchemeResolverGeneratorTests.kt
@@ -98,7 +98,7 @@ public struct DefaultExampleAuthSchemeResolver: ExampleAuthSchemeResolver {
                 sigv4Option.signingProperties.set(key: SmithyHTTPAuthAPI.SigningPropertyKeys.signingRegion, value: region)
                 validAuthOptions.append(sigv4Option)
         }
-        return self.reprioritizeAuthOptions(authSchemePreference: authSchemePreference, authOptions: validAuthOptions)
+        return self.reprioritizeAuthOptions(authSchemePreference: serviceParams.authSchemePreference, authOptions: validAuthOptions)
     }
 
     public func constructParameters(context: Smithy.Context) throws -> SmithyHTTPAuthAPI.AuthSchemeResolverParameters {


### PR DESCRIPTION
**Breaking Change**: Removed authSchemePreference from the default auth scheme resolver initializer.
Bug Fix: authSchemePreference will now operate as expected when passed into the service config
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.