### PR TITLE
fix: Don't generate smoke tests for any streaming operation

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/SmokeTestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/SmokeTestGenerator.kt
@@ -60,8 +60,8 @@ open class SmokeTestGenerator(
     private fun getOperationShapeIdToTestCasesMapping(serviceName: String): Map<ShapeId, List<SmokeTestCase>> {
         val operationShapeIdToTestCases = mutableMapOf<ShapeId, List<SmokeTestCase>>()
         ctx.model.operationShapes.forEach { op ->
-            val input = ctx.model.getShape(op.input.get()).getOrNull() as? StructureShape
-            val output = ctx.model.getShape(op.output.get()).getOrNull() as? StructureShape
+            val input = op.input.getOrNull()?.let { ctx.model.expectShape<StructureShape>(it) }
+            val output = op.output.getOrNull()?.let { ctx.model.expectShape<StructureShape>(it) }
             val operationHasEventStreams =
                 ((input?.members() ?: listOf<MemberShape>()) + (output?.members() ?: listOf())).any { member ->
                     ctx.model.expectShape(member.target).hasTrait<StreamingTrait>()


### PR DESCRIPTION
## Description of changes
Generating a smoke test for a streaming operation causes a compile failure.  While policy is decided re: smoke testing streaming operations, don't attempt to generate smoke tests for streaming ops.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.