### PR TITLE
fix: Add CustomDebugStringConvertible conformance to output-only structs & unions

### DIFF
--- a/Sources/SmithyCodegenCore/Serialize/SerializeCodegen.swift
+++ b/Sources/SmithyCodegenCore/Serialize/SerializeCodegen.swift
@@ -30,11 +30,15 @@ package struct SerializeCodegen {
         writer.write("import typealias SmithySerialization.WriteStructConsumer")
         writer.write("")
 
-        let inputStructsAndUnions = try ctx.service.inputDescendants
+        // Must generate SerializableStruct conformance for all of a service's
+        // structs & unions, not just those that are serialized as part of operation
+        // inputs, so that all structs & unions get the CustomDebugStringConvertible
+        // conformance that hides sensitive data
+        let serviceStructsAndUnions = try ctx.service.descendants
             .filter { $0.type == .structure || $0.type == .union }
             .smithySorted()
 
-        for shape in inputStructsAndUnions {
+        for shape in serviceStructsAndUnions {
             let swiftType = try ctx.symbolProvider.swiftType(shape: shape)
             let varName = shape.type == .structure ? "structure" : "union"
             writer.write("@_spi(SchemaBasedSerde)")

--- a/Tests/SmithySerializationTests/StringSerializerTests.swift
+++ b/Tests/SmithySerializationTests/StringSerializerTests.swift
@@ -14,6 +14,7 @@ import enum Smithy.Prelude
 import struct Smithy.Schema
 @_spi(SchemaBasedSerde)
 import struct Smithy.SensitiveTrait
+import struct RPCv2CBORTestSDK.GetWidgetOutput
 import enum RPCv2CBORTestSDK.RPCv2CBORServiceClientTypes
 
 final class StringSerializerTests: XCTestCase {
@@ -98,6 +99,12 @@ final class StringSerializerTests: XCTestCase {
             subject.debugDescription == "SensitiveType(privateMap: [\"y\": [CONTENT_REDACTED], \"x\": [CONTENT_REDACTED]])",
             "actual: \(subject.debugDescription)"
         )
+    }
+
+    func test_outputFieldsAreRedacted() throws {
+        let sensitiveString = "abcxyz"
+        let subject = GetWidgetOutput(privateString: sensitiveString)
+        XCTAssertFalse(String(reflecting: subject).contains(sensitiveString))
     }
 }
 

--- a/test-sdks/model/model.smithy
+++ b/test-sdks/model/model.smithy
@@ -29,6 +29,7 @@ structure GetWidgetInput {
 
 @output
 structure GetWidgetOutput {
+    privateString: PrivateString
 }
 
 structure SensitiveType {


### PR DESCRIPTION
## Description of changes
- Adds `SerializableStruct` conformance to ALL structs & unions, not just those that need to be serialized to inputs.  This ensures that output shapes do not log sensitive data when rendered to string.
- Adds test to verify that outputs do not log sensitive data when rendered to string.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.