### PR TITLE
chore: Make protocol response test client final/Sendable

### DIFF
--- a/Sources/SmithyTestUtil/ProtocolTestResponseClient.swift
+++ b/Sources/SmithyTestUtil/ProtocolTestResponseClient.swift
@@ -9,7 +9,7 @@ import protocol SmithyHTTPAPI.HTTPClient
 import class SmithyHTTPAPI.HTTPRequest
 import class SmithyHTTPAPI.HTTPResponse
 
-public class ProtocolResponseTestClient {
+public final class ProtocolResponseTestClient {
     let httpResponse: HTTPResponse
 
     public init(httpResponse: HTTPResponse) {


### PR DESCRIPTION
## Description of changes
Make the protocol response test HTTP client `final` so it can conform to `Sendable`.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.