### PR TITLE
chore: Matrix complete CI jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -79,6 +79,13 @@ jobs:
             test 2>&1 \
             | xcbeautify
 
+  apple-ci-complete:
+    needs: apple-ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success
+        run: echo "apple-ci passed"
+
   apple-downstream:
     if: github.repository == 'smithy-lang/smithy-swift' || github.event_name == 'pull_request'
     runs-on: ${{ matrix.runner }}
@@ -164,6 +171,13 @@ jobs:
             test 2>&1 \
             | xcbeautify
 
+  apple-downstream-complete:
+    needs: apple-downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success
+        run: echo "apple-downstream passed"
+
   linux-ci:
     if: github.repository == 'smithy-lang/smithy-swift' || github.event_name == 'pull_request'
     runs-on: ${{ matrix.runner }}
@@ -198,6 +212,13 @@ jobs:
         run: ./scripts/codegen.sh
       - name: Build & Run Swift Unit Tests
         run: swift test
+
+  linux-ci-complete:
+    needs: linux-ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success
+        run: echo "linux-ci passed"
 
   linux-downstream:
     if: github.repository == 'smithy-lang/smithy-swift' || github.event_name == 'pull_request'
@@ -252,3 +273,9 @@ jobs:
           cd aws-sdk-swift/codegen
           swift test
 
+  linux-downstream-complete:
+    needs: linux-downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success
+        run: echo "linux-downstream passed"


### PR DESCRIPTION
## Description of changes
Each matrix of CI jobs triggers a "complete" job on successful matrix completion, which will itself immediately complete successfully.  In the required checks below, this will allow us to require only the complete job to succeed, not every specific case within the matrix.

This will make maintenance of Github branch conditions much easier since required checks need not be changed every time an element in the matrix (i.e. Swift version, OS version, sim version, etc.) is changed; any change may be made within the matrix but we only need to check for the completion of the success job.

Will try this for a bit on this repo; if it works well, we will implement it elsewhere.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.