### PR TITLE
chore: Only generate model JSON file when used

### DIFF
--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ModelWriter.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/ModelWriter.kt
@@ -12,9 +12,6 @@ class ModelWriter {
         manifest: FileManifest,
         settings: SwiftSettings,
     ) {
-        // If a model path was added to SwiftSettings, skip writing the model
-        if (settings.modelPath != null) return
-
         // Convert the Model to a Node, then to pretty-printed JSON,
         // then write the JSON into the manifest
         val defaultPath = SDKFileUtils(settings).sourcesDirFilePath("model", "json")

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftCodegenPlugin.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftCodegenPlugin.kt
@@ -93,7 +93,8 @@ class SwiftCodegenPlugin : SmithyBuildPlugin {
         val enabledIntegrations = getEnabledIntegrations(context.model, swiftSettings)
 
         // Write the model as JSON AST, before any preprocessing occurs
-        if (SerdeUtils.useSchemaBased(swiftSettings, context.model)) {
+        // Only write JSON model if schema-based is in use and JSON model wasn't provided
+        if (SerdeUtils.useSchemaBased(swiftSettings, context.model) && swiftSettings.modelPath == null) {
             ModelWriter().write(context.model, context.fileManifest, swiftSettings)
         }
 

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftCodegenPlugin.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/SwiftCodegenPlugin.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.transform.ModelTransformer
 import software.amazon.smithy.swift.codegen.core.GenerationContext
 import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+import software.amazon.smithy.swift.codegen.integration.serde.SerdeUtils
 import software.amazon.smithy.swift.codegen.model.AddOperationShapes
 import software.amazon.smithy.swift.codegen.model.EquatableConformanceTransformer
 import software.amazon.smithy.swift.codegen.model.NeedsReaderWriterTransformer
@@ -92,7 +93,9 @@ class SwiftCodegenPlugin : SmithyBuildPlugin {
         val enabledIntegrations = getEnabledIntegrations(context.model, swiftSettings)
 
         // Write the model as JSON AST, before any preprocessing occurs
-        ModelWriter().write(context.model, context.fileManifest, swiftSettings)
+        if (SerdeUtils.useSchemaBased(swiftSettings, context.model)) {
+            ModelWriter().write(context.model, context.fileManifest, swiftSettings)
+        }
 
         val resolvedModel = preprocessModel(context.model, swiftSettings, enabledIntegrations)
 


### PR DESCRIPTION
## Description of changes
Only generate model JSON when schema-based serde is in use and no outside model file is provided, otherwise the generated model JSON file is unused.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.