### PR TITLE
fix: Fix input param syntax in operation doc comments

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ServiceGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ServiceGenerator.kt
@@ -81,10 +81,10 @@ class ServiceGenerator {
             }
 
             writeEmptyLine()
-            writer.writeDocs("\\- Parameter ${op.inputShape.name} : ${retrieveMemberShapeDoc(op.inputShape, model)}")
+            writer.writeDocs("\\- Parameter input: ${retrieveMemberShapeDoc(op.inputShape, model)} (Type: \\`${op.inputShape.name}\\`)")
 
             writeEmptyLine()
-            writer.writeDocs("\\- Returns: \\`${op.outputShape.name}\\` : ${retrieveMemberShapeDoc(op.outputShape, model)}")
+            writer.writeDocs("\\- Returns: ${retrieveMemberShapeDoc(op.outputShape, model)} (Type: \\`${op.outputShape.name}\\`)")
 
             if (op.getErrors(service).isNotEmpty()) {
                 writeEmptyLine()


### PR DESCRIPTION
## Description of changes
Corrects the `input` param description in documentation comments for operations, so that the doc comment renders in Xcode/docc correctly.

Example diff:
```
-    /// - Parameter CreateApiKeyInput : Request to create an ApiKey resource.
+    /// - Parameter input: Request to create an ApiKey resource. (Type: `CreateApiKeyInput`)
     ///
-    /// - Returns: `CreateApiKeyOutput` : A resource that can be distributed to callers for executing Method resources that require an API key. API keys can be
 mapped to any Stage on any RestApi, which indicates that the callers with the API key can make requests to that stage.
+    /// - Returns: A resource that can be distributed to callers for executing Method resources that require an API key. API keys can be mapped to any Stage on
 any RestApi, which indicates that the callers with the API key can make requests to that stage. (Type: `CreateApiKeyOutput`)
```

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.