### PR TITLE
chore: Relax aws-crt-swift version requirement to float up

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -62,7 +62,7 @@ let package = Package(
     ],
     dependencies: {
         var dependencies: [Package.Dependency] = [
-            .package(url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.61.1"),
+            .package(url: "https://github.com/awslabs/aws-crt-swift.git", from: "0.61.1"),
             .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.0"),
             .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
             .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.22.0"),


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/2181

## Description of changes
Allow `aws-crt-swift` dependency to float up to next major version.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.