### PR TITLE
fix: skip QueryItemMiddleware for schema-based protocols

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/OperationInputQueryItemMiddleware.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/OperationInputQueryItemMiddleware.kt
@@ -6,6 +6,7 @@ import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.middlewares.handlers.MiddlewareShapeUtils
+import software.amazon.smithy.swift.codegen.integration.serde.SerdeUtils
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
 import software.amazon.smithy.swift.codegen.swiftmodules.ClientRuntimeTypes
 
@@ -21,6 +22,9 @@ class OperationInputQueryItemMiddleware(
         op: OperationShape,
         operationStackName: String,
     ) {
+        // Mirrors the skip at HTTPBindingProtocolGenerator.generateSerializers; without it, the
+        // middleware references a queryItemProvider static that's never emitted.
+        if (SerdeUtils.useSchemaBased(ctx)) return
         if (MiddlewareShapeUtils.hasQueryItems(model, op)) {
             super.renderSpecific(ctx, writer, op, operationStackName, "serialize")
         }

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/requestflow/Rpcv2CborWithHttpQueryOnInputTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/requestandresponse/requestflow/Rpcv2CborWithHttpQueryOnInputTests.kt
@@ -1,0 +1,42 @@
+package software.amazon.smithy.swift.codegen.requestandresponse.requestflow
+
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.swift.codegen.TestContext
+import software.amazon.smithy.swift.codegen.defaultSettings
+import software.amazon.smithy.swift.codegen.getFileContents
+import software.amazon.smithy.swift.codegen.protocols.rpcv2cbor.RpcV2CborProtocolGenerator
+
+class Rpcv2CborWithHttpQueryOnInputTests {
+    @Test
+    fun `does not emit queryItemProvider middleware for rpcv2Cbor service with @httpQuery member traits`() {
+        val context = setupTests("rpcv2cbor-with-httpquery-on-input.smithy", "com.test#Example")
+        val client = getFileContents(context.manifest, "Sources/example/ExampleClient.swift")
+        client.shouldNotContain("ListEvaluatorsInput.queryItemProvider(_:)")
+    }
+
+    private fun setupTests(
+        smithyFile: String,
+        serviceShapeId: String,
+    ): TestContext {
+        val context =
+            TestContext.initContextFrom(
+                smithyFile,
+                serviceShapeId,
+                RpcV2CborProtocolGenerator(),
+                { model -> model.defaultSettings(serviceShapeId, "example", "1.0.0", "Example") },
+            )
+        context.generator.initializeMiddleware(context.generationCtx)
+        context.generator.generateSerializers(context.generationCtx)
+        context.generator.generateProtocolClient(context.generationCtx)
+        context.generator.generateDeserializers(context.generationCtx)
+        context.generator.generateCodableConformanceForNestedTypes(context.generationCtx)
+        context.generationCtx.delegator.flushWriters()
+        return context
+    }
+}

--- a/smithy-swift-codegen/src/test/resources/rpcv2cbor-with-httpquery-on-input.smithy
+++ b/smithy-swift-codegen/src/test/resources/rpcv2cbor-with-httpquery-on-input.smithy
@@ -1,0 +1,36 @@
+$version: "2.0"
+namespace com.test
+
+use smithy.protocols#rpcv2Cbor
+
+@rpcv2Cbor
+service Example {
+    version: "1.0.0",
+    operations: [
+        ListEvaluators
+    ]
+}
+
+@http(method: "GET", uri: "/evaluators")
+@readonly
+operation ListEvaluators {
+    input: ListEvaluatorsInput,
+    output: ListEvaluatorsOutput
+}
+
+@input
+structure ListEvaluatorsInput {
+    @httpQuery("provider")
+    provider: String,
+
+    @httpQuery("maxResults")
+    maxResults: Integer,
+
+    @httpQuery("nextToken")
+    nextToken: String
+}
+
+@output
+structure ListEvaluatorsOutput {
+    nextToken: String
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->


## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.