### PR TITLE
chore: Add Red Hat Enterprise Linux to CI matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -170,7 +170,9 @@ jobs:
           - ubuntu-24.04-arm
         swift:
           - 5.9-jammy
+          - 5.9-rhel-ubi9
           - 6.2-noble
+          - 6.3-rhel-ubi9
     container:
       image: swift:${{ matrix.swift }}
     env:
@@ -203,7 +205,9 @@ jobs:
           - ubuntu-24.04-arm
         swift:
           - 5.9-jammy
+          - 5.9-rhel-ubi9
           - 6.2-noble
+          - 6.3-rhel-ubi9
     container:
       image: swift:${{ matrix.swift }}
     env:


### PR DESCRIPTION
## Description of changes
Adds Red Hat Enterprise Linux (RHEL) CI builds for minimum & maximum Swift versions.

RHEL coverage buys us the following benefits, besides coverage of RHEL itself:
- RHEL is CentOS-based, which gives us coverage of CentOS Linux that we don't currently have. (AL2, which is also CentOS-based, cannot run on Github CI due to glibc version conflicts, and we don't yet have Swift published for AL2023.)
- Due to https://github.com/awslabs/aws-sdk-swift/issues/2133 we can't yet run SDK CI on Debian-based Linux.  This change gives us at least some coverage of Linux on Swift 6.3.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.