### PR TITLE
Adding support for Android

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -246,3 +246,35 @@ jobs:
           cd aws-sdk-swift/codegen
           swift test
 
+  android-ci:
+    if: github.repository == 'smithy-lang/smithy-swift' || github.event_name == 'pull_request'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+        swift:
+          - 5.9-jammy
+          - 6.2-noble
+    container:
+      image: swift:${{ matrix.swift }}
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    steps:
+      - name: Checkout smithy-swift
+        uses: actions/checkout@v4
+      - name: Install openssl
+        run: |
+          if [ -x "$(command -v apt)" ]; then
+            apt-get update && apt-get install -y libssl-dev
+          else
+            yum install -y openssl-devel which
+          fi
+      - name: Setup common tools
+        uses: ./.github/actions/setup-common-tools-composite-action
+      - name: Build & Run Kotlin Unit Tests
+        run: ./gradlew build
+      - name: "Test Swift Package on Android"
+        uses: skiptools/swift-android-action@v2


### PR DESCRIPTION
As support for Android has solidified and is now official, efforts are being made to add Android support to existing swift packages and their dependencies (smithy-swift being one).


Most of the time, packages that support linux also support Android, or require minimal changes.
From what I tested locally, there seems to be an issue with "libxml" not being present, but that speaks more to the local host being MacOS.
Adding this CI workflow can help making sure changes don't break Android support.



## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.