### PR TITLE
fix: Synthesize operation input & output with namespace

### DIFF
--- a/Sources/SmithyCodegenCore/ModelTransformer/Model+InputOutput.swift
+++ b/Sources/SmithyCodegenCore/ModelTransformer/Model+InputOutput.swift
@@ -32,8 +32,10 @@ extension Model {
 
         for operation in operations {
             // Make new "synthetic" ShapeIDs for this operation's input & output
-            let newInputShapeID = ShapeID("swift.synthetic", "\(operation.id.name)Input")
-            let newOutputShapeID = ShapeID("swift.synthetic", "\(operation.id.name)Output")
+            // Use both the namespace and name in the new IDs, to ensure that every operation's input/output
+            // has a unique synthesized equivalent
+            let newInputShapeID = ShapeID("swift.synthetic.\(operation.id.namespace)", "\(operation.id.name)Input")
+            let newOutputShapeID = ShapeID("swift.synthetic.\(operation.id.namespace)", "\(operation.id.name)Output")
 
             // Get the input & output structures for this operation.  Substitute an empty
             // structure if ID is omitted or targets Unit


### PR DESCRIPTION
## Description of changes
Fixes an issue where a model containing two operations with the same name but different namespaces can cause name collision when synthesizing input/output shapes.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.