### PR TITLE
chore: Use iOS sim 26.0.1 in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
           - Xcode_26.0
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=iOS Simulator,OS=26.0,name=iPhone 17'
+          - 'platform=iOS Simulator,OS=26.0.1,name=iPhone 17'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
@@ -48,7 +48,7 @@ jobs:
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
-          - destination: 'platform=iOS Simulator,OS=26.0,name=iPhone 17'
+          - destination: 'platform=iOS Simulator,OS=26.0.1,name=iPhone 17'
             xcode: Xcode_15.2
           - destination: 'platform=visionOS Simulator,OS=26.0,name=Apple Vision Pro'
             xcode: Xcode_15.2
@@ -61,6 +61,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup common tools
         uses: ./.github/actions/setup-common-tools-composite-action
+      - name: List all sims installed
+        run: xcrun simctl list
       - name: Build & Run smithy-swift Kotlin Unit Tests
         run: ./gradlew build
       - name: Build & Run smithy-swift Swift Unit Tests
@@ -88,7 +90,7 @@ jobs:
           - Xcode_26.0
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=iOS Simulator,OS=26.0,name=iPhone 17'
+          - 'platform=iOS Simulator,OS=26.0.1,name=iPhone 17'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
@@ -111,7 +113,7 @@ jobs:
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
-          - destination: 'platform=iOS Simulator,OS=26.0,name=iPhone 17'
+          - destination: 'platform=iOS Simulator,OS=26.0.1,name=iPhone 17'
             xcode: Xcode_15.2
           - destination: 'platform=visionOS Simulator,OS=26.0,name=Apple Vision Pro'
             xcode: Xcode_15.2
@@ -133,6 +135,8 @@ jobs:
         uses: ./smithy-swift/.github/actions/setup-common-tools-composite-action
       - name: Tools Versions
         run: ./aws-sdk-swift/scripts/ci_steps/log_tool_versions.sh
+      - name: List all sims installed
+        run: xcrun simctl list
       - name: Prepare aws-sdk-swift Protocol & Unit Tests
         run: |
           cd aws-sdk-swift


### PR DESCRIPTION
## Description of changes
Github has updated their `macos-26-arm64` runner image to version `20251022.0070` which uses iOS simulator 26.0.1 instead of 26.0.

See https://github.com/actions/runner-images/issues/13220

Update the xcodebuild destination accordingly.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.