### PR TITLE
feat: Add Bedrock API key support

### DIFF
--- a/Sources/SmithyIdentityAPI/Context/Context+AuthSchemePreference.swift
+++ b/Sources/SmithyIdentityAPI/Context/Context+AuthSchemePreference.swift
@@ -16,6 +16,12 @@ extension Context {
     public func getAuthSchemePreference() -> [String]? {
         get(key: authSchemePreferenceKey)
     }
+
+    /// The auth scheme preferences for authenticating this request.
+    public var authSchemePreference: [String]? {
+        get { getAuthSchemePreference() }
+        set { set(key: authSchemePreferenceKey, value: newValue) }
+    }
 }
 
 extension ContextBuilder {

--- a/Sources/SmithyIdentityAPI/Context/Context+IdentityResolver.swift
+++ b/Sources/SmithyIdentityAPI/Context/Context+IdentityResolver.swift
@@ -14,6 +14,12 @@ extension Context {
     public func getIdentityResolvers() -> Attributes? {
         get(key: identityResolversKey)
     }
+
+    public func addIdentityResolver<T: IdentityResolver>(value: T, schemeID: String) {
+        var identityResolvers: Attributes = get(key: identityResolversKey) ?? Attributes()
+        identityResolvers.set(key: AttributeKey<any IdentityResolver>(name: schemeID), value: value)
+        set(key: identityResolversKey, value: identityResolvers)
+    }
 }
 
 extension ContextBuilder {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolServiceClient.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolServiceClient.kt
@@ -84,7 +84,7 @@ open class HttpProtocolServiceClient(
                     val defaultPlugins: MutableList<Plugin> = mutableListOf(DefaultClientPlugin())
 
                     ctx.integrations
-                        .flatMap { it.plugins(serviceConfig) }
+                        .flatMap { it.plugins(ctx, serviceConfig) }
                         .filter { it.isDefault }
                         .onEach { defaultPlugins.add(it) }
 
@@ -273,7 +273,7 @@ open class HttpProtocolServiceClient(
     private fun renderServiceSpecificPlugins() {
         ctx.delegator.useFileWriter("Sources/${ctx.settings.moduleName}/Plugins.swift") { writer ->
             ctx.integrations
-                .flatMap { it.plugins(serviceConfig) }
+                .flatMap { it.plugins(ctx, serviceConfig) }
                 .onEach { it.render(ctx, writer) }
         }
     }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/SwiftIntegration.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/SwiftIntegration.kt
@@ -162,7 +162,7 @@ interface SwiftIntegration : SmithyIntegration<SwiftSettings, SwiftWriter, Gener
     /**
      * Returns a list of default Plugins for configuring client configuration's default properties
      */
-    fun plugins(serviceConfig: ServiceConfig): List<Plugin> = emptyList()
+    fun plugins(ctx: ProtocolGenerator.GenerationContext, serviceConfig: ServiceConfig): List<Plugin> = emptyList()
 
     /**
      * Returns a list of ClientConfiguration protocols to be implemented by the client configuration


### PR DESCRIPTION
## Description of changes
These changes support the addition of Bedrock API Key support in https://github.com/awslabs/aws-sdk-swift/pull/1992
- Add the ability to modify auth scheme preferences and identity resolvers on an existing `Context`.
- Pass generation context into the Plugins generator, to allow the default plugins to vary based on the model being generated.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.