### PR TITLE
chore: Protocol tests use new Sendable client config

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
@@ -105,7 +105,7 @@ open class HttpProtocolUnitTestRequestGenerator protected constructor(
         val clientName = "${ctx.settings.sdkId}Client"
         val region = "us-west-2"
 
-        writer.openBlock("let config = try await \$L.Config(", ")", clientName) {
+        writer.openBlock("let config = try await \$1L.\$1LConfig(", ")", clientName) {
             writer.write("awsCredentialIdentityResolver: try \$N(),", SmithyTestUtilTypes.dummyIdentityResolver)
             writer.write("region: \$S,", region)
             writer.write("signingRegion: \$S,", region)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
@@ -183,7 +183,7 @@ open class HttpProtocolUnitTestResponseGenerator protected constructor(
         // - credential resolver
         // - endpoint resolver (unless the test has endpoint rules)
         // - HTTP client engine; a mock that returns the test's HTTPResponse is used
-        writer.openBlock("let config = try await \$L.Config(", ")", clientName) {
+        writer.openBlock("let config = try await \$1L.\$1LConfig(", ")", clientName) {
             writer.write("awsCredentialIdentityResolver: try \$N(),", SmithyTestUtilTypes.dummyIdentityResolver)
             writer.write("region: \$S,", region)
             writer.write("signingRegion: \$S,", region)

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/HttpProtocolUnitTestErrorGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/HttpProtocolUnitTestErrorGeneratorTests.kt
@@ -35,7 +35,7 @@ class HttpProtocolUnitTestErrorGeneratorTests : HttpProtocolUnitTestResponseGene
             return
         }
 
-        let config = try await ExampleClient.Config(
+        let config = try await ExampleClient.ExampleClientConfig(
             awsCredentialIdentityResolver: try SmithyTestUtil.dummyIdentityResolver(),
             region: "us-west-2",
             signingRegion: "us-west-2",
@@ -102,7 +102,7 @@ class HttpProtocolUnitTestErrorGeneratorTests : HttpProtocolUnitTestResponseGene
             return
         }
 
-        let config = try await ExampleClient.Config(
+        let config = try await ExampleClient.ExampleClientConfig(
             awsCredentialIdentityResolver: try SmithyTestUtil.dummyIdentityResolver(),
             region: "us-west-2",
             signingRegion: "us-west-2",

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/HttpProtocolUnitTestResponseGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/HttpProtocolUnitTestResponseGeneratorTests.kt
@@ -54,7 +54,7 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
             return
         }
 
-        let config = try await ExampleClient.Config(
+        let config = try await ExampleClient.ExampleClientConfig(
             awsCredentialIdentityResolver: try SmithyTestUtil.dummyIdentityResolver(),
             region: "us-west-2",
             signingRegion: "us-west-2",
@@ -108,7 +108,7 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
             return
         }
 
-        let config = try await ExampleClient.Config(
+        let config = try await ExampleClient.ExampleClientConfig(
             awsCredentialIdentityResolver: try SmithyTestUtil.dummyIdentityResolver(),
             region: "us-west-2",
             signingRegion: "us-west-2",
@@ -156,7 +156,7 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
             return
         }
 
-        let config = try await ExampleClient.Config(
+        let config = try await ExampleClient.ExampleClientConfig(
             awsCredentialIdentityResolver: try SmithyTestUtil.dummyIdentityResolver(),
             region: "us-west-2",
             signingRegion: "us-west-2",
@@ -206,7 +206,7 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
             return
         }
 
-        let config = try await ExampleClient.Config(
+        let config = try await ExampleClient.ExampleClientConfig(
             awsCredentialIdentityResolver: try SmithyTestUtil.dummyIdentityResolver(),
             region: "us-west-2",
             signingRegion: "us-west-2",
@@ -266,7 +266,7 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
             return
         }
 
-        let config = try await ExampleClient.Config(
+        let config = try await ExampleClient.ExampleClientConfig(
             awsCredentialIdentityResolver: try SmithyTestUtil.dummyIdentityResolver(),
             region: "us-west-2",
             signingRegion: "us-west-2",
@@ -328,7 +328,7 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
             return
         }
 
-        let config = try await ExampleClient.Config(
+        let config = try await ExampleClient.ExampleClientConfig(
             awsCredentialIdentityResolver: try SmithyTestUtil.dummyIdentityResolver(),
             region: "us-west-2",
             signingRegion: "us-west-2",
@@ -382,7 +382,7 @@ open class HttpProtocolUnitTestResponseGeneratorTests {
             return
         }
 
-        let config = try await ExampleClient.Config(
+        let config = try await ExampleClient.ExampleClientConfig(
             awsCredentialIdentityResolver: try SmithyTestUtil.dummyIdentityResolver(),
             region: "us-west-2",
             signingRegion: "us-west-2",


### PR DESCRIPTION
## Description of changes
Protocol tests use the new, Sendable client config object to create a client for testing.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.