### PR TITLE
fix: Eliminate warning when model has only indirect properties

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/struct/StructDecodeGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/serde/struct/StructDecodeGenerator.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.swift.codegen.SwiftWriter
+import software.amazon.smithy.swift.codegen.customtraits.SwiftBoxTrait
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.serde.member.MemberShapeDecodeGenerator
 import software.amazon.smithy.swift.codegen.model.ShapeMetadata
@@ -46,7 +47,8 @@ open class StructDecodeGenerator(
             if (members.isEmpty()) {
                 writer.write("return \$N()", symbol)
             } else {
-                writer.write("var value = \$N()", symbol)
+                val decl = "let".takeIf { members.all { it.hasTrait<SwiftBoxTrait>() } } ?: "var"
+                writer.write("\$L value = \$N()", decl, symbol)
                 if (isUnwrapped) {
                     writer.write("let reader = reader.parent ?? reader")
                 }


### PR DESCRIPTION
## Description of changes
In struct deserializers, render the new value as a `let` (i.e. immutable) when all properties of that struct are indirect.

Eliminates a warning for "unmodified var".

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.