### PR TITLE
feat: Add plugin for AWS specific unknown error

### DIFF
--- a/Sources/ClientRuntime/Interceptor/DefaultInterceptorContext.swift
+++ b/Sources/ClientRuntime/Interceptor/DefaultInterceptorContext.swift
@@ -70,6 +70,7 @@ extension DefaultInterceptorContext: BeforeDeserialization {
 }
 
 extension DefaultInterceptorContext: MutableResponse {
+
     public func updateResponse(updated: ResponseType) {
         self.response = updated
     }
@@ -93,8 +94,13 @@ extension DefaultInterceptorContext: AfterAttempt {
 }
 
 extension DefaultInterceptorContext: MutableOutputAfterAttempt {
+
     public func updateOutput(updated: OutputType) {
         self.result = .success(updated)
+    }
+
+    public func updateError(updated: any Error) {
+        self.result = .failure(updated)
     }
 }
 

--- a/Sources/ClientRuntime/Interceptor/InterceptorContext.swift
+++ b/Sources/ClientRuntime/Interceptor/InterceptorContext.swift
@@ -141,6 +141,10 @@ public protocol MutableOutputAfterAttempt<InputType, OutputType, RequestType, Re
     /// Mutates the operation output.
     /// - Parameter updated: The updated output.
     func updateOutput(updated: OutputType)
+
+    /// Mutates the operation error.
+    /// - Parameter updated: The updated error.
+    func updateError(updated: any Error)
 }
 
 /// Context given to interceptor hooks called after execution.
@@ -179,4 +183,8 @@ public protocol MutableOutputFinalization<InputType, OutputType, RequestType, Re
     /// Mutates the operation output.
     /// - Parameter updated: The updated output.
     func updateOutput(updated: OutputType)
+
+    /// Mutates the operation error.
+    /// - Parameter updated: The updated error.
+    func updateError(updated: any Error)
 }


### PR DESCRIPTION
## Description of changes
This is a companion to https://github.com/awslabs/aws-sdk-swift/pull/2147 which implements the AWS-specific error.

In this PR, a method for changing the operation error is added to orchestrator context implementation, and the method is exposed on the `MutableOutputAfterAttempt` and `MutableOutputFinalization` context protocols.  This allows for modification of a service error before it is thrown back to the caller; in this case, replacing a Smithy-generic error with an AWS-specific one.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.