### PR TITLE
chore: SmithyStreams cleanup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -216,7 +216,6 @@ var runtimeTargets: [PackageDescription.Target] {
             dependencies: [
                 "Smithy",
                 "SmithyHTTPAPI",
-                "SmithyStreams",
                 .product(name: "AwsCommonRuntimeKit", package: "aws-crt-swift")
             ]
         ),
@@ -257,11 +256,7 @@ var runtimeTargets: [PackageDescription.Target] {
         ),
         .target(
             name: "SmithyStreams",
-            dependencies: [
-                "Smithy",
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "AwsCommonRuntimeKit", package: "aws-crt-swift")
-            ]
+            dependencies: ["Smithy"]
         ),
         .target(
             name: "SmithyChecksumsAPI",

--- a/Sources/SmithyHTTPClient/SdkHttpRequest+CRT.swift
+++ b/Sources/SmithyHTTPClient/SdkHttpRequest+CRT.swift
@@ -8,7 +8,6 @@
 import AwsCommonRuntimeKit
 import struct Smithy.URI
 import class SmithyHTTPAPI.HTTPRequest
-@_spi(SmithyStreams) import class SmithyStreams.StreamableHttpBody
 
 @_spi(SmithyHTTPClient)
 extension HTTPRequest {

--- a/Sources/SmithyHTTPClient/StreamableHttpBody.swift
+++ b/Sources/SmithyHTTPClient/StreamableHttpBody.swift
@@ -14,8 +14,7 @@ import struct Smithy.SwiftLogger
 
 /// A class that implements the `IStreamable` protocol for `ByteStream`.
 /// It acts as a bridge between AWS SDK and CRT.
-@_spi(SmithyStreams)
-public class StreamableHttpBody: IStreamable {
+class StreamableHttpBody: IStreamable {
 
     /// The index of the data being transferred.
     ///
@@ -26,7 +25,7 @@ public class StreamableHttpBody: IStreamable {
     let body: ByteStream
     let logger: SwiftLogger
 
-    public init(body: ByteStream) {
+    init(body: ByteStream) {
         self.body = body
 
         switch body {
@@ -44,7 +43,7 @@ public class StreamableHttpBody: IStreamable {
     /// Returns the length of the stream
     /// - Returns: The length of the stream
     /// if not available, returns 0
-    public func length() throws -> UInt64 {
+    func length() throws -> UInt64 {
         switch body {
         case .data(let data):
             return UInt64(data?.count ?? 0)
@@ -59,7 +58,7 @@ public class StreamableHttpBody: IStreamable {
     /// - Parameters:
     ///   - offset: offset to seek to
     ///   - streamSeekType: type of seek
-    public func seek(offset: Int64, streamSeekType: AwsCommonRuntimeKit.StreamSeekType) throws {
+    func seek(offset: Int64, streamSeekType: AwsCommonRuntimeKit.StreamSeekType) throws {
         guard streamSeekType == .begin else {
             throw StreamError.notSupported("Seeking from end is not supported."
                                            + " Only seeking from beginning is supported.")
@@ -85,7 +84,7 @@ public class StreamableHttpBody: IStreamable {
         }
     }
 
-    public func read(buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int? {
+    func read(buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int? {
         switch body {
         case .data(let data):
             guard let data = data else { return nil }
@@ -111,7 +110,7 @@ public class StreamableHttpBody: IStreamable {
         }
     }
 
-    public func isEndOfStream() -> Bool {
+    func isEndOfStream() -> Bool {
         switch body {
         case .data(let data):
             guard let data = data else { return true }

--- a/Sources/SmithyHTTPClient/StreamableHttpBody.swift
+++ b/Sources/SmithyHTTPClient/StreamableHttpBody.swift
@@ -14,7 +14,7 @@ import struct Smithy.SwiftLogger
 
 /// A class that implements the `IStreamable` protocol for `ByteStream`.
 /// It acts as a bridge between AWS SDK and CRT.
-class StreamableHttpBody: IStreamable {
+final class StreamableHttpBody: IStreamable {
 
     /// The index of the data being transferred.
     ///

--- a/Tests/SmithyHTTPClientTests/StreamableHttpBodyTests.swift
+++ b/Tests/SmithyHTTPClientTests/StreamableHttpBodyTests.swift
@@ -6,8 +6,8 @@
 //
 
 import XCTest
-@testable import ClientRuntime
-@_spi(SmithyStreams) import class SmithyStreams.StreamableHttpBody
+import Smithy
+@testable import SmithyHTTPClient
 import AwsCommonRuntimeKit
 
 final class StreamableHttpBodyTests: XCTestCase {


### PR DESCRIPTION
## Description of changes
Cleans up two targets and simplifies public APIs by moving `StreamableHttpBody` to the only target where it is used.  (It has no other use than with the CRT-based HTTP client since its purpose is to bridge the SDK's & CRT's data streaming systems.)
- Moves `StreamableHttpBody` from `SmithyStreams` to `SmithyHTTPClient` (i.e. the CRT-based HTTP client) since that is the only place it is used.
- `StreamableHttpBody` is made internal since it is no longer accessed outside its module, and its `@_spi()` annotation is removed.
- Removed unused dependencies from `SmithyStreams` and `SmithyHTTPClient`.
- Moved the tests for `StreamableHttpBody` from `ClientRuntimeTests` to `SmithyHTTPClientTests`.  (Having those tests in `ClientRuntimeTests` was probably an oversight from when `StreamableHttpBody` was pulled out of `ClientRuntime` during initial SDK modularization.)

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.