### PR TITLE
chore: Use Swift 6.2 as Linux latest

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -209,7 +209,7 @@ jobs:
           - ubuntu-24.04-arm
         swift:
           - 5.9-focal
-          - 6.1-jammy
+          - 6.2-jammy
     container:
       image: swift:${{ matrix.swift }}
     env:
@@ -242,7 +242,7 @@ jobs:
           - ubuntu-24.04-arm
         swift:
           - 5.9-focal
-          - 6.1-jammy
+          - 6.2-jammy
     container:
       image: swift:${{ matrix.swift }}
     env:


### PR DESCRIPTION
## Description of changes
Use Swift 6.2 as the latest Linux image for CI & integration tests.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.