### PR TITLE
fix: Disable tests requiring codegen by default

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   AWS_SWIFT_SDK_USE_LOCAL_DEPS: 1
+  AWS_SWIFT_SDK_ENABLE_UNIT_TESTS: 1
 
 jobs:
   apple-ci:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,6 @@ permissions:
 
 env:
   AWS_SWIFT_SDK_USE_LOCAL_DEPS: 1
-  AWS_SWIFT_SDK_ENABLE_UNIT_TESTS: 1
 
 jobs:
   apple-ci:
@@ -74,6 +73,8 @@ jobs:
       - name: Generate test SDKs
         run: ./scripts/codegen.sh
       - name: Build & Run smithy-swift Swift Unit Tests
+        env:
+          AWS_SWIFT_SDK_ENABLE_UNIT_TESTS: 1
         run: |
           set -o pipefail && \
           NSUnbufferedIO=YES xcodebuild \
@@ -218,6 +219,8 @@ jobs:
       - name: Generate test SDKs
         run: ./scripts/codegen.sh
       - name: Build & Run Swift Unit Tests
+        env:
+          AWS_SWIFT_SDK_ENABLE_UNIT_TESTS: 1
         run: swift test
 
   linux-ci-complete:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,6 +67,8 @@ jobs:
         uses: ./.github/actions/setup-common-tools-composite-action
       - name: List all sims installed
         run: xcrun simctl list
+      - name: Describe Package
+        run: swift package describe
       - name: Build & Run smithy-swift Kotlin Unit Tests
         run: ./gradlew build
       - name: Generate test SDKs
@@ -149,6 +151,8 @@ jobs:
         run: ./aws-sdk-swift/scripts/ci_steps/log_tool_versions.sh
       - name: List all sims installed
         run: xcrun simctl list
+      - name: Describe Package
+        run: swift package describe
       - name: Prepare aws-sdk-swift Protocol & Unit Tests
         run: |
           cd aws-sdk-swift
@@ -207,6 +211,8 @@ jobs:
           fi
       - name: Setup common tools
         uses: ./.github/actions/setup-common-tools-composite-action
+      - name: Describe Package
+        run: swift package describe
       - name: Build & Run Kotlin Unit Tests
         run: ./gradlew build
       - name: Generate test SDKs
@@ -256,6 +262,8 @@ jobs:
           STAGING_PARTNER_REPO: ${{ secrets.STAGING_PARTNER_REPO }}
       - name: Setup common tools
         uses: ./smithy-swift/.github/actions/setup-common-tools-composite-action
+      - name: Describe Package
+        run: swift package describe
       - name: Tools Versions
         run: ./aws-sdk-swift/scripts/ci_steps/log_tool_versions.sh
       - name: Prepare aws-sdk-swift Protocol & Unit Tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -153,7 +153,7 @@ jobs:
       - name: List all sims installed
         run: xcrun simctl list
       - name: Describe Package
-        run: swift package describe
+        run: cd smithy-swift && swift package describe
       - name: Prepare aws-sdk-swift Protocol & Unit Tests
         run: |
           cd aws-sdk-swift
@@ -266,7 +266,7 @@ jobs:
       - name: Setup common tools
         uses: ./smithy-swift/.github/actions/setup-common-tools-composite-action
       - name: Describe Package
-        run: swift package describe
+        run: cd smithy-swift && swift package describe
       - name: Tools Versions
         run: ./aws-sdk-swift/scripts/ci_steps/log_tool_versions.sh
       - name: Prepare aws-sdk-swift Protocol & Unit Tests

--- a/Package.swift
+++ b/Package.swift
@@ -323,8 +323,14 @@ var runtimeTargets: [PackageDescription.Target] {
 }
 
 var runtimeTestTargets: [PackageDescription.Target] {
-    guard ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_ENABLE_UNIT_TESTS"] != nil else { return [] }
-    return [
+    let baseTests: [PackageDescription.Target] = [
+        .testTarget(
+            name: "SmithyTests",
+            dependencies: ["Smithy"]
+        ),
+    ]
+    guard ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_ENABLE_UNIT_TESTS"] != nil else { return baseTests }
+    return baseTests + [
         .testTarget(
             name: "ClientRuntimeTests",
             dependencies: [
@@ -334,10 +340,6 @@ var runtimeTestTargets: [PackageDescription.Target] {
                 .product(name: "Logging", package: "swift-log"),
             ],
             resources: [ .process("Resources") ]
-        ),
-        .testTarget(
-            name: "SmithyTests",
-            dependencies: ["Smithy"]
         ),
         .testTarget(
             name: "SmithySwiftNIOTests",

--- a/Package.swift
+++ b/Package.swift
@@ -74,7 +74,11 @@ let package = Package(
         }
         return dependencies
     }(),
-    targets: [
+    targets: runtimeTargets + runtimeTestTargets
+)
+
+var runtimeTargets: [PackageDescription.Target] {
+    [
         .target(
             name: "Smithy",
             dependencies: [
@@ -315,6 +319,12 @@ let package = Package(
                 "SmithyCBOR",
             ]
         ),
+    ].compactMap { $0 }
+}
+
+var runtimeTestTargets: [PackageDescription.Target] {
+    guard ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_ENABLE_UNIT_TESTS"] != nil else { return [] }
+    return [
         .testTarget(
             name: "ClientRuntimeTests",
             dependencies: [
@@ -439,5 +449,5 @@ let package = Package(
             name: "SmithySerializationTests",
             dependencies: ["SmithySerialization", "RPCv2CBORTestSDK"]
         ),
-    ].compactMap { $0 }
-)
+    ]
+}


### PR DESCRIPTION
## Description of changes
- Unit tests and test SDKs are excluded from the `Package.swift` unless env var `AWS_SWIFT_SDK_ENABLE_UNIT_TESTS` is set (except for one, see note below).
- Set that env var on Github CI.
- Run `swift package describe` during CI builds, before codegen, to prove that the project is valid on install.

(Only the `SmithyTests` suite is tested when the env var is not set, because `swift test` fails with a nonzero exit code if there are no tests in the package.  `SmithyTests` has no dependency on generated code, and due to its nature, it likely never will.)

This addresses https://github.com/smithy-lang/smithy-swift/issues/1080.

This is intended as an interim solution to the problem described in that ticket.  A more permanent solution may be substituted at a later time.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.