### PR TITLE
chore: Make DeserializableShape Sendable

### DIFF
--- a/Sources/SmithySerialization/Deserialization/DeserializableShape.swift
+++ b/Sources/SmithySerialization/Deserialization/DeserializableShape.swift
@@ -6,6 +6,6 @@
 //
 
 @_spi(SchemaBasedSerde)
-public protocol DeserializableShape {
+public protocol DeserializableShape: Sendable {
     static func deserialize(_ deserializer: ShapeDeserializer) throws -> Self
 }


### PR DESCRIPTION
## Description of changes
Re-adds the `Sendable` protocol to `DeserializableShape`.

Needed because the `TypeRegistry` is `Sendable` and it stores many `DeserializableShape` types.  As a practical matter, all Swift model types are already `Sendable` so this addition places no additional requirements on models.

This quiets a warning thrown by `TypeRegistry`:
```
Stored property 'swiftType' of 'Sendable'-conforming struct 'Entry' has non-Sendable type 'any DeserializableShape.Type'
```

I should also add that the following, which would seem to be the most appropriate solution, does not work: changing the type of `TypeRegistry`'s stored model type from `any DeserializableShape` to `any (DeserializableShape & Sendable)`.  While this type specification (a "composed metatype") is allowed, the Swift compiler cannot resolve any methods on a composed metatype.  This appears to be a bug or limitation (you pick!) of the Swift type system.  So, the best solution is adding the constraint to `DeserializableShape` as we have done.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.