### PR TITLE
chore: Sort imports

### DIFF
--- a/Sources/ClientRuntime/Config/ClientConfigDefaultsProvider.swift
+++ b/Sources/ClientRuntime/Config/ClientConfigDefaultsProvider.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import protocol SmithyHTTPAPI.HTTPClient
 import SmithyIdentity
 import SmithyIdentityAPI
-import protocol SmithyHTTPAPI.HTTPClient
 import struct SmithyRetries.DefaultRetryStrategy
 import struct SmithyRetries.ExponentialBackoffStrategy
 import struct SmithyRetriesAPI.RetryStrategyOptions

--- a/Sources/ClientRuntime/Config/Context+Config.swift
+++ b/Sources/ClientRuntime/Config/Context+Config.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Smithy.AttributeKey
 import class Smithy.Context
 import class Smithy.ContextBuilder
-import struct Smithy.AttributeKey
 
 public extension Context {
 

--- a/Sources/ClientRuntime/Config/DefaultSDKRuntimeConfiguration.swift
+++ b/Sources/ClientRuntime/Config/DefaultSDKRuntimeConfiguration.swift
@@ -5,17 +5,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import enum Smithy.ClientError
 import class Smithy.Context
 import protocol SmithyHTTPAPI.HTTPClient
-import enum Smithy.ClientError
 import struct SmithyHTTPAuthAPI.AuthOption
 import protocol SmithyHTTPAuthAPI.AuthSchemeResolver
 import protocol SmithyHTTPAuthAPI.AuthSchemeResolverParameters
-import protocol SmithyRetriesAPI.RetryStrategy
-import protocol SmithyRetriesAPI.RetryErrorInfoProvider
-import struct SmithyRetriesAPI.RetryStrategyOptions
 import struct SmithyRetries.DefaultRetryStrategy
 import struct SmithyRetries.ExponentialBackoffStrategy
+import protocol SmithyRetriesAPI.RetryErrorInfoProvider
+import protocol SmithyRetriesAPI.RetryStrategy
+import struct SmithyRetriesAPI.RetryStrategyOptions
 
 public struct DefaultSDKRuntimeConfiguration<DefaultSDKRuntimeRetryStrategy: RetryStrategy,
     DefaultSDKRuntimeRetryErrorInfoProvider: RetryErrorInfoProvider> {

--- a/Sources/ClientRuntime/Endpoints/DefaultEndpointResolver.swift
+++ b/Sources/ClientRuntime/Endpoints/DefaultEndpointResolver.swift
@@ -6,8 +6,8 @@
 //
 
 import struct SmithyHTTPAPI.Endpoint
-import struct SmithyHTTPAPI.Headers
 import enum SmithyHTTPAPI.EndpointPropertyValue
+import struct SmithyHTTPAPI.Headers
 
 public struct DefaultEndpointResolver<Params: EndpointsRequestContextProviding> {
 

--- a/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/CRTClientEngine.swift
@@ -3,23 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+import AwsCommonRuntimeKit
 import Foundation
-import enum Smithy.URIScheme
 import struct Smithy.Attributes
-import struct Smithy.SwiftLogger
+import enum Smithy.ByteStreamError
 import protocol Smithy.LogAgent
 import enum Smithy.StreamError
-import enum Smithy.ByteStreamError
-import protocol SmithyHTTPAPI.HTTPClient
-import struct SmithyHTTPAPI.Headers
-import struct SmithyHTTPAPI.Endpoint
+import struct Smithy.SwiftLogger
+import enum Smithy.URIScheme
+import class SmithyChecksums.ChunkedStream
 import enum SmithyHTTPAPI.ALPNProtocol
+import struct SmithyHTTPAPI.Endpoint
+import struct SmithyHTTPAPI.Headers
+import protocol SmithyHTTPAPI.HTTPClient
 import class SmithyHTTPAPI.HTTPRequest
 import class SmithyHTTPAPI.HTTPResponse
 import enum SmithyHTTPAPI.HTTPStatusCode
-import class SmithyChecksums.ChunkedStream
 import class SmithyStreams.BufferedStream
-import AwsCommonRuntimeKit
 #if os(Linux)
 import Glibc
 #elseif !os(Windows)

--- a/Sources/ClientRuntime/Networking/Http/CRT/HTTP2Stream+ByteStream.swift
+++ b/Sources/ClientRuntime/Networking/Http/CRT/HTTP2Stream+ByteStream.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import enum Smithy.ByteStream
-import struct Smithy.Attributes
 import AwsCommonRuntimeKit
+import struct Smithy.Attributes
+import enum Smithy.ByteStream
 
 extension HTTP2Stream {
     /// Returns the recommended size, in bytes, for the data to write

--- a/Sources/ClientRuntime/Networking/Http/HTTPResponse+WireDataProviding.swift
+++ b/Sources/ClientRuntime/Networking/Http/HTTPResponse+WireDataProviding.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class SmithyHTTPAPI.HTTPResponse
-import enum Smithy.ByteStream
-@_spi(SmithyReadWrite) import protocol SmithyReadWrite.WireDataProviding
 import struct Foundation.Data
+import enum Smithy.ByteStream
+import class SmithyHTTPAPI.HTTPResponse
+@_spi(SmithyReadWrite) import protocol SmithyReadWrite.WireDataProviding
 
 @_spi(SmithyReadWrite)
 extension HTTPResponse: WireDataProviding {

--- a/Sources/ClientRuntime/Networking/Http/HttpClientConfiguration.swift
+++ b/Sources/ClientRuntime/Networking/Http/HttpClientConfiguration.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AwsCommonRuntimeKit
+import struct Foundation.TimeInterval
 import enum Smithy.URIScheme
 import struct SmithyHTTPAPI.Headers
-import struct Foundation.TimeInterval
-import AwsCommonRuntimeKit
 
 public class HttpClientConfiguration {
 

--- a/Sources/ClientRuntime/Networking/Http/HttpTelemetry.swift
+++ b/Sources/ClientRuntime/Networking/Http/HttpTelemetry.swift
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-import protocol SmithyHTTPAPI.HTTPClient
-import struct Smithy.Attributes
-import struct Smithy.AttributeKey
 import class Foundation.NSRecursiveLock
+import struct Smithy.AttributeKey
+import struct Smithy.Attributes
+import protocol SmithyHTTPAPI.HTTPClient
 
 /// Container for HTTPClient telemetry, including configurable attributes and names.
 ///

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/AuthSchemeMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/AuthSchemeMiddleware.swift
@@ -5,14 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import enum Smithy.ClientError
-import struct Smithy.Attributes
 import struct Smithy.AttributeKey
+import struct Smithy.Attributes
+import enum Smithy.ClientError
 import class Smithy.Context
 import class SmithyHTTPAPI.HTTPRequestBuilder
-import struct SmithyHTTPAuthAPI.SelectedAuthScheme
-import protocol SmithyHTTPAuthAPI.AuthScheme
 import struct SmithyHTTPAuth.DefaultIdentityResolverConfiguration
+import protocol SmithyHTTPAuthAPI.AuthScheme
+import struct SmithyHTTPAuthAPI.SelectedAuthScheme
 
 public struct AuthSchemeMiddleware<OperationStackOutput> {
     public let id: String = "AuthSchemeMiddleware"

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/ContentMD5Middleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/ContentMD5Middleware.swift
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0.
 
-import Smithy
-import enum SmithyChecksumsAPI.ChecksumAlgorithm
 import AwsCommonRuntimeKit
+import Smithy
 import SmithyChecksums
+import enum SmithyChecksumsAPI.ChecksumAlgorithm
 import SmithyHTTPAPI
 
 public struct ContentMD5Middleware<OperationStackInput, OperationStackOutput> {

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/DeserializeMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/DeserializeMiddleware.swift
@@ -5,8 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import SmithyHTTPAPI
-@_spi(SmithyReadWrite) import SmithyReadWrite
 import struct Foundation.Date
 import class Foundation.DateFormatter
 import struct Foundation.Locale
@@ -15,6 +13,8 @@ import struct Foundation.TimeZone
 import struct Foundation.UUID
 import class Smithy.Context
 import protocol Smithy.ResponseMessageDeserializer
+import SmithyHTTPAPI
+@_spi(SmithyReadWrite) import SmithyReadWrite
 
 @_spi(SmithyReadWrite)
 public struct DeserializeMiddleware<OperationStackOutput> {

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/HeaderMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/HeaderMiddleware.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import class Smithy.Context
 import protocol Smithy.RequestMessageSerializer
 import class SmithyHTTPAPI.HTTPRequest
 import class SmithyHTTPAPI.HTTPRequestBuilder
-import class Smithy.Context
 
 public struct HeaderMiddleware<OperationStackInput, OperationStackOutput> {
     public let id: String = "\(String(describing: OperationStackInput.self))HeadersMiddleware"

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/LoggerMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/LoggerMiddleware.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol Smithy.LogAgent
 import class Smithy.Context
+import protocol Smithy.LogAgent
 import class SmithyHTTPAPI.HTTPRequest
 import class SmithyHTTPAPI.HTTPResponse
 

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/MutateHeadersMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/MutateHeadersMiddleware.swift
@@ -3,8 +3,8 @@
 
 import class Smithy.Context
 import struct SmithyHTTPAPI.Headers
-import class SmithyHTTPAPI.HTTPRequestBuilder
 import class SmithyHTTPAPI.HTTPRequest
+import class SmithyHTTPAPI.HTTPRequestBuilder
 import class SmithyHTTPAPI.HTTPResponse
 
 public struct MutateHeadersMiddleware<OperationStackInput, OperationStackOutput> {

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/QueryItemMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/QueryItemMiddleware.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol Smithy.RequestMessageSerializer
 import class Smithy.Context
+import protocol Smithy.RequestMessageSerializer
 import SmithyHTTPAPI
 
 public struct QueryItemMiddleware<OperationStackInput, OperationStackOutput> {

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/BlobBodyMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/BlobBodyMiddleware.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol Smithy.RequestMessageSerializer
+import struct Foundation.Data
 import class Smithy.Context
+import protocol Smithy.RequestMessageSerializer
 import class SmithyHTTPAPI.HTTPRequest
 import class SmithyHTTPAPI.HTTPRequestBuilder
-import struct Foundation.Data
 
 public struct BlobBodyMiddleware<OperationStackInput, OperationStackOutput> {
     public let id: Swift.String = "BlobBodyMiddleware"

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/BlobStreamBodyMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/BlobStreamBodyMiddleware.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol Smithy.RequestMessageSerializer
-import class Smithy.Context
+import struct Foundation.Data
 import enum Smithy.ByteStream
+import class Smithy.Context
+import protocol Smithy.RequestMessageSerializer
 import class SmithyHTTPAPI.HTTPRequest
 import class SmithyHTTPAPI.HTTPRequestBuilder
-import struct Foundation.Data
 
 public struct BlobStreamBodyMiddleware<OperationStackInput, OperationStackOutput> {
     public let id: Swift.String = "BlobStreamBodyMiddleware"

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/BodyMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/BodyMiddleware.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Foundation.Data
 import Smithy
 import SmithyHTTPAPI
-import struct Foundation.Data
 @_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyWriter
 @_spi(SmithyReadWrite) import typealias SmithyReadWrite.WritingClosure
 

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/EnumBodyMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/EnumBodyMiddleware.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Foundation.Data
 import class Smithy.Context
 import protocol Smithy.RequestMessageSerializer
-import struct Foundation.Data
 import SmithyHTTPAPI
 
 public struct EnumBodyMiddleware<OperationStackInput,

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/EventStreamBodyMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/EventStreamBodyMiddleware.swift
@@ -5,14 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol Smithy.RequestMessageSerializer
+import struct Foundation.Data
 import class Smithy.Context
+import protocol Smithy.RequestMessageSerializer
 import SmithyEventStreams
 import SmithyEventStreamsAPI
 import SmithyEventStreamsAuthAPI
-import struct Foundation.Data
-@_spi(SmithyReadWrite) import typealias SmithyReadWrite.WritingClosure
 import SmithyHTTPAPI
+@_spi(SmithyReadWrite) import typealias SmithyReadWrite.WritingClosure
 
 public struct EventStreamBodyMiddleware<OperationStackInput,
                                         OperationStackOutput,

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/PayloadBodyMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/PayloadBodyMiddleware.swift
@@ -5,14 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Foundation.Data
 import enum Smithy.ByteStream
 import enum Smithy.ClientError
-import protocol Smithy.RequestMessageSerializer
 import class Smithy.Context
-import struct Foundation.Data
+import protocol Smithy.RequestMessageSerializer
+import SmithyHTTPAPI
 @_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyWriter
 @_spi(SmithyReadWrite) import typealias SmithyReadWrite.WritingClosure
-import SmithyHTTPAPI
 
 @_spi(SmithyReadWrite)
 public struct PayloadBodyMiddleware<OperationStackInput,

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/StringBodyMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/RequestBody/StringBodyMiddleware.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol Smithy.RequestMessageSerializer
-import class Smithy.Context
 import struct Foundation.Data
+import class Smithy.Context
+import protocol Smithy.RequestMessageSerializer
 import SmithyHTTPAPI
 
 public struct StringBodyMiddleware<OperationStackInput, OperationStackOutput> {

--- a/Sources/ClientRuntime/Networking/Http/Middlewares/SignerMiddleware.swift
+++ b/Sources/ClientRuntime/Networking/Http/Middlewares/SignerMiddleware.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
-import enum Smithy.ClientError
 import Foundation
+import struct Smithy.AttributeKey
+import enum Smithy.ClientError
+import class Smithy.Context
 import SmithyHTTPAPI
 import SmithyHTTPAuthAPI
-import struct Smithy.AttributeKey
 
 public struct SignerMiddleware<OperationStackOutput> {
     public let id: String = "SignerMiddleware"

--- a/Sources/ClientRuntime/Networking/Http/URLSession/FoundationStreamBridge.swift
+++ b/Sources/ClientRuntime/Networking/Http/URLSession/FoundationStreamBridge.swift
@@ -7,21 +7,21 @@
 
 #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS) || os(visionOS)
 
+import func Foundation.CFWriteStreamSetDispatchQueue
+import struct Foundation.Data
+import class Foundation.DispatchQueue
+import class Foundation.InputStream
+import class Foundation.NSObject
+import class Foundation.OutputStream
+import class Foundation.RunLoop
+import class Foundation.Stream
+import protocol Foundation.StreamDelegate
+import class Foundation.Thread
+import struct Foundation.TimeInterval
+import class Foundation.Timer
+import struct Smithy.Attributes
 import protocol Smithy.LogAgent
 import protocol Smithy.ReadableStream
-import struct Smithy.Attributes
-import func Foundation.CFWriteStreamSetDispatchQueue
-import class Foundation.DispatchQueue
-import class Foundation.NSObject
-import class Foundation.Stream
-import class Foundation.InputStream
-import class Foundation.OutputStream
-import class Foundation.Thread
-import class Foundation.RunLoop
-import class Foundation.Timer
-import struct Foundation.TimeInterval
-import struct Foundation.Data
-import protocol Foundation.StreamDelegate
 
 /// Reads data from a smithy-swift native `ReadableStream` and streams the data through to a Foundation `InputStream`.
 ///

--- a/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionHTTPClient.swift
+++ b/Sources/ClientRuntime/Networking/Http/URLSession/URLSessionHTTPClient.swift
@@ -7,41 +7,41 @@
 
 #if os(iOS) || os(macOS) || os(watchOS) || os(tvOS) || os(visionOS)
 
-import struct Smithy.Attributes
-import struct Smithy.SwiftLogger
-import protocol Smithy.LogAgent
-import protocol SmithyHTTPAPI.HTTPClient
-import struct SmithyHTTPAPI.Headers
-import class SmithyHTTPAPI.HTTPResponse
-import class SmithyHTTPAPI.HTTPRequest
-import enum SmithyHTTPAPI.HTTPStatusCode
-import protocol Smithy.ReadableStream
-import enum Smithy.ByteStream
-import class SmithyStreams.BufferedStream
-import struct Foundation.Date
+import AwsCommonRuntimeKit
 import class Foundation.Bundle
+import struct Foundation.Data
+import struct Foundation.Date
+import class Foundation.HTTPURLResponse
 import class Foundation.InputStream
 import class Foundation.NSObject
 import class Foundation.NSRecursiveLock
 import var Foundation.NSURLAuthenticationMethodClientCertificate
 import var Foundation.NSURLAuthenticationMethodServerTrust
+import struct Foundation.TimeInterval
 import class Foundation.URLAuthenticationChallenge
 import struct Foundation.URLComponents
 import class Foundation.URLCredential
 import struct Foundation.URLQueryItem
 import struct Foundation.URLRequest
 import class Foundation.URLResponse
-import class Foundation.HTTPURLResponse
-import struct Foundation.TimeInterval
 import class Foundation.URLSession
 import class Foundation.URLSessionConfiguration
+import protocol Foundation.URLSessionDataDelegate
+import class Foundation.URLSessionDataTask
 import class Foundation.URLSessionTask
 import class Foundation.URLSessionTaskMetrics
-import class Foundation.URLSessionDataTask
-import protocol Foundation.URLSessionDataDelegate
-import struct Foundation.Data
-import AwsCommonRuntimeKit
 import Security
+import struct Smithy.Attributes
+import enum Smithy.ByteStream
+import protocol Smithy.LogAgent
+import protocol Smithy.ReadableStream
+import struct Smithy.SwiftLogger
+import struct SmithyHTTPAPI.Headers
+import protocol SmithyHTTPAPI.HTTPClient
+import class SmithyHTTPAPI.HTTPRequest
+import class SmithyHTTPAPI.HTTPResponse
+import enum SmithyHTTPAPI.HTTPStatusCode
+import class SmithyStreams.BufferedStream
 
 /// A client that can be used to make requests to AWS services using `Foundation`'s `URLSession` HTTP client.
 ///

--- a/Sources/ClientRuntime/Networking/Streaming/ByteStream+FileHandle.swift
+++ b/Sources/ClientRuntime/Networking/Streaming/ByteStream+FileHandle.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import class Foundation.FileHandle
 import enum Smithy.ByteStream
 import class SmithyStreams.FileStream
-import class Foundation.FileHandle
 
 extension ByteStream {
 

--- a/Sources/ClientRuntime/Networking/Streaming/ByteStream+Validating.swift
+++ b/Sources/ClientRuntime/Networking/Streaming/ByteStream+Validating.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol Smithy.Stream
 import enum Smithy.ByteStream
-import class SmithyStreams.BufferedStream
-import enum SmithyChecksumsAPI.ChecksumAlgorithm
+import protocol Smithy.Stream
 import class SmithyChecksums.ValidatingBufferedStream
+import enum SmithyChecksumsAPI.ChecksumAlgorithm
+import class SmithyStreams.BufferedStream
 
 extension ByteStream {
 

--- a/Sources/ClientRuntime/Orchestrator/Orchestrator.swift
+++ b/Sources/ClientRuntime/Orchestrator/Orchestrator.swift
@@ -7,15 +7,15 @@
 
 import struct Foundation.Date
 import struct Foundation.TimeInterval
-import class Smithy.Context
-import enum Smithy.ClientError
-import protocol Smithy.RequestMessage
-import protocol Smithy.ResponseMessage
 import struct Smithy.AttributeKey
 import struct Smithy.Attributes
+import enum Smithy.ClientError
+import class Smithy.Context
+import protocol Smithy.RequestMessage
+import protocol Smithy.ResponseMessage
 import SmithyHTTPAPI
-import protocol SmithyRetriesAPI.RetryStrategy
 import struct SmithyRetriesAPI.RetryErrorInfo
+import protocol SmithyRetriesAPI.RetryStrategy
 
 /// Orchestrates operation execution
 ///

--- a/Sources/ClientRuntime/Orchestrator/OrchestratorBuilder.swift
+++ b/Sources/ClientRuntime/Orchestrator/OrchestratorBuilder.swift
@@ -10,12 +10,12 @@ import struct Foundation.TimeInterval
 import class Smithy.Context
 import class Smithy.ContextBuilder
 import protocol Smithy.RequestMessage
-import protocol Smithy.ResponseMessage
 import protocol Smithy.RequestMessageSerializer
+import protocol Smithy.ResponseMessage
 import protocol Smithy.ResponseMessageDeserializer
 import struct SmithyHTTPAuthAPI.SelectedAuthScheme
-import protocol SmithyRetriesAPI.RetryStrategy
 import struct SmithyRetriesAPI.RetryErrorInfo
+import protocol SmithyRetriesAPI.RetryStrategy
 
 /// Builds an Orchestrator, combining runtime components, interceptors, serializers, and deserializers.
 ///

--- a/Sources/ClientRuntime/Orchestrator/OrchestratorTelemetry.swift
+++ b/Sources/ClientRuntime/Orchestrator/OrchestratorTelemetry.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
-import struct Smithy.Attributes
 import struct Smithy.AttributeKey
+import struct Smithy.Attributes
+import class Smithy.Context
 import enum SmithyHTTPAPI.SmithyHTTPAPIKeys
 
 /// Container for Orchestrator telemetry, including configurable attributes and names.

--- a/Sources/ClientRuntime/PrimitiveTypeExtensions/String+Extensions.swift
+++ b/Sources/ClientRuntime/PrimitiveTypeExtensions/String+Extensions.swift
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-import enum Smithy.ClientError
-import struct Foundation.Data
 import AwsCommonRuntimeKit
+import struct Foundation.Data
+import enum Smithy.ClientError
 
 extension StringProtocol where Self.Index == String.Index {
     func escape(_ characterSet: [(character: String, escapedCharacter: String)]) -> String {

--- a/Sources/ClientRuntime/Retries/DefaultRetryErrorInfoProvider.swift
+++ b/Sources/ClientRuntime/Retries/DefaultRetryErrorInfoProvider.swift
@@ -5,15 +5,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import enum SmithyHTTPAPI.HTTPStatusCode
-import struct SmithyRetriesAPI.RetryErrorInfo
-import enum SmithyRetriesAPI.RetryErrorType
-import protocol SmithyRetriesAPI.RetryErrorInfoProvider
-import struct Foundation.TimeInterval
+import enum AwsCommonRuntimeKit.CommonRunTimeError
+import struct AwsCommonRuntimeKit.CRTError
 import class Foundation.NSError
 import var Foundation.NSURLErrorDomain
-import struct AwsCommonRuntimeKit.CRTError
-import enum AwsCommonRuntimeKit.CommonRunTimeError
+import struct Foundation.TimeInterval
+import enum SmithyHTTPAPI.HTTPStatusCode
+import struct SmithyRetriesAPI.RetryErrorInfo
+import protocol SmithyRetriesAPI.RetryErrorInfoProvider
+import enum SmithyRetriesAPI.RetryErrorType
 
 public enum DefaultRetryErrorInfoProvider: RetryErrorInfoProvider, Sendable {
     /// Returns information used to determine how & if to retry an error.

--- a/Sources/ClientRuntime/Serialization/SerializationUtils/TimestampFormatter.swift
+++ b/Sources/ClientRuntime/Serialization/SerializationUtils/TimestampFormatter.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(SmithyTimestamps) import struct SmithyTimestamps.TimestampFormatter
 @_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
+@_spi(SmithyTimestamps) import struct SmithyTimestamps.TimestampFormatter
 
 @_spi(SmithyTimestamps)
 public typealias TimestampFormatter = SmithyTimestamps.TimestampFormatter

--- a/Sources/ClientRuntime/Telemetry/Providers/OpenTelemetry/OTelTracing.swift
+++ b/Sources/ClientRuntime/Telemetry/Providers/OpenTelemetry/OTelTracing.swift
@@ -6,19 +6,19 @@
 //
 
  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-// OpenTelemetryApi specific imports
-@preconcurrency import protocol OpenTelemetryApi.Tracer
+@preconcurrency import enum OpenTelemetryApi.AttributeValue
 @preconcurrency import protocol OpenTelemetryApi.Span
 @preconcurrency import enum OpenTelemetryApi.SpanKind
 @preconcurrency import enum OpenTelemetryApi.Status
-@preconcurrency import enum OpenTelemetryApi.AttributeValue
+// OpenTelemetryApi specific imports
+@preconcurrency import protocol OpenTelemetryApi.Tracer
 
-// OpenTelemetrySdk specific imports
-@preconcurrency import class OpenTelemetrySdk.TracerProviderSdk
-@preconcurrency import class OpenTelemetrySdk.TracerProviderBuilder
+@preconcurrency import struct OpenTelemetrySdk.Resource
 @preconcurrency import struct OpenTelemetrySdk.SimpleSpanProcessor
 @preconcurrency import protocol OpenTelemetrySdk.SpanExporter
-@preconcurrency import struct OpenTelemetrySdk.Resource
+@preconcurrency import class OpenTelemetrySdk.TracerProviderBuilder
+// OpenTelemetrySdk specific imports
+@preconcurrency import class OpenTelemetrySdk.TracerProviderSdk
 
 // Smithy specific imports
 import struct Smithy.AttributeKey

--- a/Sources/ClientRuntime/Telemetry/Providers/OpenTelemetry/OTelUtils.swift
+++ b/Sources/ClientRuntime/Telemetry/Providers/OpenTelemetry/OTelUtils.swift
@@ -6,13 +6,13 @@
 //
 
  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+@preconcurrency import class OpenTelemetryApi.AttributeArray
 // OpenTelemetryApi specific imports
 @preconcurrency import enum OpenTelemetryApi.AttributeValue
-@preconcurrency import class OpenTelemetryApi.AttributeArray
 
+import struct Smithy.AttributeKey
 // Smithy imports
 import struct Smithy.Attributes
-import struct Smithy.AttributeKey
 
 extension Attributes {
     public func toOtelAttributes() -> [String: AttributeValue] {

--- a/Sources/ClientRuntime/Telemetry/Tracing/TraceSpan.swift
+++ b/Sources/ClientRuntime/Telemetry/Tracing/TraceSpan.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Smithy.Attributes
 import struct Smithy.AttributeKey
+import struct Smithy.Attributes
 
 /// A Trace Span represents a single unit of work which has a beginning and end time, and may be connected to other
 /// spans as part of a parent / child relationship.

--- a/Sources/ClientRuntime/protocols/rpcv2cbor/RpcV2CborError.swift
+++ b/Sources/ClientRuntime/protocols/rpcv2cbor/RpcV2CborError.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class SmithyHTTPAPI.HTTPResponse
 @_spi(SmithyReadWrite) import class SmithyCBOR.Reader
+import class SmithyHTTPAPI.HTTPResponse
 
 public struct RpcV2CborError: BaseError {
     public let code: String

--- a/Sources/Smithy/ByteStream.swift
+++ b/Sources/Smithy/ByteStream.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Foundation.FileHandle
 import struct Foundation.Data
+import class Foundation.FileHandle
 
 public enum ByteStream: Sendable {
     case data(Data?)

--- a/Sources/SmithyCBOR/Reader/Reader.swift
+++ b/Sources/SmithyCBOR/Reader/Reader.swift
@@ -8,11 +8,11 @@
 import AwsCommonRuntimeKit
 import Foundation
 
-@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyReader
-@_spi(SmithyReadWrite) import enum SmithyReadWrite.ReaderError
-@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyWriter
 @_spi(Smithy) import struct Smithy.Document
 @_spi(Smithy) import protocol Smithy.SmithyDocument
+@_spi(SmithyReadWrite) import enum SmithyReadWrite.ReaderError
+@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyReader
+@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyWriter
 @_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
 @_spi(SmithyTimestamps) import struct SmithyTimestamps.TimestampFormatter
 

--- a/Sources/SmithyCBOR/Writer/Writer.swift
+++ b/Sources/SmithyCBOR/Writer/Writer.swift
@@ -8,11 +8,11 @@
 import AwsCommonRuntimeKit
 import Foundation
 
+@_spi(Smithy) import struct Smithy.Document
+@_spi(Smithy) import protocol Smithy.SmithyDocument
 @_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyReader
 @_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyWriter
 @_spi(SmithyReadWrite) import enum SmithyReadWrite.WriterError
-@_spi(Smithy) import struct Smithy.Document
-@_spi(Smithy) import protocol Smithy.SmithyDocument
 @_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
 @_spi(SmithyTimestamps) import struct SmithyTimestamps.TimestampFormatter
 

--- a/Sources/SmithyChecksums/CRC32.swift
+++ b/Sources/SmithyChecksums/CRC32.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AwsCommonRuntimeKit
+import struct Foundation.Data
 import protocol SmithyChecksumsAPI.Checksum
 import enum SmithyChecksumsAPI.HashResult
-import struct Foundation.Data
-import AwsCommonRuntimeKit
 
 class CRC32 {
     let checksumName = "crc32"

--- a/Sources/SmithyChecksums/CRC32C.swift
+++ b/Sources/SmithyChecksums/CRC32C.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AwsCommonRuntimeKit
+import struct Foundation.Data
 import protocol SmithyChecksumsAPI.Checksum
 import enum SmithyChecksumsAPI.HashResult
-import struct Foundation.Data
-import AwsCommonRuntimeKit
 
 class CRC32C {
     let checksumName = "crc32c"

--- a/Sources/SmithyChecksums/CRC64NVME.swift
+++ b/Sources/SmithyChecksums/CRC64NVME.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AwsCommonRuntimeKit
+import struct Foundation.Data
 import protocol SmithyChecksumsAPI.Checksum
 import enum SmithyChecksumsAPI.HashResult
-import struct Foundation.Data
-import AwsCommonRuntimeKit
 
 class CRC64NVME {
     let checksumName = "crc64nvme"

--- a/Sources/SmithyChecksums/ChecksumAlgorithm.swift
+++ b/Sources/SmithyChecksums/ChecksumAlgorithm.swift
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+import AwsCommonRuntimeKit
+import struct Foundation.Data
 import protocol SmithyChecksumsAPI.Checksum
 import enum SmithyChecksumsAPI.ChecksumAlgorithm
 import enum SmithyChecksumsAPI.HashResult
-import struct Foundation.Data
-import AwsCommonRuntimeKit
 
 public enum HashError: Error {
     case invalidInput

--- a/Sources/SmithyChecksums/ChunkedReader.swift
+++ b/Sources/SmithyChecksums/ChunkedReader.swift
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AwsCommonRuntimeKit
+import struct Foundation.Data
+import Smithy
 import protocol SmithyChecksumsAPI.Checksum
 import enum SmithyChecksumsAPI.ChecksumAlgorithm
 import struct SmithyHTTPAPI.Headers
-import AwsCommonRuntimeKit
 import SmithyHTTPClient
-import struct Foundation.Data
-import Smithy
 
 public class ChunkedReader {
     private var stream: ReadableStream

--- a/Sources/SmithyChecksums/ChunkedStream.swift
+++ b/Sources/SmithyChecksums/ChunkedStream.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AwsCommonRuntimeKit
+import struct Foundation.Data
+import class Smithy.Context
 import protocol Smithy.Stream
 import struct SmithyHTTPAPI.Headers
-import struct Foundation.Data
-import AwsCommonRuntimeKit
 import class SmithyStreams.BufferedStream
-import class Smithy.Context
 
 /// Reads data from the input stream, chunks it, and passes it out through its output stream.
 ///

--- a/Sources/SmithyChecksums/MD5.swift
+++ b/Sources/SmithyChecksums/MD5.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AwsCommonRuntimeKit
+import struct Foundation.Data
 import protocol SmithyChecksumsAPI.Checksum
 import enum SmithyChecksumsAPI.HashResult
-import struct Foundation.Data
-import AwsCommonRuntimeKit
 
 class MD5 {
     let checksumName = "md5"

--- a/Sources/SmithyChecksums/SHA1.swift
+++ b/Sources/SmithyChecksums/SHA1.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AwsCommonRuntimeKit
+import struct Foundation.Data
 import protocol SmithyChecksumsAPI.Checksum
 import enum SmithyChecksumsAPI.HashResult
-import struct Foundation.Data
-import AwsCommonRuntimeKit
 
 class SHA1 {
     let checksumName = "sha1"

--- a/Sources/SmithyChecksums/SHA256.swift
+++ b/Sources/SmithyChecksums/SHA256.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AwsCommonRuntimeKit
+import struct Foundation.Data
 import protocol SmithyChecksumsAPI.Checksum
 import enum SmithyChecksumsAPI.HashResult
-import struct Foundation.Data
-import AwsCommonRuntimeKit
 
 class SHA256 {
     let checksumName = "sha256"

--- a/Sources/SmithyChecksums/ValidatingBufferedStream.swift
+++ b/Sources/SmithyChecksums/ValidatingBufferedStream.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AwsCommonRuntimeKit
+import struct Foundation.Data
 import protocol Smithy.Stream
 import protocol SmithyChecksumsAPI.Checksum
 import enum SmithyChecksumsAPI.ChecksumAlgorithm
-import struct Foundation.Data
-import AwsCommonRuntimeKit
 import class SmithyStreams.BufferedStream
 
 public class ValidatingBufferedStream: @unchecked Sendable {

--- a/Sources/SmithyChecksumsAPI/Context+Checksum.swift
+++ b/Sources/SmithyChecksumsAPI/Context+Checksum.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
 import struct Smithy.AttributeKey
+import class Smithy.Context
 
 public extension Context {
 

--- a/Sources/SmithyEventStreams/DefaultMessageDecoder.swift
+++ b/Sources/SmithyEventStreams/DefaultMessageDecoder.swift
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Smithy
-import enum SmithyEventStreamsAPI.EventStreamError
-import struct SmithyEventStreamsAPI.Message
-import struct SmithyEventStreamsAPI.Header
-import protocol SmithyEventStreamsAPI.MessageDecoder
 import AwsCommonRuntimeKit
 import struct Foundation.Data
+import Smithy
+import enum SmithyEventStreamsAPI.EventStreamError
+import struct SmithyEventStreamsAPI.Header
+import struct SmithyEventStreamsAPI.Message
+import protocol SmithyEventStreamsAPI.MessageDecoder
 
 /// AWS implementation of `MessageDecoder` for decoding event stream messages
 /// Note: This is class because struct does not allow using `self` in closure

--- a/Sources/SmithyEventStreams/DefaultMessageDecoderStream.swift
+++ b/Sources/SmithyEventStreams/DefaultMessageDecoderStream.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Foundation.Data
 import Smithy
 import SmithyEventStreamsAPI
 import SmithyEventStreamsAuthAPI
-import struct Foundation.Data
 
 /// Stream adapter that decodes input data into `EventStream.Message` objects.
 public struct DefaultMessageDecoderStream<Event: Sendable>: MessageDecoderStream, Sendable {

--- a/Sources/SmithyEventStreams/DefaultMessageEncoder.swift
+++ b/Sources/SmithyEventStreams/DefaultMessageEncoder.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Foundation.Data
 import struct SmithyEventStreamsAPI.Message
 import protocol SmithyEventStreamsAPI.MessageEncoder
-import struct Foundation.Data
 
     /// Encodes a `Message` into a `Data` object
     /// to be sent over the wire.

--- a/Sources/SmithyEventStreams/DefaultMessageEncoderStream.swift
+++ b/Sources/SmithyEventStreams/DefaultMessageEncoderStream.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Foundation.Data
 import Smithy
 import SmithyEventStreamsAPI
 import SmithyEventStreamsAuthAPI
-import struct Foundation.Data
 
 /// Stream adapter that encodes input into `Data` objects.
 public class DefaultMessageEncoderStream<Event>: MessageEncoderStream, Stream, @unchecked Sendable {

--- a/Sources/SmithyEventStreams/Header+CRT.swift
+++ b/Sources/SmithyEventStreams/Header+CRT.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct SmithyEventStreamsAPI.Header
-import enum SmithyEventStreamsAPI.HeaderValue
 import AwsCommonRuntimeKit
 import Foundation
+import struct SmithyEventStreamsAPI.Header
+import enum SmithyEventStreamsAPI.HeaderValue
 
 extension Header {
 

--- a/Sources/SmithyEventStreams/Message+CRT.swift
+++ b/Sources/SmithyEventStreams/Message+CRT.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import enum SmithyEventStreamsAPI.EventStreamError
-import enum SmithyEventStreamsAPI.MessageType
-import struct SmithyEventStreamsAPI.Message
 import AwsCommonRuntimeKit
+import enum SmithyEventStreamsAPI.EventStreamError
+import struct SmithyEventStreamsAPI.Message
+import enum SmithyEventStreamsAPI.MessageType
 
 extension Message {
     /// Parses the protocol level headers into a `MessageType`

--- a/Sources/SmithyEventStreamsAPI/Context+EventStreamsAPI.swift
+++ b/Sources/SmithyEventStreamsAPI/Context+EventStreamsAPI.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
 import struct Smithy.AttributeKey
+import class Smithy.Context
 
 public extension Context {
 

--- a/Sources/SmithyEventStreamsAuthAPI/Context+EventStreamsAuthAPI.swift
+++ b/Sources/SmithyEventStreamsAuthAPI/Context+EventStreamsAuthAPI.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
 import struct Smithy.AttributeKey
+import class Smithy.Context
 
 public extension Context {
 

--- a/Sources/SmithyEventStreamsAuthAPI/MessageDataSigner.swift
+++ b/Sources/SmithyEventStreamsAuthAPI/MessageDataSigner.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Foundation.Data
 import struct Smithy.Attributes
 import struct SmithyEventStreamsAPI.Message
-import struct Foundation.Data
 
 /// Protocol for signing messages.
 public protocol MessageDataSigner: Sendable {

--- a/Sources/SmithyEventStreamsAuthAPI/MessageEncoderStream.swift
+++ b/Sources/SmithyEventStreamsAuthAPI/MessageEncoderStream.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Foundation.Data
 import Smithy
 import SmithyEventStreamsAPI
-import struct Foundation.Data
 
 /// Stream adapter that encodes input into `Data` objects that are encoded, signed events.
 public protocol MessageEncoderStream: Stream, AsyncSequence where Element == Data {

--- a/Sources/SmithyFormURL/Writer.swift
+++ b/Sources/SmithyFormURL/Writer.swift
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyWriter
-import protocol Smithy.SmithyDocument
-@_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
-@_spi(SmithyTimestamps) import struct SmithyTimestamps.TimestampFormatter
+import struct Foundation.CharacterSet
 import struct Foundation.Data
 import struct Foundation.Date
-import struct Foundation.CharacterSet
+import protocol Smithy.SmithyDocument
+@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyWriter
+@_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
+@_spi(SmithyTimestamps) import struct SmithyTimestamps.TimestampFormatter
 
 @_spi(SmithyReadWrite)
 public final class Writer: SmithyWriter {

--- a/Sources/SmithyHTTPAPI/Context+HTTP.swift
+++ b/Sources/SmithyHTTPAPI/Context+HTTP.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Smithy.Attributes
+import struct Foundation.TimeInterval
 import struct Smithy.AttributeKey
+import struct Smithy.Attributes
 import class Smithy.Context
 import class Smithy.ContextBuilder
-import struct Foundation.TimeInterval
 
 /// This extends `OperationContext` for all http middleware operations
 extension Context {

--- a/Sources/SmithyHTTPAPI/Endpoint.swift
+++ b/Sources/SmithyHTTPAPI/Endpoint.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import enum AwsCommonRuntimeKit.EndpointProperty
 import Foundation
 import Smithy
-import enum AwsCommonRuntimeKit.EndpointProperty
 
 public struct Endpoint: Sendable, Equatable {
     public let uri: URI

--- a/Sources/SmithyHTTPAPI/EndpointPropertyValue.swift
+++ b/Sources/SmithyHTTPAPI/EndpointPropertyValue.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import enum AwsCommonRuntimeKit.EndpointProperty
 import Foundation
 import Smithy
-import enum AwsCommonRuntimeKit.EndpointProperty
 
 public enum EndpointPropertyValue: Sendable, Equatable {
     case bool(Bool)

--- a/Sources/SmithyHTTPAPI/HTTPRequest.swift
+++ b/Sources/SmithyHTTPAPI/HTTPRequest.swift
@@ -5,18 +5,18 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Smithy.URI
-import class Smithy.URIBuilder
-import enum Smithy.URIScheme
-import struct Smithy.URIQueryItem
-import protocol Smithy.RequestMessage
-import protocol Smithy.RequestMessageBuilder
+import struct Foundation.CharacterSet
+import struct Foundation.Date
+import struct Foundation.URLComponents
+import struct Foundation.URLQueryItem
 import enum Smithy.ByteStream
 import enum Smithy.ClientError
-import struct Foundation.Date
-import struct Foundation.CharacterSet
-import struct Foundation.URLQueryItem
-import struct Foundation.URLComponents
+import protocol Smithy.RequestMessage
+import protocol Smithy.RequestMessageBuilder
+import struct Smithy.URI
+import class Smithy.URIBuilder
+import struct Smithy.URIQueryItem
+import enum Smithy.URIScheme
 // In Linux, Foundation.URLRequest is moved to FoundationNetworking.
 #if canImport(FoundationNetworking)
 import FoundationNetworking

--- a/Sources/SmithyHTTPAPI/HTTPResponse.swift
+++ b/Sources/SmithyHTTPAPI/HTTPResponse.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import class Foundation.NSRecursiveLock
+import enum Smithy.ByteStream
 import protocol Smithy.ResponseMessage
 import protocol Smithy.Stream
-import enum Smithy.ByteStream
-import class Foundation.NSRecursiveLock
 
 public final class HTTPResponse: ResponseMessage, @unchecked Sendable {
     private var lock = NSRecursiveLock()

--- a/Sources/SmithyHTTPAPI/URL+getQueryItems.swift
+++ b/Sources/SmithyHTTPAPI/URL+getQueryItems.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Smithy.URIQueryItem
 import struct Foundation.URL
 import struct Foundation.URLComponents
+import struct Smithy.URIQueryItem
 
 public func getQueryItems(url: URL) -> [URIQueryItem]? {
     URLComponents(url: url, resolvingAgainstBaseURL: false)?

--- a/Sources/SmithyHTTPAuth/AWSSigningConfig.swift
+++ b/Sources/SmithyHTTPAuth/AWSSigningConfig.swift
@@ -5,17 +5,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class SmithyIdentity.CRTAWSCredentialIdentity
-import enum SmithyHTTPAuthAPI.SigningAlgorithm
-import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
-import enum SmithyHTTPAuthAPI.AWSSignedBodyValue
-import enum SmithyHTTPAuthAPI.AWSSignatureType
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
 import struct Foundation.Date
 import struct Foundation.Locale
 import struct Foundation.TimeInterval
+import enum SmithyHTTPAuthAPI.AWSSignatureType
+import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
+import enum SmithyHTTPAuthAPI.AWSSignedBodyValue
+import enum SmithyHTTPAuthAPI.SigningAlgorithm
 import struct SmithyHTTPAuthAPI.SigningFlags
 import struct SmithyIdentity.AWSCredentialIdentity
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
+import class SmithyIdentity.CRTAWSCredentialIdentity
 
 public struct AWSSigningConfig: Sendable {
     public let credentials: AWSCredentialIdentity?

--- a/Sources/SmithyHTTPAuth/AuthSchemes/BearerTokenAuthScheme.swift
+++ b/Sources/SmithyHTTPAuth/AuthSchemes/BearerTokenAuthScheme.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Smithy.Attributes
 import class Smithy.Context
 import protocol SmithyHTTPAuthAPI.AuthScheme
 import protocol SmithyHTTPAuthAPI.Signer
-import struct Smithy.Attributes
 
 public struct BearerTokenAuthScheme: AuthScheme {
     public let schemeID: String = "smithy.api#httpBearerAuth"

--- a/Sources/SmithyHTTPAuth/CRTAdapters.swift
+++ b/Sources/SmithyHTTPAuth/CRTAdapters.swift
@@ -5,16 +5,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import enum AwsCommonRuntimeKit.SigningAlgorithmType
+import enum AwsCommonRuntimeKit.SignatureType
 import enum AwsCommonRuntimeKit.SignedBodyHeaderType
 import enum AwsCommonRuntimeKit.SignedBodyValue
-import enum AwsCommonRuntimeKit.SignatureType
+import enum AwsCommonRuntimeKit.SigningAlgorithmType
 import struct AwsCommonRuntimeKit.SigningConfig
 
-import enum SmithyHTTPAuthAPI.SigningAlgorithm
+import enum SmithyHTTPAuthAPI.AWSSignatureType
 import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
 import enum SmithyHTTPAuthAPI.AWSSignedBodyValue
-import enum SmithyHTTPAuthAPI.AWSSignatureType
+import enum SmithyHTTPAuthAPI.SigningAlgorithm
 
 import struct Foundation.Locale
 import class SmithyIdentity.CRTAWSCredentialIdentity

--- a/Sources/SmithyHTTPAuth/DefaultIdentityResolverConfiguration.swift
+++ b/Sources/SmithyHTTPAuth/DefaultIdentityResolverConfiguration.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol SmithyIdentityAPI.IdentityResolver
-import protocol SmithyHTTPAuthAPI.IdentityResolverConfiguration
-import struct Smithy.Attributes
 import struct Smithy.AttributeKey
+import struct Smithy.Attributes
+import protocol SmithyHTTPAuthAPI.IdentityResolverConfiguration
+import protocol SmithyIdentityAPI.IdentityResolver
 
 public struct DefaultIdentityResolverConfiguration: IdentityResolverConfiguration {
     let identityResolvers: Attributes

--- a/Sources/SmithyHTTPAuth/SigV4AuthScheme.swift
+++ b/Sources/SmithyHTTPAuth/SigV4AuthScheme.swift
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
-import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
-import enum SmithyHTTPAuthAPI.SigningPropertyKeys
-import protocol SmithyHTTPAuthAPI.AuthScheme
-import protocol SmithyHTTPAuthAPI.Signer
 import struct Smithy.Attributes
+import class Smithy.Context
 import SmithyChecksumsAPI
+import protocol SmithyHTTPAuthAPI.AuthScheme
+import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
+import protocol SmithyHTTPAuthAPI.Signer
+import enum SmithyHTTPAuthAPI.SigningPropertyKeys
 
 public struct SigV4AuthScheme: AuthScheme {
     public let schemeID: String = "aws.auth#sigv4"

--- a/Sources/SmithyHTTPAuth/SigV4Signer.swift
+++ b/Sources/SmithyHTTPAuth/SigV4Signer.swift
@@ -5,30 +5,30 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import enum AwsCommonRuntimeKit.CommonRunTimeError
+import class AwsCommonRuntimeKit.HTTPRequestBase
+import class AwsCommonRuntimeKit.Signer
+import struct AwsCommonRuntimeKit.SigningConfig
 import struct Foundation.Date
 import struct Foundation.TimeInterval
 import struct Foundation.URL
-import class AwsCommonRuntimeKit.HTTPRequestBase
-import class AwsCommonRuntimeKit.Signer
-import class SmithyHTTPAPI.HTTPRequest
-import class SmithyHTTPAPI.HTTPRequestBuilder
-import enum AwsCommonRuntimeKit.CommonRunTimeError
-import enum Smithy.ClientError
-import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
-import enum SmithyHTTPAuthAPI.AWSSignedBodyValue
-import enum SmithyHTTPAuthAPI.AWSSignatureType
-import enum SmithyHTTPAuthAPI.SigningAlgorithm
-import enum SmithyHTTPAuthAPI.SigningPropertyKeys
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
-import protocol SmithyIdentityAPI.Identity
-import protocol SmithyHTTPAuthAPI.Signer
-import struct AwsCommonRuntimeKit.SigningConfig
 import struct Smithy.AttributeKey
 import struct Smithy.Attributes
+import enum Smithy.ClientError
 import struct Smithy.SwiftLogger
-import struct SmithyIdentity.AWSCredentialIdentity
+import class SmithyHTTPAPI.HTTPRequest
+import class SmithyHTTPAPI.HTTPRequestBuilder
+import enum SmithyHTTPAuthAPI.AWSSignatureType
+import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
+import enum SmithyHTTPAuthAPI.AWSSignedBodyValue
+import protocol SmithyHTTPAuthAPI.Signer
+import enum SmithyHTTPAuthAPI.SigningAlgorithm
 import struct SmithyHTTPAuthAPI.SigningFlags
+import enum SmithyHTTPAuthAPI.SigningPropertyKeys
 import SmithyHTTPClient
+import struct SmithyIdentity.AWSCredentialIdentity
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
+import protocol SmithyIdentityAPI.Identity
 
 public class SigV4Signer: SmithyHTTPAuthAPI.Signer, @unchecked Sendable {
     public init() {}

--- a/Sources/SmithyHTTPAuth/Signers/BearerTokenSigner.swift
+++ b/Sources/SmithyHTTPAuth/Signers/BearerTokenSigner.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class SmithyHTTPAPI.HTTPRequestBuilder
-import enum Smithy.ClientError
-import protocol SmithyIdentityAPI.Identity
-import protocol SmithyHTTPAuthAPI.Signer
 import struct Smithy.Attributes
+import enum Smithy.ClientError
+import class SmithyHTTPAPI.HTTPRequestBuilder
+import protocol SmithyHTTPAuthAPI.Signer
 import struct SmithyIdentity.BearerTokenIdentity
+import protocol SmithyIdentityAPI.Identity
 
 /// The signer for HTTP bearer auth.
 /// Adds the Authorization header to the request using the resolved bearer token identity as its value.

--- a/Sources/SmithyHTTPAuthAPI/AuthScheme.swift
+++ b/Sources/SmithyHTTPAuthAPI/AuthScheme.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Smithy.Attributes
 import class Smithy.Context
 import protocol SmithyIdentityAPI.IdentityResolver
-import struct Smithy.Attributes
 
 public protocol AuthScheme: Sendable {
     var schemeID: String { get }

--- a/Sources/SmithyHTTPAuthAPI/Context/Context+Chunked.swift
+++ b/Sources/SmithyHTTPAuthAPI/Context/Context+Chunked.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
 import struct Smithy.AttributeKey
+import class Smithy.Context
 
 public extension Context {
     var isChunkedEligibleStream: Bool? {

--- a/Sources/SmithyHTTPAuthAPI/Context/Context+EstimatedSkew.swift
+++ b/Sources/SmithyHTTPAuthAPI/Context/Context+EstimatedSkew.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
-import class Smithy.ContextBuilder
 import struct Foundation.TimeInterval
 import struct Smithy.AttributeKey
+import class Smithy.Context
+import class Smithy.ContextBuilder
 
 public extension Context {
     var estimatedSkew: TimeInterval? {

--- a/Sources/SmithyHTTPAuthAPI/Context/Context+HTTPAuth.swift
+++ b/Sources/SmithyHTTPAuthAPI/Context/Context+HTTPAuth.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Smithy.AttributeKey
+import struct Smithy.Attributes
 import class Smithy.Context
 import class Smithy.ContextBuilder
-import struct Smithy.Attributes
-import struct Smithy.AttributeKey
 
 public extension Context {
 

--- a/Sources/SmithyHTTPAuthAPI/Context/Context+RequestSignature.swift
+++ b/Sources/SmithyHTTPAuthAPI/Context/Context+RequestSignature.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Smithy.AttributeKey
 import class Smithy.Context
 import class Smithy.ContextBuilder
-import struct Smithy.AttributeKey
 
 public extension Context {
 

--- a/Sources/SmithyHTTPAuthAPI/Context/SigningPropertyKeys.swift
+++ b/Sources/SmithyHTTPAuthAPI/Context/SigningPropertyKeys.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Smithy.AttributeKey
 import struct Foundation.TimeInterval
+import struct Smithy.AttributeKey
 
 public enum SigningPropertyKeys {
     public static let signingName = AttributeKey<String>(name: "SigningName")

--- a/Sources/SmithyHTTPAuthAPI/SelectedAuthScheme.swift
+++ b/Sources/SmithyHTTPAuthAPI/SelectedAuthScheme.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol SmithyIdentityAPI.Identity
-import struct Smithy.Attributes
 import struct Smithy.AttributeKey
+import struct Smithy.Attributes
+import protocol SmithyIdentityAPI.Identity
 
 public struct SelectedAuthScheme: Sendable {
     public let schemeID: String

--- a/Sources/SmithyHTTPAuthAPI/Signer.swift
+++ b/Sources/SmithyHTTPAuthAPI/Signer.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Smithy.Attributes
 import class SmithyHTTPAPI.HTTPRequestBuilder
 import protocol SmithyIdentityAPI.Identity
-import struct Smithy.Attributes
 
 public protocol Signer: Sendable {
 

--- a/Sources/SmithyHTTPClient/SdkHttpRequest+CRT.swift
+++ b/Sources/SmithyHTTPClient/SdkHttpRequest+CRT.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Smithy.URI
-import class SmithyStreams.StreamableHttpBody
-import class SmithyHTTPAPI.HTTPRequest
 import AwsCommonRuntimeKit
+import struct Smithy.URI
+import class SmithyHTTPAPI.HTTPRequest
+import class SmithyStreams.StreamableHttpBody
 
 extension HTTPRequest {
 

--- a/Sources/SmithyHTTPClient/SdkHttpRequestBuilder+HTTPRequestBase.swift
+++ b/Sources/SmithyHTTPClient/SdkHttpRequestBuilder+HTTPRequestBase.swift
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AwsCommonRuntimeKit
 import struct Foundation.Date
 import struct Foundation.URLComponents
 import struct Smithy.URIQueryItem
+import struct SmithyHTTPAPI.Headers
 import class SmithyHTTPAPI.HTTPRequest
 import class SmithyHTTPAPI.HTTPRequestBuilder
-import struct SmithyHTTPAPI.Headers
-import AwsCommonRuntimeKit
 
 extension HTTPRequestBuilder {
 

--- a/Sources/SmithyIdentity/AWSCredentialIdentity.swift
+++ b/Sources/SmithyIdentity/AWSCredentialIdentity.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol SmithyIdentityAPI.Identity
 import struct Foundation.Date
 import struct Smithy.Attributes
+import protocol SmithyIdentityAPI.Identity
 
 /// A type representing AWS credentials for authenticating with an AWS service
 ///

--- a/Sources/SmithyIdentity/AWSCredentialIdentityResolver.swift
+++ b/Sources/SmithyIdentity/AWSCredentialIdentityResolver.swift
@@ -6,8 +6,8 @@
 //
 
 import class AwsCommonRuntimeKit.CredentialsProvider
-import protocol SmithyIdentityAPI.IdentityResolver
 import struct Smithy.Attributes
+import protocol SmithyIdentityAPI.IdentityResolver
 
 /// A type that can provide credentials for authenticating with an AWS service
 public protocol AWSCredentialIdentityResolver: IdentityResolver where IdentityT == AWSCredentialIdentity {}

--- a/Sources/SmithyIdentity/AWSCredentialIdentityResolvers/StaticAWSCredentialIdentityResolver.swift
+++ b/Sources/SmithyIdentity/AWSCredentialIdentityResolvers/StaticAWSCredentialIdentityResolver.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(ClientConfigDefaultIdentityResolver) import protocol SmithyIdentityAPI.ClientConfigDefaultIdentityResolver
 import struct Smithy.Attributes
+@_spi(ClientConfigDefaultIdentityResolver) import protocol SmithyIdentityAPI.ClientConfigDefaultIdentityResolver
 
 /// A credential identity resolver that provides a fixed set of credentials
 public struct StaticAWSCredentialIdentityResolver: AWSCredentialIdentityResolver {

--- a/Sources/SmithyIdentity/BearerTokenIdentity.swift
+++ b/Sources/SmithyIdentity/BearerTokenIdentity.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol SmithyIdentityAPI.Identity
 import struct Foundation.Date
 import struct Smithy.Attributes
+import protocol SmithyIdentityAPI.Identity
 
 /// The type representing bearer token identity, used in HTTP bearer auth.
 public struct BearerTokenIdentity: Identity {

--- a/Sources/SmithyIdentity/BearerTokenIdentityResolvers/StaticBearerTokenIdentityResolver.swift
+++ b/Sources/SmithyIdentity/BearerTokenIdentityResolvers/StaticBearerTokenIdentityResolver.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(ClientConfigDefaultIdentityResolver) import protocol SmithyIdentityAPI.ClientConfigDefaultIdentityResolver
 import struct Smithy.Attributes
+@_spi(ClientConfigDefaultIdentityResolver) import protocol SmithyIdentityAPI.ClientConfigDefaultIdentityResolver
 
 /// The token identity resolver that returns a static token identity given to it at initialization.
 public struct StaticBearerTokenIdentityResolver: BearerTokenIdentityResolver {

--- a/Sources/SmithyIdentityAPI/Context/Context+AuthSchemePreference.swift
+++ b/Sources/SmithyIdentityAPI/Context/Context+AuthSchemePreference.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Smithy.Attributes
 import struct Smithy.AttributeKey
+import struct Smithy.Attributes
 import class Smithy.Context
 import class Smithy.ContextBuilder
 

--- a/Sources/SmithyIdentityAPI/Context/Context+FlowType.swift
+++ b/Sources/SmithyIdentityAPI/Context/Context+FlowType.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Smithy.AttributeKey
 import class Smithy.Context
 import class Smithy.ContextBuilder
-import struct Smithy.AttributeKey
 
 public let flowTypeKey = AttributeKey<FlowType>(name: "FlowType")
 

--- a/Sources/SmithyIdentityAPI/Context/Context+IdentityResolver.swift
+++ b/Sources/SmithyIdentityAPI/Context/Context+IdentityResolver.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Smithy.Attributes
 import struct Smithy.AttributeKey
+import struct Smithy.Attributes
 import class Smithy.Context
 import class Smithy.ContextBuilder
 

--- a/Sources/SmithyJSON/Document+JSONUtils.swift
+++ b/Sources/SmithyJSON/Document+JSONUtils.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import func CoreFoundation.CFGetTypeID
 import func CoreFoundation.CFBooleanGetTypeID
+import func CoreFoundation.CFGetTypeID
 import struct Foundation.Data
 import struct Foundation.Date
 import class Foundation.DateFormatter

--- a/Sources/SmithyJSON/Reader/Reader+JSONDeserialization.swift
+++ b/Sources/SmithyJSON/Reader/Reader+JSONDeserialization.swift
@@ -6,8 +6,8 @@
 //
 
 import struct Foundation.Data
-import class Foundation.NSError
 import class Foundation.JSONSerialization
+import class Foundation.NSError
 import class Foundation.NSNull
 
 extension Reader {

--- a/Sources/SmithyJSON/Reader/Reader.swift
+++ b/Sources/SmithyJSON/Reader/Reader.swift
@@ -5,20 +5,20 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyReader
-import protocol Smithy.SmithyDocument
-import struct Smithy.Document
-import typealias SmithyReadWrite.ReadingClosure
-import enum SmithyReadWrite.ReaderError
-@_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
-@_spi(SmithyTimestamps) import struct SmithyTimestamps.TimestampFormatter
+import func CoreFoundation.CFBooleanGetTypeID
+import func CoreFoundation.CFGetTypeID
 import struct Foundation.Data
 import struct Foundation.Date
+import class Foundation.NSDecimalNumber
 import class Foundation.NSNull
 import class Foundation.NSNumber
-import class Foundation.NSDecimalNumber
-import func CoreFoundation.CFGetTypeID
-import func CoreFoundation.CFBooleanGetTypeID
+import struct Smithy.Document
+import protocol Smithy.SmithyDocument
+import enum SmithyReadWrite.ReaderError
+import typealias SmithyReadWrite.ReadingClosure
+@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyReader
+@_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
+@_spi(SmithyTimestamps) import struct SmithyTimestamps.TimestampFormatter
 
 @_spi(SmithyReadWrite)
 public final class Reader: SmithyReader {

--- a/Sources/SmithyJSON/Writer/Writer.swift
+++ b/Sources/SmithyJSON/Writer/Writer.swift
@@ -5,14 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyWriter
-@_spi(SmithyDocumentImpl) import protocol Smithy.SmithyDocument
-import enum Smithy.DocumentError
-@_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
-@_spi(SmithyTimestamps) import struct SmithyTimestamps.TimestampFormatter
 import struct Foundation.Data
 import struct Foundation.Date
 import class Foundation.NSNumber
+import enum Smithy.DocumentError
+@_spi(SmithyDocumentImpl) import protocol Smithy.SmithyDocument
+@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyWriter
+@_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
+@_spi(SmithyTimestamps) import struct SmithyTimestamps.TimestampFormatter
 
 @_spi(SmithyReadWrite)
 public final class Writer: SmithyWriter {

--- a/Sources/SmithyReadWrite/SmithyReader.swift
+++ b/Sources/SmithyReadWrite/SmithyReader.swift
@@ -7,8 +7,8 @@
 
 import struct Foundation.Data
 import struct Foundation.Date
-@_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
 import struct Smithy.Document
+@_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
 
 @_spi(SmithyReadWrite)
 public protocol SmithyReader: AnyObject {

--- a/Sources/SmithyReadWrite/SmithyWriter.swift
+++ b/Sources/SmithyReadWrite/SmithyWriter.swift
@@ -7,9 +7,9 @@
 
 import struct Foundation.Data
 import struct Foundation.Date
-@_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
 import enum Smithy.ByteStream
 import protocol Smithy.SmithyDocument
+@_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
 
 @_spi(SmithyReadWrite)
 public protocol SmithyWriter: AnyObject {

--- a/Sources/SmithyReadWrite/WritingClosure.swift
+++ b/Sources/SmithyReadWrite/WritingClosure.swift
@@ -7,8 +7,8 @@
 
 import struct Foundation.Data
 import struct Foundation.Date
-@_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
 import protocol Smithy.SmithyDocument
+@_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
 
 @_spi(SmithyReadWrite)
 public typealias WritingClosure<T, Writer> = (T, Writer) throws -> Void

--- a/Sources/SmithyRetries/DefaultRetryStrategy/ClientSideRateLimiter.swift
+++ b/Sources/SmithyRetries/DefaultRetryStrategy/ClientSideRateLimiter.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Foundation.TimeInterval
 import struct Foundation.Date
 import func Foundation.pow
+import struct Foundation.TimeInterval
 
 actor ClientSideRateLimiter {
 

--- a/Sources/SmithyRetries/DefaultRetryStrategy/DefaultRetryStrategy.swift
+++ b/Sources/SmithyRetries/DefaultRetryStrategy/DefaultRetryStrategy.swift
@@ -6,10 +6,10 @@
 //
 
 import struct Foundation.TimeInterval
+import enum SmithyRetriesAPI.RetryError
+import struct SmithyRetriesAPI.RetryErrorInfo
 import protocol SmithyRetriesAPI.RetryStrategy
 import struct SmithyRetriesAPI.RetryStrategyOptions
-import struct SmithyRetriesAPI.RetryErrorInfo
-import enum SmithyRetriesAPI.RetryError
 
 public struct DefaultRetryStrategy: RetryStrategy {
     public typealias Token = DefaultRetryToken

--- a/Sources/SmithyStreams/FileStream.swift
+++ b/Sources/SmithyStreams/FileStream.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Foundation.Data
 import class Foundation.FileHandle
 import class Foundation.NSRecursiveLock
-import struct Foundation.Data
 import protocol Smithy.Stream
 
 /// A `Stream` that wraps a `FileHandle` for reading the file.

--- a/Sources/SmithyStreams/StreamableHttpBody.swift
+++ b/Sources/SmithyStreams/StreamableHttpBody.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Foundation.Data
 import AwsCommonRuntimeKit
-import struct Smithy.SwiftLogger
-import protocol Smithy.Stream
+import struct Foundation.Data
 import enum Smithy.ByteStream
+import protocol Smithy.Stream
 import enum Smithy.StreamError
+import struct Smithy.SwiftLogger
 
 /// A class that implements the `IStreamable` protocol for `ByteStream`.
 /// It acts as a bridge between AWS SDK and CRT.

--- a/Sources/SmithyTimestamps/DateFormatters.swift
+++ b/Sources/SmithyTimestamps/DateFormatters.swift
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-import class Foundation.DateFormatter
-import struct Foundation.TimeZone
-import struct Foundation.Locale
 import struct Foundation.Date
+import class Foundation.DateFormatter
+import struct Foundation.Locale
+import struct Foundation.TimeZone
 
 public typealias DateFormatter = Foundation.DateFormatter
 

--- a/Sources/SmithyTimestamps/TimestampSerdeUtils.swift
+++ b/Sources/SmithyTimestamps/TimestampSerdeUtils.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import func Foundation.floor
 import struct Foundation.Date
+import func Foundation.floor
 
 /// Custom timestamp serialization formats
 /// https://smithy.io/2.0/spec/protocol-traits.html#smithy-api-timestampformat-trait

--- a/Sources/SmithyXML/Reader/Reader+libxml2.swift
+++ b/Sources/SmithyXML/Reader/Reader+libxml2.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@preconcurrency import libxml2
 import struct Foundation.Data
+@preconcurrency import libxml2
 
 extension Reader {
 

--- a/Sources/SmithyXML/Reader/Reader.swift
+++ b/Sources/SmithyXML/Reader/Reader.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyReader
+import struct Foundation.Data
+import struct Foundation.Date
 import struct Smithy.Document
 @_spi(SmithyReadWrite) import typealias SmithyReadWrite.ReadingClosure
-import struct Foundation.Date
-import struct Foundation.Data
+@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyReader
 @_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
 @_spi(SmithyTimestamps) import struct SmithyTimestamps.TimestampFormatter
 

--- a/Sources/SmithyXML/Writer/Writer+libxml2.swift
+++ b/Sources/SmithyXML/Writer/Writer+libxml2.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@preconcurrency import libxml2
 import struct Foundation.Data
+@preconcurrency import libxml2
 
 /// Extends Writer to copy its tree into libxml2, then write the tree to XML data.
 extension Writer {

--- a/Sources/SmithyXML/Writer/Writer.swift
+++ b/Sources/SmithyXML/Writer/Writer.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyWriter
-import protocol Smithy.SmithyDocument
-import struct Foundation.Date
 import struct Foundation.Data
+import struct Foundation.Date
+import protocol Smithy.SmithyDocument
+@_spi(SmithyReadWrite) import protocol SmithyReadWrite.SmithyWriter
 @_spi(SmithyReadWrite) import typealias SmithyReadWrite.WritingClosure
 @_spi(SmithyTimestamps) import enum SmithyTimestamps.TimestampFormat
 @_spi(SmithyTimestamps) import struct SmithyTimestamps.TimestampFormatter


### PR DESCRIPTION
## Description of changes
A recent update to Swiftlint fixes its enforcement for sorted order of imports.
https://github.com/realm/SwiftLint/releases/tag/0.62.0

This change applies Swiftlint's automatic fix for import sort order.  Other than import sorting, there are no other changes in this PR.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.