### PR TITLE
chore: move OTEL Tracing behind feature flag

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,35 @@ let libXML2DependencyOrNil: Target.Dependency? = nil
 let libXML2TargetOrNil: Target? = nil
 #endif
 
+// Feature Flags
+let isDocCEnabled = ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_ENABLE_DOCC"] != nil
+let isOpenTelemetryEnabled = ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_ENABLE_OPENTELEMETRY"] != nil
+
+// OpenTelemetry dependencies
+let otelDependencies: [Target.Dependency] = isOpenTelemetryEnabled ? [
+    // Only include these on macOS, iOS, tvOS, watchOS, and macCatalyst (visionOS and Linux are excluded)
+    .product(
+        name: "InMemoryExporter",
+        package: "opentelemetry-swift",
+        condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .macCatalyst])
+    ),
+    .product(
+        name: "OpenTelemetryApi",
+        package: "opentelemetry-swift",
+        condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .macCatalyst])
+    ),
+    .product(
+        name: "OpenTelemetrySdk",
+        package: "opentelemetry-swift",
+        condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .macCatalyst])
+    ),
+    .product(
+        name: "OpenTelemetryProtocolExporterHTTP",
+        package: "opentelemetry-swift",
+        condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .macCatalyst])
+    ),
+] : []
+
 let package = Package(
     name: "smithy-swift",
     platforms: [
@@ -58,10 +87,12 @@ let package = Package(
         var dependencies: [Package.Dependency] = [
             .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.52.1"),
             .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-            .package(url: "https://github.com/open-telemetry/opentelemetry-swift", from: "1.13.0"),
         ]
 
-        let isDocCEnabled = ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_ENABLE_DOCC"] != nil
+        if isOpenTelemetryEnabled {
+            dependencies.append(.package(url: "https://github.com/open-telemetry/opentelemetry-swift", from: "1.13.0"))
+        }
+
         if isDocCEnabled {
             dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
         }
@@ -97,31 +128,13 @@ let package = Package(
                 "SmithyChecksums",
                 "SmithyCBOR",
                 .product(name: "AwsCommonRuntimeKit", package: "aws-crt-swift"),
-                // Only include these on macOS, iOS, tvOS, watchOS, and macCatalyst (visionOS and Linux are excluded)
-                .product(
-                    name: "InMemoryExporter",
-                    package: "opentelemetry-swift",
-                    condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .macCatalyst])
-                ),
-                .product(
-                    name: "OpenTelemetryApi",
-                    package: "opentelemetry-swift",
-                    condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .macCatalyst])
-                ),
-                .product(
-                    name: "OpenTelemetrySdk",
-                    package: "opentelemetry-swift",
-                    condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .macCatalyst])
-                ),
-                .product(
-                    name: "OpenTelemetryProtocolExporterHTTP",
-                    package: "opentelemetry-swift",
-                    condition: .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .macCatalyst])
-                ),
-            ],
+            ] + otelDependencies,
             resources: [
                 .copy("PrivacyInfo.xcprivacy")
-            ]
+            ],
+            swiftSettings: isOpenTelemetryEnabled ? [
+                .define("AWS_SWIFT_SDK_ENABLE_OPENTELEMETRY")
+            ] : []
         ),
         .target(
             name: "SmithyRetriesAPI"

--- a/Sources/ClientRuntime/Telemetry/Providers/OpenTelemetry/OTelProvider.swift
+++ b/Sources/ClientRuntime/Telemetry/Providers/OpenTelemetry/OTelProvider.swift
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
- #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+
+// Only compile OpenTelemetry code when explicitly enabled
+#if AWS_SWIFT_SDK_ENABLE_OPENTELEMETRY
+
 import Foundation
 
 // OpenTelemetrySdk specific imports
@@ -37,4 +41,6 @@ public enum OpenTelemetrySwift {
         }
     }
 }
-#endif
+
+#endif // AWS_SWIFT_SDK_ENABLE_OPENTELEMETRY
+#endif // Platform check

--- a/Sources/ClientRuntime/Telemetry/Providers/OpenTelemetry/OTelTracing.swift
+++ b/Sources/ClientRuntime/Telemetry/Providers/OpenTelemetry/OTelTracing.swift
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
- #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+
+// Only compile OpenTelemetry code when explicitly enabled
+#if AWS_SWIFT_SDK_ENABLE_OPENTELEMETRY
+
 // OpenTelemetryApi specific imports
 @preconcurrency import protocol OpenTelemetryApi.Tracer
 @preconcurrency import protocol OpenTelemetryApi.Span
@@ -131,4 +135,6 @@ extension TraceSpanStatus {
         }
     }
 }
-#endif
+
+#endif // AWS_SWIFT_SDK_ENABLE_OPENTELEMETRY
+#endif // Platform check

--- a/Sources/ClientRuntime/Telemetry/Providers/OpenTelemetry/OTelUtils.swift
+++ b/Sources/ClientRuntime/Telemetry/Providers/OpenTelemetry/OTelUtils.swift
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
- #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+
+// Only compile OpenTelemetry code when explicitly enabled
+#if AWS_SWIFT_SDK_ENABLE_OPENTELEMETRY
+
 // OpenTelemetryApi specific imports
 @preconcurrency import enum OpenTelemetryApi.AttributeValue
 @preconcurrency import class OpenTelemetryApi.AttributeArray
@@ -52,4 +56,6 @@ extension Attributes {
         return otelKeys
     }
 }
-#endif
+
+#endif // AWS_SWIFT_SDK_ENABLE_OPENTELEMETRY
+#endif // Platform check


### PR DESCRIPTION
## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
- Adds flag `AWS_SWIFT_SDK_ENABLE_OPENTELEMETRY`
- By default, SDK and smithy-swift will no longer pull in open telemetry reducing dependencies from 26 => 3

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.