### PR TITLE
chore: Cache gradle in GitHub workflows

### DIFF
--- a/.github/actions/setup-common-tools-composite-action/action.yml
+++ b/.github/actions/setup-common-tools-composite-action/action.yml
@@ -28,3 +28,4 @@ runs:
       with:
         distribution: corretto
         java-version: 17
+        cache: gradle

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'corretto'
+          cache: gradle
 
       - name: Log Kotlin version
         run: |


### PR DESCRIPTION
## Issue \#
https://github.com/smithy-lang/smithy/pull/2776

## Description of changes
Cache gradle in GitHub workflows

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.