### PR TITLE
chore: Remove package scope property

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/DependencyJSONGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/DependencyJSONGenerator.kt
@@ -8,20 +8,14 @@ import software.amazon.smithy.codegen.core.SymbolDependency
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import kotlin.jvm.optionals.getOrNull
 
-val DEPENDENCY_JSON_NAME = "Dependencies.json"
-
 class DependencyJSONGenerator(
     val ctx: ProtocolGenerator.GenerationContext,
 ) {
     fun writePackageJSON(dependencies: List<SymbolDependency>) {
-        ctx.delegator.useFileWriter(DEPENDENCY_JSON_NAME) { writer ->
+        ctx.delegator.useFileWriter("Dependencies.json") { writer ->
             writer.openBlock("[", "]") {
                 val externalDependencies =
-                    dependencies
-                        .filter {
-                            it.getProperty("url", String::class.java).getOrNull() != null ||
-                                it.getProperty("scope", String::class.java).getOrNull() != null
-                        }
+                    dependencies.filter { it.getProperty("url", String::class.java).getOrNull() != null }
 
                 val dependenciesByTarget =
                     externalDependencies

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/DependencyJSONGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/DependencyJSONGenerator.kt
@@ -6,7 +6,6 @@ package software.amazon.smithy.swift.codegen
 
 import software.amazon.smithy.codegen.core.SymbolDependency
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import kotlin.jvm.optionals.getOrNull
 
 class DependencyJSONGenerator(
     val ctx: ProtocolGenerator.GenerationContext,
@@ -15,19 +14,17 @@ class DependencyJSONGenerator(
         ctx.delegator.useFileWriter("Dependencies.json") { writer ->
             writer.openBlock("[", "]") {
                 val externalDependencies =
-                    dependencies.filter { it.getProperty("url", String::class.java).getOrNull() != null }
+                    dependencies.filter { it.getProperty("url", String::class.java).isPresent }
 
                 val dependenciesByTarget =
                     externalDependencies
-                        .distinctBy { it.targetName() + it.packageName }
-                        .sortedBy { it.targetName() }
+                        .distinctBy { it.targetName + it.packageName }
+                        .sortedBy { it.targetName }
 
-                dependenciesByTarget.forEach { writer.write("\$S,", it.targetName()) }
+                dependenciesByTarget.forEach { writer.write("\$S,", it.targetName) }
                 writer.unwrite(",\n")
                 writer.write("")
             }
         }
     }
 }
-
-private fun SymbolDependency.targetName(): String = expectProperty("target", String::class.java)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
@@ -30,18 +30,12 @@ class PackageManifestGenerator(
                 }
 
                 val externalDependencies =
-                    dependencies
-                        .filter {
-                            it.getProperty("url", String::class.java).getOrNull() != null ||
-                                it.getProperty("scope", String::class.java).getOrNull() != null
-                        }
+                    dependencies.filter { it.getProperty("url", String::class.java).getOrNull() != null }
 
                 val dependenciesByURL =
                     externalDependencies
-                        .distinctBy {
-                            it.getProperty("url", String::class.java).getOrNull()
-                                ?: "${it.getProperty("scope", String::class.java).get()}.${it.packageName}"
-                        }.sortedBy { it.targetName() }
+                        .distinctBy { it.getProperty("url", String::class.java).getOrNull() }
+                        .sortedBy { it.targetName() }
 
                 writer.openBlock("dependencies: [", "],") {
                     dependenciesByURL.forEach { writePackageDependency(writer, it) }
@@ -76,14 +70,8 @@ class PackageManifestGenerator(
         dependency: SymbolDependency,
     ) {
         writer.openBlock(".package(", "),") {
-            val scope = dependency.getProperty("scope", String::class.java).getOrNull()
-            scope?.let {
-                writer.write("id: \$S,", "$it.${dependency.packageName}")
-            }
-            val url = dependency.getProperty("url", String::class.java).getOrNull()
-            url?.let {
-                writer.write("url: \$S,", it)
-            }
+            val url = dependency.getProperty("url", String::class.java).get()
+            writer.write("url: \$S,", url)
             writer.write("exact: \$S", dependency.version)
         }
     }
@@ -93,11 +81,8 @@ class PackageManifestGenerator(
         dependency: SymbolDependency,
     ) {
         writer.openBlock(".product(", "),") {
-            val target = dependency.targetName()
-            writer.write("name: \$S,", target)
-            val scope = dependency.getProperty("scope", String::class.java).getOrNull()
-            val packageName = scope?.let { "$it.${dependency.packageName}" } ?: dependency.packageName
-            writer.write("package: \$S", packageName)
+            writer.write("name: \$S,", dependency.targetName())
+            writer.write("package: \$S", dependency.packageName)
         }
     }
 }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
@@ -86,5 +86,5 @@ class PackageManifestGenerator(
     }
 }
 
-private val SymbolDependency.targetName: String
+val SymbolDependency.targetName: String
     get() = expectProperty("target", String::class.java)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftDependency.kt
@@ -14,13 +14,7 @@ class SwiftDependency(
     private val location: String,
     private val localPath: String,
     override var packageName: String,
-    private val distributionMethod: DistributionMethod,
 ) : Dependency {
-    enum class DistributionMethod {
-        SPR,
-        GIT,
-    }
-
     companion object {
         val NONE =
             SwiftDependency(
@@ -30,7 +24,6 @@ class SwiftDependency(
                 "",
                 "",
                 "",
-                DistributionMethod.GIT,
             )
         val SWIFT =
             SwiftDependency(
@@ -40,7 +33,6 @@ class SwiftDependency(
                 "",
                 "",
                 "",
-                DistributionMethod.GIT,
             )
         val XCTest =
             SwiftDependency(
@@ -50,7 +42,6 @@ class SwiftDependency(
                 "",
                 "",
                 "",
-                DistributionMethod.GIT,
             )
         val CLIENT_RUNTIME = smithySwiftDependency("ClientRuntime")
         val SMITHY = smithySwiftDependency("Smithy")
@@ -80,29 +71,19 @@ class SwiftDependency(
                 "https://github.com/smithy-lang/smithy-swift",
                 "../../../smithy-swift",
                 "smithy-swift",
-                DistributionMethod.GIT,
             )
     }
 
     override fun getDependencies(): List<SymbolDependency> = listOf(toSymbolDependency())
 
-    private fun toSymbolDependency(): SymbolDependency {
-        val builder =
-            SymbolDependency
-                .builder()
-                .putProperty("target", target)
-                .putProperty("branch", branch)
-                .putProperty("localPath", localPath)
-                .packageName(packageName)
-                .version(version)
-        when (distributionMethod) {
-            DistributionMethod.GIT -> {
-                builder.putProperty("url", location)
-            }
-            DistributionMethod.SPR -> {
-                builder.putProperty("scope", location)
-            }
-        }
-        return builder.build()
-    }
+    private fun toSymbolDependency(): SymbolDependency =
+        SymbolDependency
+            .builder()
+            .putProperty("target", target)
+            .putProperty("branch", branch)
+            .putProperty("localPath", localPath)
+            .putProperty("url", location)
+            .packageName(packageName)
+            .version(version)
+            .build()
 }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/manifestanddocs/DependencyJSONGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/manifestanddocs/DependencyJSONGeneratorTests.kt
@@ -13,7 +13,7 @@ import software.amazon.smithy.swift.codegen.TestContext
 import software.amazon.smithy.swift.codegen.defaultSettings
 import software.amazon.smithy.swift.codegen.protocolgeneratormocks.MockHTTPAWSJson11ProtocolGenerator
 
-class ServiceClientJSONManifestGeneratorTests {
+class DependencyJSONGeneratorTests {
     private val testContext = setupTests("simple-service-with-operation-and-dependency.smithy", "smithy.example#Example")
 
     @Test

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/manifestanddocs/PackageManifestGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/manifestanddocs/PackageManifestGeneratorTests.kt
@@ -10,6 +10,7 @@ import io.kotest.matchers.string.shouldStartWith
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.swift.codegen.PackageManifestGenerator
+import software.amazon.smithy.swift.codegen.SwiftDependency
 import software.amazon.smithy.swift.codegen.TestContext
 import software.amazon.smithy.swift.codegen.defaultSettings
 import software.amazon.smithy.swift.codegen.protocolgeneratormocks.MockHTTPAWSJson11ProtocolGenerator
@@ -49,6 +50,21 @@ class PackageManifestGeneratorTests {
     }
 
     @Test
+    fun `it renders package manifest file with dependencies`() {
+        val packageManifest = testContext.manifest.getFileString("Package.swift").get()
+        assertNotNull(packageManifest)
+        val expected = """
+    dependencies: [
+        .package(
+            url: "https://github.com/smithy-lang/smithy-swift",
+            exact: "0.0.1"
+        ),
+    ],
+"""
+        packageManifest.shouldContain(expected)
+    }
+
+    @Test
     fun `it renders package manifest file with target and test target`() {
         val packageManifest = testContext.manifest.getFileString("Package.swift").get()
         assertNotNull(packageManifest)
@@ -57,6 +73,10 @@ class PackageManifestGeneratorTests {
         .target(
             name: "MockSDK",
             dependencies: [
+                .product(
+                    name: "ClientRuntime",
+                    package: "smithy-swift"
+                ),
             ]
         ),
         .testTarget(
@@ -82,6 +102,9 @@ class PackageManifestGeneratorTests {
             TestContext.initContextFrom(smithyFile, serviceShapeId, MockHTTPAWSJson11ProtocolGenerator()) { model ->
                 model.defaultSettings(serviceShapeId, "MockSDK", "2019-12-16", "MockSDKID")
             }
+        context.generationCtx.delegator.useFileWriter("xyz.swift") { writer ->
+            writer.addDependency(SwiftDependency.CLIENT_RUNTIME)
+        }
         PackageManifestGenerator(context.generationCtx).writePackageManifest(context.generationCtx.delegator.dependencies)
         context.generationCtx.delegator.flushWriters()
         return context


### PR DESCRIPTION
## Description of changes
Removes the `DistributionMethod` type because it was only needed for Swift Package Registry.  Simplified code that used to handle distribution method.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.