### PR TITLE
fix: Eliminate compile warning in generated auth scheme resolvers

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/AuthSchemeResolverGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/AuthSchemeResolverGenerator.kt
@@ -27,9 +27,7 @@ import software.amazon.smithy.swift.codegen.utils.clientName
 import software.amazon.smithy.swift.codegen.utils.toLowerCamelCase
 import java.util.Locale
 
-class AuthSchemeResolverGenerator(
-    private val optionCustomization: ((String, SwiftWriter) -> SwiftWriter)? = null,
-) {
+class AuthSchemeResolverGenerator() {
     fun render(ctx: ProtocolGenerator.GenerationContext) {
         val serviceIndex = ServiceIndex(ctx.model)
 
@@ -257,10 +255,17 @@ class AuthSchemeResolverGenerator(
     ) {
         writer.apply {
             val authOptionName = "${scheme.key.name}Option"
-            write("var $authOptionName = \$N(schemeID: \$S)", SmithyHTTPAuthAPITypes.AuthOption, scheme.key)
-            if (scheme.key == SigV4Trait.ID) renderSigV4AuthOptionCustomization(authOptionName, scheme, writer)
-            optionCustomization?.invoke(authOptionName, writer)
-            write("validAuthOptions.append($authOptionName)")
+            val authOptionType = SmithyHTTPAuthAPITypes.AuthOption
+            when (scheme.key) {
+                SigV4Trait.ID -> {
+                    write("var \$L = \$N(schemeID: \$S)", authOptionName, authOptionType, scheme.key)
+                    renderSigV4AuthOptionCustomization(authOptionName, scheme, writer)
+                }
+                else -> {
+                    write("let \$L = \$N(schemeID: \$S)", authOptionName, authOptionType, scheme.key)
+                }
+            }
+            write("validAuthOptions.append(\$L)", authOptionName)
         }
     }
 

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/requestflow/AuthSchemeResolverGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/requestflow/AuthSchemeResolverGeneratorTests.kt
@@ -42,28 +42,28 @@ public struct DefaultExampleAuthSchemeResolver: ExampleAuthSchemeResolver {
         }
         switch serviceParams.operation {
             case "onlyHttpApiKeyAuth":
-                var httpApiKeyAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpApiKeyAuth")
+                let httpApiKeyAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpApiKeyAuth")
                 validAuthOptions.append(httpApiKeyAuthOption)
             case "onlyHttpApiKeyAuthOptional":
-                var httpApiKeyAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpApiKeyAuth")
+                let httpApiKeyAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpApiKeyAuth")
                 validAuthOptions.append(httpApiKeyAuthOption)
                 validAuthOptions.append(SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#noAuth"))
             case "onlyHttpBearerAuth":
-                var httpBearerAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpBearerAuth")
+                let httpBearerAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpBearerAuth")
                 validAuthOptions.append(httpBearerAuthOption)
             case "onlyHttpBearerAuthOptional":
-                var httpBearerAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpBearerAuth")
+                let httpBearerAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpBearerAuth")
                 validAuthOptions.append(httpBearerAuthOption)
                 validAuthOptions.append(SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#noAuth"))
             case "onlyHttpApiKeyAndBearerAuth":
-                var httpApiKeyAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpApiKeyAuth")
+                let httpApiKeyAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpApiKeyAuth")
                 validAuthOptions.append(httpApiKeyAuthOption)
-                var httpBearerAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpBearerAuth")
+                let httpBearerAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpBearerAuth")
                 validAuthOptions.append(httpBearerAuthOption)
             case "onlyHttpApiKeyAndBearerAuthReversed":
-                var httpBearerAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpBearerAuth")
+                let httpBearerAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpBearerAuth")
                 validAuthOptions.append(httpBearerAuthOption)
-                var httpApiKeyAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpApiKeyAuth")
+                let httpApiKeyAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#httpApiKeyAuth")
                 validAuthOptions.append(httpApiKeyAuthOption)
             case "onlySigv4Auth":
                 var sigv4Option = SmithyHTTPAuthAPI.AuthOption(schemeID: "aws.auth#sigv4")
@@ -83,10 +83,10 @@ public struct DefaultExampleAuthSchemeResolver: ExampleAuthSchemeResolver {
                 validAuthOptions.append(sigv4Option)
                 validAuthOptions.append(SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#noAuth"))
             case "onlyCustomAuth":
-                var customAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "com.test#customAuth")
+                let customAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "com.test#customAuth")
                 validAuthOptions.append(customAuthOption)
             case "onlyCustomAuthOptional":
-                var customAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "com.test#customAuth")
+                let customAuthOption = SmithyHTTPAuthAPI.AuthOption(schemeID: "com.test#customAuth")
                 validAuthOptions.append(customAuthOption)
                 validAuthOptions.append(SmithyHTTPAuthAPI.AuthOption(schemeID: "smithy.api#noAuth"))
             default:


### PR DESCRIPTION
## Description of changes
Eliminates a compile warning by using `let` instead of `var` for variables that hold auth scheme options that are not modified.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.