### PR TITLE
chore: Run latest CI on Xcode 26

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,35 +22,35 @@ jobs:
           - macos-15
         xcode:
           - Xcode_15.2
-          - Xcode_16.4
+          - Xcode_26.0
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=iOS Simulator,OS=18.5,name=iPhone 16'
+          - 'platform=iOS Simulator,OS=26.0,name=iPhone 16'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
-          - 'platform=tvOS Simulator,OS=18.5,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
-          - 'platform=visionOS Simulator,OS=2.5,name=Apple Vision Pro'
+          - 'platform=visionOS Simulator,OS=26.0,name=Apple Vision Pro'
           - 'platform=macOS'
         exclude:
           # Don't run old macOS with new Xcode
           - runner: macos-14
-            xcode: Xcode_16.4
+            xcode: Xcode_26.0
           # Don't run new macOS with old Xcode
           - runner: macos-15
             xcode: Xcode_15.2
           # Don't run old simulators with new Xcode
           - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_16.4
+            xcode: Xcode_26.0
           - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-            xcode: Xcode_16.4
+            xcode: Xcode_26.0
           - destination: 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
-            xcode: Xcode_16.4
+            xcode: Xcode_26.0
           # Don't run new simulators with old Xcode
-          - destination: 'platform=tvOS Simulator,OS=18.5,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - destination: 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
-          - destination: 'platform=iOS Simulator,OS=18.5,name=iPhone 16'
+          - destination: 'platform=iOS Simulator,OS=26.0,name=iPhone 16'
             xcode: Xcode_15.2
-          - destination: 'platform=visionOS Simulator,OS=2.5,name=Apple Vision Pro'
+          - destination: 'platform=visionOS Simulator,OS=26.0,name=Apple Vision Pro'
             xcode: Xcode_15.2
     steps:
       - name: Configure Xcode
@@ -58,11 +58,25 @@ jobs:
           sudo xcode-select -s /Applications/${{ matrix.xcode }}.app
           xcode-select -p
       - name: Install visionOS sim if needed
-        if: ${{ contains(matrix.destination, 'platform=visionOS') }}
+        if: ${{ contains(matrix.destination, 'platform=visionOS Simulator') }}
         run: |
           sudo xcodebuild -runFirstLaunch
-          sudo xcrun simctl list
+          xcrun simctl list > /dev/null
           sudo xcodebuild -downloadPlatform visionOS
+          sudo xcodebuild -runFirstLaunch
+      - name: Install iOS 26 sim if needed
+        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=iOS Simulator') }}
+        run: |
+          sudo xcodebuild -runFirstLaunch
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform iOS
+          sudo xcodebuild -runFirstLaunch
+      - name: Install tvOS 26 sim if needed
+        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=tvOS Simulator') }}
+        run: |
+          sudo xcodebuild -runFirstLaunch
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform tvOS
           sudo xcodebuild -runFirstLaunch
       - name: Checkout smithy-swift
         uses: actions/checkout@v4
@@ -92,35 +106,35 @@ jobs:
           - macos-15
         xcode:
           - Xcode_15.2
-          - Xcode_16.4
+          - Xcode_26.0
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=iOS Simulator,OS=18.5,name=iPhone 16'
+          - 'platform=iOS Simulator,OS=26.0,name=iPhone 16'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
-          - 'platform=tvOS Simulator,OS=18.5,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
-          - 'platform=visionOS Simulator,OS=2.5,name=Apple Vision Pro'
+          - 'platform=visionOS Simulator,OS=26.0,name=Apple Vision Pro'
           - 'platform=macOS'
         exclude:
           # Don't run old macOS with new Xcode
           - runner: macos-14
-            xcode: Xcode_16.4
+            xcode: Xcode_26.0
           # Don't run new macOS with old Xcode
           - runner: macos-15
             xcode: Xcode_15.2
           # Don't run old simulators with new Xcode
           - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_16.4
+            xcode: Xcode_26.0
           - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-            xcode: Xcode_16.4
+            xcode: Xcode_26.0
           - destination: 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
-            xcode: Xcode_16.4
+            xcode: Xcode_26.0
           # Don't run new simulators with old Xcode
-          - destination: 'platform=tvOS Simulator,OS=18.5,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - destination: 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
-          - destination: 'platform=iOS Simulator,OS=18.5,name=iPhone 16'
+          - destination: 'platform=iOS Simulator,OS=26.0,name=iPhone 16'
             xcode: Xcode_15.2
-          - destination: 'platform=visionOS Simulator,OS=2.5,name=Apple Vision Pro'
+          - destination: 'platform=visionOS Simulator,OS=26.0,name=Apple Vision Pro'
             xcode: Xcode_15.2
     steps:
       - name: Configure Xcode
@@ -128,11 +142,25 @@ jobs:
           sudo xcode-select -s /Applications/${{ matrix.xcode }}.app
           xcode-select -p
       - name: Install visionOS sim if needed
-        if: ${{ contains(matrix.destination, 'platform=visionOS') }}
+        if: ${{ contains(matrix.destination, 'platform=visionOS Simulator') }}
         run: |
           sudo xcodebuild -runFirstLaunch
-          sudo xcrun simctl list
+          xcrun simctl list > /dev/null
           sudo xcodebuild -downloadPlatform visionOS
+          sudo xcodebuild -runFirstLaunch
+      - name: Install iOS 26 sim if needed
+        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=iOS Simulator') }}
+        run: |
+          sudo xcodebuild -runFirstLaunch
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform iOS
+          sudo xcodebuild -runFirstLaunch
+      - name: Install tvOS 26 sim if needed
+        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=tvOS Simulator') }}
+        run: |
+          sudo xcodebuild -runFirstLaunch
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform tvOS
           sudo xcodebuild -runFirstLaunch
       - name: Checkout smithy-swift
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description of changes
Runs smithy-swift latest CI on Xcode 26, and using iOS 26 / tvOS 26 / visionOS 26 sims.  All "26" versions are currently pre-release beta versions.

Changes are copied in from PR https://github.com/awslabs/aws-sdk-swift/pull/2016.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.