### PR TITLE
chore: Run latest CI jobs on AL2023

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -180,7 +180,7 @@ jobs:
       image: swift:${{ matrix.swift }}
     steps:
       - name: Checkout smithy-swift
-        uses: actions/checkout
+        uses: actions/checkout@v6
       - name: Install openssl
         run: |
           if [ -x "$(command -v apt)" ]; then
@@ -220,7 +220,7 @@ jobs:
             yum install -y openssl-devel which
           fi
       - name: Checkout smithy-swift
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: smithy-swift
       - name: Checkout aws-sdk-swift with composite action

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -175,14 +175,12 @@ jobs:
           - 5.9-jammy
           - 5.9-rhel-ubi9
           - 6.2-noble
-          - 6.3-rhel-ubi9
+          - 6.3-amazonlinux2023
     container:
       image: swift:${{ matrix.swift }}
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout smithy-swift
-        uses: actions/checkout@v4
+        uses: actions/checkout
       - name: Install openssl
         run: |
           if [ -x "$(command -v apt)" ]; then
@@ -210,11 +208,9 @@ jobs:
           - 5.9-jammy
           - 5.9-rhel-ubi9
           - 6.2-noble
-          - 6.3-rhel-ubi9
+          - 6.3-amazonlinux2023
     container:
       image: swift:${{ matrix.swift }}
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Install openssl
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -61,7 +61,7 @@ jobs:
           sudo xcode-select -s /Applications/${{ matrix.xcode }}.app
           xcode-select -p
       - name: Checkout smithy-swift
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup common tools
         uses: ./.github/actions/setup-common-tools-composite-action
       - name: List all sims installed
@@ -125,7 +125,7 @@ jobs:
           sudo xcode-select -s /Applications/${{ matrix.xcode }}.app
           xcode-select -p
       - name: Checkout smithy-swift
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: smithy-swift
       - name: Checkout aws-sdk-swift with composite action


### PR DESCRIPTION
## Description of changes
- Use Amazon Linux 2023 in place of RHEL as "latest" Linux
- Update `actions/checkout` from v4 to v6 and disallow use of old/unsupported Node.  (This was required with AL2)

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.