### PR TITLE
fix: Generate manifests with correct test targets & dependencies

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
@@ -63,7 +63,7 @@ class PackageManifestGenerator(
                         }
                     }
                     val service = ctx.model.expectShape(ctx.settings.service) as ServiceShape
-                    if (dependenciesByTarget.any { it.targetName == "SmithyTestUtil" }) {
+                    if (externalDependencies.any { it.targetName == "SmithyTestUtil" }) {
                         writer.openBlock(".testTarget(", ")") {
                             writer.write("name: \$S,", ctx.settings.testModuleName)
                             writer.openBlock("dependencies: [", "]") {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
@@ -5,7 +5,6 @@
 package software.amazon.smithy.swift.codegen
 
 import software.amazon.smithy.codegen.core.SymbolDependency
-import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.swift.codegen.core.GenerationContext
 import software.amazon.smithy.swift.codegen.utils.SDKFileUtils
 
@@ -62,7 +61,6 @@ class PackageManifestGenerator(
                             }
                         }
                     }
-                    val service = ctx.model.expectShape(ctx.settings.service) as ServiceShape
                     if (externalDependencies.any { it.targetName == "SmithyTestUtil" }) {
                         writer.openBlock(".testTarget(", ")") {
                             writer.write("name: \$S,", ctx.settings.testModuleName)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
@@ -5,13 +5,8 @@
 package software.amazon.smithy.swift.codegen
 
 import software.amazon.smithy.codegen.core.SymbolDependency
-import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ServiceShape
-import software.amazon.smithy.protocoltests.traits.HttpRequestTestsTrait
-import software.amazon.smithy.protocoltests.traits.HttpResponseTestsTrait
 import software.amazon.smithy.swift.codegen.core.GenerationContext
-import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.utils.SDKFileUtils
 
 class PackageManifestGenerator(
@@ -68,7 +63,7 @@ class PackageManifestGenerator(
                         }
                     }
                     val service = ctx.model.expectShape(ctx.settings.service) as ServiceShape
-                    if (service.hasTests(ctx)) {
+                    if (dependenciesByTarget.any { it.targetName == "SmithyTestUtil" }) {
                         writer.openBlock(".testTarget(", ")") {
                             writer.write("name: \$S,", ctx.settings.testModuleName)
                             writer.openBlock("dependencies: [", "]") {
@@ -109,10 +104,3 @@ class PackageManifestGenerator(
 
 val SymbolDependency.targetName: String
     get() = expectProperty("target", String::class.java)
-
-fun ServiceShape.hasTests(ctx: GenerationContext): Boolean {
-    return allOperations.any {
-        val operation = ctx.model.expectShape(it)
-        return operation.hasTrait<HttpRequestTestsTrait>() || operation.hasTrait<HttpResponseTestsTrait>()
-    }
-}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/PackageManifestGenerator.kt
@@ -5,7 +5,13 @@
 package software.amazon.smithy.swift.codegen
 
 import software.amazon.smithy.codegen.core.SymbolDependency
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.protocoltests.traits.HttpRequestTestsTrait
+import software.amazon.smithy.protocoltests.traits.HttpResponseTestsTrait
 import software.amazon.smithy.swift.codegen.core.GenerationContext
+import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
+import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.utils.SDKFileUtils
 
 class PackageManifestGenerator(
@@ -44,6 +50,7 @@ class PackageManifestGenerator(
 
                 val dependenciesByTarget =
                     externalDependencies
+                        .filter { it.targetName != "SmithyTestUtil" }
                         .distinctBy { it.targetName + it.packageName }
                         .sortedBy { it.targetName }
 
@@ -60,11 +67,14 @@ class PackageManifestGenerator(
                             }
                         }
                     }
-                    writer.openBlock(".testTarget(", ")") {
-                        writer.write("name: \$S,", ctx.settings.testModuleName)
-                        writer.openBlock("dependencies: [", "]") {
-                            writer.write("\$S,", ctx.settings.moduleName)
-                            SwiftDependency.SMITHY_TEST_UTIL.dependencies.forEach { writeTargetDependency(writer, it) }
+                    val service = ctx.model.expectShape(ctx.settings.service) as ServiceShape
+                    if (service.hasTests(ctx)) {
+                        writer.openBlock(".testTarget(", ")") {
+                            writer.write("name: \$S,", ctx.settings.testModuleName)
+                            writer.openBlock("dependencies: [", "]") {
+                                writer.write("\$S,", ctx.settings.moduleName)
+                                SwiftDependency.SMITHY_TEST_UTIL.dependencies.forEach { writeTargetDependency(writer, it) }
+                            }
                         }
                     }
                 }
@@ -99,3 +109,10 @@ class PackageManifestGenerator(
 
 val SymbolDependency.targetName: String
     get() = expectProperty("target", String::class.java)
+
+fun ServiceShape.hasTests(ctx: GenerationContext): Boolean {
+    return allOperations.any {
+        val operation = ctx.model.expectShape(it)
+        return operation.hasTrait<HttpRequestTestsTrait>() || operation.hasTrait<HttpResponseTestsTrait>()
+    }
+}

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestGenerator.kt
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.swift.codegen.integration
 
+import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.OperationShape
@@ -30,7 +31,7 @@ abstract class HttpProtocolUnitTestGenerator<T : HttpMessageTestCase>
         protected val httpProtocolCustomizable = builder.httpProtocolCustomizable!!
         protected val httpBindingResolver = builder.httpBindingResolver!!
         protected val serviceName: String = builder.serviceName!!
-        abstract val baseTestClassName: String
+        abstract val baseTestClassSymbol: Symbol
 
         /**
          * Render a test class and unit tests for the specified [testCases]
@@ -38,10 +39,10 @@ abstract class HttpProtocolUnitTestGenerator<T : HttpMessageTestCase>
         fun renderTestClass(testClassName: String) {
             writer.write("")
             writer.openBlock(
-                "class \$L: \$L {",
+                "class \$L: \$N {",
                 "}",
                 testClassName,
-                baseTestClassName,
+                baseTestClassSymbol,
             ) {
                 testCases.forEach { renderTestFunction(it) }
             }

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
@@ -4,7 +4,6 @@
  */
 package software.amazon.smithy.swift.codegen.integration
 
-import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.protocoltests.traits.HttpRequestTestCase
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestRequestGenerator.kt
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.swift.codegen.integration
 
+import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.protocoltests.traits.HttpRequestTestCase
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait
@@ -24,7 +25,7 @@ import java.util.Base64
 open class HttpProtocolUnitTestRequestGenerator protected constructor(
     builder: Builder,
 ) : HttpProtocolUnitTestGenerator<HttpRequestTestCase>(builder) {
-    override val baseTestClassName = "HttpRequestTestBase"
+    override val baseTestClassSymbol = SmithyTestUtilTypes.HttpRequestTestBase
 
     override fun renderTestBody(test: HttpRequestTestCase) {
         renderExpectedBlock(test)

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
@@ -4,7 +4,6 @@
  */
 package software.amazon.smithy.swift.codegen.integration
 
-import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeType
 import software.amazon.smithy.model.shapes.StructureShape

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/integration/HttpProtocolUnitTestResponseGenerator.kt
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.swift.codegen.integration
 
+import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeType
 import software.amazon.smithy.model.shapes.StructureShape
@@ -38,7 +39,7 @@ import java.util.Base64
 open class HttpProtocolUnitTestResponseGenerator protected constructor(
     builder: Builder,
 ) : HttpProtocolUnitTestGenerator<HttpResponseTestCase>(builder) {
-    override val baseTestClassName = "HttpResponseTestBase"
+    override val baseTestClassSymbol = SmithyTestUtilTypes.HttpResponseTestBase
 
     protected open val inputShape: Shape?
         get() {

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/swiftmodules/SmithyTestUtilTypes.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/swiftmodules/SmithyTestUtilTypes.kt
@@ -12,6 +12,8 @@ object SmithyTestUtilTypes {
     val ProtocolTestRetryStrategyOptions = runtimeSymbol("ProtocolTestRetryStrategyOptions", SwiftDeclaration.ENUM)
     val SerdeBenchmarker = runtimeSymbol("SerdeBenchmarker", SwiftDeclaration.STRUCT)
     val SerdeBenchmarkTelemetryProvider = runtimeSymbol("SerdeBenchmarkTelemetryProvider", SwiftDeclaration.CLASS)
+    val HttpRequestTestBase = runtimeSymbol("HttpRequestTestBase", SwiftDeclaration.CLASS)
+    val HttpResponseTestBase = runtimeSymbol("HttpResponseTestBase", SwiftDeclaration.CLASS)
 }
 
 private fun runtimeSymbol(

--- a/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/manifestanddocs/PackageManifestGeneratorTests.kt
+++ b/smithy-swift-codegen/src/test/kotlin/software/amazon/smithy/swift/codegen/manifestanddocs/PackageManifestGeneratorTests.kt
@@ -108,6 +108,7 @@ class PackageManifestGeneratorTests {
             }
         testContext.generationCtx.delegator.useFileWriter("xyz.swift") { writer ->
             writer.addDependency(SwiftDependency.CLIENT_RUNTIME)
+            writer.addDependency(SwiftDependency.SMITHY_TEST_UTIL)
         }
         PackageManifestGenerator(testContext.context).writePackageManifest(testContext.generationCtx.delegator.dependencies)
         testContext.generationCtx.delegator.flushWriters()

--- a/smithy-swift-codegen/src/test/resources/simple-service-with-operation-and-dependency.smithy
+++ b/smithy-swift-codegen/src/test/resources/simple-service-with-operation-and-dependency.smithy
@@ -2,7 +2,6 @@ $version: "1.0"
 namespace smithy.example
 
 use aws.protocols#awsJson1_1
-use smithy.test#httpRequestTests
 
 @awsJson1_1
 service Example {
@@ -10,9 +9,6 @@ service Example {
     operations: [GetFoo]
 }
 
-@httpRequestTests([
-    { id: "SomeTest", protocol: "aws.protocols#restJson1", method: "GET", uri: "/" }
-])
 operation GetFoo {
     input: GetFooInput,
     output: GetFooOutput,

--- a/smithy-swift-codegen/src/test/resources/simple-service-with-operation-and-dependency.smithy
+++ b/smithy-swift-codegen/src/test/resources/simple-service-with-operation-and-dependency.smithy
@@ -2,6 +2,7 @@ $version: "1.0"
 namespace smithy.example
 
 use aws.protocols#awsJson1_1
+use smithy.test#httpRequestTests
 
 @awsJson1_1
 service Example {
@@ -9,6 +10,9 @@ service Example {
     operations: [GetFoo]
 }
 
+@httpRequestTests([
+    { id: "SomeTest", protocol: "aws.protocols#restJson1", method: "GET", uri: "/" }
+])
 operation GetFoo {
     input: GetFooInput,
     output: GetFooOutput,


### PR DESCRIPTION
## Description of changes
Corrects the following problems in code-generated package manifests:
- `SmithyTestUtil` is currently included as a dependency of the generated SDK target.  This attempts to link the SDK to `XCTest` at runtime, which fails because `XCTest` is not available to executables outside of Xcode / `swift test`.  To correct, `SmithyTestUtil` is filtered from SDK dependencies by name.  (It is still linked by default to the SDK's test target, if it has one, see next item.)
- Currently, all package manifests are generated with a test target, even if they don't have tests.  To correct, the test target will be added only when `SmithyTestUtil` has been imported by the `SwiftWriter`, which is always true when there are tests.

Refactor:
- `HttpProtocolUnitTestGenerator`'s string-typed `baseTestClassName` is changed to a Symbol-typed `baseTestClassSymbol`.  Subclasses are changed as well.

## Scope
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.