### PR TITLE
chore: Update iOS & visionOS sims to 26.4.1 on CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,11 +28,11 @@ jobs:
           - Xcode_26.4
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=iOS Simulator,OS=26.4,name=iPhone 17'
+          - 'platform=iOS Simulator,OS=26.4.1,name=iPhone 17'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=26.4,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
-          - 'platform=visionOS Simulator,OS=26.4,name=Apple Vision Pro'
+          - 'platform=visionOS Simulator,OS=26.4.1,name=Apple Vision Pro'
           - 'platform=macOS'
         exclude:
           # Don't run old macOS with new Xcode
@@ -51,9 +51,9 @@ jobs:
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=26.4,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
-          - destination: 'platform=iOS Simulator,OS=26.4,name=iPhone 17'
+          - destination: 'platform=iOS Simulator,OS=26.4.1,name=iPhone 17'
             xcode: Xcode_15.2
-          - destination: 'platform=visionOS Simulator,OS=26.4,name=Apple Vision Pro'
+          - destination: 'platform=visionOS Simulator,OS=26.4.1,name=Apple Vision Pro'
             xcode: Xcode_15.2
     steps:
       - name: Configure Xcode
@@ -92,11 +92,11 @@ jobs:
           - Xcode_26.4
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=iOS Simulator,OS=26.4,name=iPhone 17'
+          - 'platform=iOS Simulator,OS=26.4.1,name=iPhone 17'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=26.4,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
-          - 'platform=visionOS Simulator,OS=26.4,name=Apple Vision Pro'
+          - 'platform=visionOS Simulator,OS=26.4.1,name=Apple Vision Pro'
           - 'platform=macOS'
         exclude:
           # Don't run old macOS with new Xcode
@@ -115,9 +115,9 @@ jobs:
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=26.4,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
-          - destination: 'platform=iOS Simulator,OS=26.4,name=iPhone 17'
+          - destination: 'platform=iOS Simulator,OS=26.4.1,name=iPhone 17'
             xcode: Xcode_15.2
-          - destination: 'platform=visionOS Simulator,OS=26.4,name=Apple Vision Pro'
+          - destination: 'platform=visionOS Simulator,OS=26.4.1,name=Apple Vision Pro'
             xcode: Xcode_15.2
     steps:
       - name: Configure Xcode


### PR DESCRIPTION
## Description of changes
Github released a new macos-26 image version that updates the iOS & visionOS sim versions from 26.4 to 26.4.1, and removes the 26.4 sim:
https://github.com/actions/runner-images/releases/tag/macos-26%2F20260422.0018

Since iOS sim version must be specified exactly for the sim to resolve (and avoid a build failure), this PR updates the sim version specified for latest iOS & visionOS builds.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.