### PR TITLE
chore: Private-scope member schemas

### DIFF
--- a/Sources/SmithyCodegenCore/Schemas/SchemasCodegen.swift
+++ b/Sources/SmithyCodegenCore/Schemas/SchemasCodegen.swift
@@ -45,12 +45,19 @@ package struct SchemasCodegen {
         // Render each shape's schema, followed by a separate schema for each of its members, if any
         for shape in allShapes {
             // First, render a schema var for the shape itself
-            try writeSchema(ctx: ctx, writer: writer, shape: shape, containerType: nil, index: nil)
+            try writeSchema(ctx: ctx, writer: writer, shape: shape, containerType: nil, index: nil, scope: "")
 
             // Then render a schema var for each of the shape's members, if any
             guard let memberShapes = try (shape as? HasMembers)?.members else { continue }
             for (index, member) in memberShapes.enumerated() {
-                try writeSchema(ctx: ctx, writer: writer, shape: member, containerType: shape.type, index: index)
+                try writeSchema(
+                    ctx: ctx,
+                    writer: writer,
+                    shape: member,
+                    containerType: shape.type,
+                    index: index,
+                    scope: "private "
+                )
             }
         }
         // Get rid of last trailing whitespace
@@ -63,14 +70,16 @@ package struct SchemasCodegen {
         writer: SwiftWriter,
         shape: Shape,
         containerType: ShapeType?,
-        index: Int?
+        index: Int?,
+        scope: String
     ) throws {
         // Assign to a global var & open the initializer.
         // If the type is not made explicit, a schema can get a "circular reference" compile error
         // when schema target causes a reference cycle.
         // This must be a vagary of the Swift expression type checking system
+
         let varName = try shape.schemaVarName
-        try writer.openBlock("let \(varName): Smithy.Schema = Smithy.Schema(", ")") { writer in
+        try writer.openBlock("\(scope)let \(varName): Smithy.Schema = Smithy.Schema(", ")") { writer in
 
             // Write the id: and type: params.  All schemas will have this
             writer.write("id: \(shape.id.rendered),")


### PR DESCRIPTION
## Description of changes
Member schemas are never referenced except by their containing schema, which is defined in the same file.  Change member schema scope to `private` so that they may be scoped down to only where they are accessed.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.