### PR TITLE
fix: Render non-optional properties correctly in urlPath

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/providers/HttpUrlPathProvider.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/middlewares/providers/HttpUrlPathProvider.kt
@@ -121,8 +121,10 @@ class HttpUrlPathProvider(
                     writer.openBlock("guard let $labelMemberName = value.$labelMemberName else {", "}") {
                         writer.write("return nil")
                     }
+                    resolvedURIComponents.add("\\($formattedLabel)")
+                } else {
+                    resolvedURIComponents.add("\\(value.$formattedLabel)")
                 }
-                resolvedURIComponents.add("\\($formattedLabel)")
             } else {
                 resolvedURIComponents.add(it.content)
             }


### PR DESCRIPTION
## Description of changes
Non-optional properties are being rendered incorrectly into `urlPath`.  (Specifically, they are rendered as though they were unwrapped with `guard` when they weren't.)

Correct rendered code to access non-optional properties correctly for use in `urlPath` without unwrapping.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.