### PR TITLE
chore: Use iPhone 17 sim on Xcode 26

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
           - Xcode_26.0
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=iOS Simulator,OS=26.0,name=iPhone 16'
+          - 'platform=iOS Simulator,OS=26.0,name=iPhone 17'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
@@ -48,7 +48,7 @@ jobs:
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
-          - destination: 'platform=iOS Simulator,OS=26.0,name=iPhone 16'
+          - destination: 'platform=iOS Simulator,OS=26.0,name=iPhone 17'
             xcode: Xcode_15.2
           - destination: 'platform=visionOS Simulator,OS=26.0,name=Apple Vision Pro'
             xcode: Xcode_15.2
@@ -109,7 +109,7 @@ jobs:
           - Xcode_26.0
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=iOS Simulator,OS=26.0,name=iPhone 16'
+          - 'platform=iOS Simulator,OS=26.0,name=iPhone 17'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
@@ -132,7 +132,7 @@ jobs:
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
-          - destination: 'platform=iOS Simulator,OS=26.0,name=iPhone 16'
+          - destination: 'platform=iOS Simulator,OS=26.0,name=iPhone 17'
             xcode: Xcode_15.2
           - destination: 'platform=visionOS Simulator,OS=26.0,name=Apple Vision Pro'
             xcode: Xcode_15.2


### PR DESCRIPTION
## Description of changes
Github recently updated their runner images from Xcode 26 beta 7 to Xcode 26 RC.
With that update, the pre-installed iOS simulator changes from iPhone 16 to iPhone 17.

This PR updates the sim used to match what is pre-installed.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.