### PR TITLE
fix: Adjust path for smoke test codegen

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/SmokeTestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/SmokeTestGenerator.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.swift.codegen.model.expectTrait
 import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.swiftmodules.ClientRuntimeTypes
 import software.amazon.smithy.swift.codegen.swiftmodules.FoundationTypes
+import software.amazon.smithy.swift.codegen.utils.SDKFileUtils
 import software.amazon.smithy.swift.codegen.utils.toLowerCamelCase
 import kotlin.jvm.optionals.getOrNull
 
@@ -34,7 +35,8 @@ open class SmokeTestGenerator(
             val operationShapeIdToTestCases = getOperationShapeIdToTestCasesMapping(serviceName)
             val testCaseNames = operationShapeIdToTestCases.values.flatten().map { it.id.toLowerCamelCase() }
             if (testCaseNames.isNotEmpty()) {
-                ctx.delegator.useFileWriter("SmokeTests/$testRunnerName/$testRunnerName.swift") { writer ->
+                val filePath = SDKFileUtils(ctx.settings).rootDirFilePath("SmokeTests/$testRunnerName/$testRunnerName")
+                ctx.delegator.useFileWriter(filePath) { writer ->
                     renderPrefixContent(serviceName, writer)
                     addEmptyLine(writer)
                     writer.write("@main")


### PR DESCRIPTION
## Description of changes
Adjust the path for smoke test codegen to match the recent move of all files into a module subfolder.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.