### PR TITLE
chore: Split test SDKs into dedicated units

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -78,7 +78,7 @@ jobs:
           cd test-sdks && \
           set -o pipefail && \
           NSUnbufferedIO=YES xcodebuild \
-            -scheme SmithySwiftTests-Package \
+            -scheme SmithySwiftCodegenTests-Package \
             -destination '${{ matrix.destination }}' \
             test 2>&1 \
             | xcbeautify

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -75,18 +75,10 @@ jobs:
         run: ./scripts/codegen.sh
       - name: Build & Run smithy-swift Swift Unit Tests
         run: |
-          set -o pipefail && \
-          NSUnbufferedIO=YES xcodebuild \
-            -scheme smithy-swift-Package \
-            -destination '${{ matrix.destination }}' \
-            test 2>&1 \
-            | xcbeautify
-      - name: Build & Run Swift Codegen Tests
-        run: |
           cd test-sdks && \
           set -o pipefail && \
           NSUnbufferedIO=YES xcodebuild \
-            -scheme SmithySwiftCodegenTests-Package \
+            -scheme SmithySwiftTests-Package \
             -destination '${{ matrix.destination }}' \
             test 2>&1 \
             | xcbeautify

--- a/test-sdks/Package.swift
+++ b/test-sdks/Package.swift
@@ -25,8 +25,20 @@ let package = Package(
             path: "build/smithyprojections/test-sdks/awsjson-test-sdk/swift-codegen/AWSJSONTestSDK"
         ),
         .package(
-            name: "RPCv2CBORTestSDK",
-            path: "build/smithyprojections/test-sdks/rpcv2cbor-test-sdk/swift-codegen/RPCv2CBORTestSDK"
+            name: "JSONNameTestSDK",
+            path: "build/smithyprojections/test-sdks/jsonname-test-sdk/swift-codegen/JSONNameTestSDK"
+        ),
+        .package(
+            name: "MaxRecursionTestSDK",
+            path: "build/smithyprojections/test-sdks/maxrecursion-test-sdk/swift-codegen/MaxRecursionTestSDK"
+        ),
+        .package(
+            name: "NullToleranceTestSDK",
+            path: "build/smithyprojections/test-sdks/nulltolerance-test-sdk/swift-codegen/NullToleranceTestSDK"
+        ),
+        .package(
+            name: "StringSerTestSDK",
+            path: "build/smithyprojections/test-sdks/stringser-test-sdk/swift-codegen/StringSerTestSDK"
         ),
         .package(
             name: "WaitersTestSDK",
@@ -38,7 +50,7 @@ let package = Package(
             name: "SmithySerializationTests",
             dependencies: [
                 .product(name: "SmithySerialization", package: "smithy-swift"),
-                .product(name: "RPCv2CBORTestSDK", package: "RPCv2CBORTestSDK"),
+                .product(name: "StringSerTestSDK", package: "StringSerTestSDK"),
             ]
         ),
         .testTarget(
@@ -47,7 +59,7 @@ let package = Package(
                 .product(name: "SmithyCBOR", package: "smithy-swift"),
                 .product(name: "Smithy", package: "smithy-swift"),
                 .product(name: "AwsCommonRuntimeKit", package: "aws-crt-swift"),
-                .product(name: "RPCv2CBORTestSDK", package: "RPCv2CBORTestSDK"),
+                .product(name: "MaxRecursionTestSDK", package: "MaxRecursionTestSDK"),
             ]
         ),
         .testTarget(
@@ -59,6 +71,8 @@ let package = Package(
                 .product(name: "SmithyTimestamps", package: "smithy-swift"),
                 .product(name: "SmithyTestUtil", package: "smithy-swift"),
                 .product(name: "AWSJSONTestSDK", package: "AWSJSONTestSDK"),
+                .product(name: "JSONNameTestSDK", package: "JSONNameTestSDK"),
+                .product(name: "NullToleranceTestSDK", package: "NullToleranceTestSDK"),
             ]
         ),
         .testTarget(

--- a/test-sdks/Package.swift
+++ b/test-sdks/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "SmithySwiftCodegenTests",
+    name: "SmithySwiftTests",
     platforms: [
         .macOS(.v12),
         .iOS(.v13),
@@ -20,37 +20,19 @@ let package = Package(
 
         // Generated test SDKs.  Models are in build/model.  Use them where Smithy generates them.
         // Run bash script ./scripts/codegen.sh from smithy-swift root to generate or regenerate these files
-        .package(
-            name: "AWSJSONTestSDK",
-            path: "build/smithyprojections/test-sdks/awsjson-test-sdk/swift-codegen/AWSJSONTestSDK"
-        ),
-        .package(
-            name: "JSONNameTestSDK",
-            path: "build/smithyprojections/test-sdks/jsonname-test-sdk/swift-codegen/JSONNameTestSDK"
-        ),
-        .package(
-            name: "MaxRecursionTestSDK",
-            path: "build/smithyprojections/test-sdks/maxrecursion-test-sdk/swift-codegen/MaxRecursionTestSDK"
-        ),
-        .package(
-            name: "NullToleranceTestSDK",
-            path: "build/smithyprojections/test-sdks/nulltolerance-test-sdk/swift-codegen/NullToleranceTestSDK"
-        ),
-        .package(
-            name: "StringSerTestSDK",
-            path: "build/smithyprojections/test-sdks/stringser-test-sdk/swift-codegen/StringSerTestSDK"
-        ),
-        .package(
-            name: "WaitersTestSDK",
-            path: "build/smithyprojections/test-sdks/waiters-test-sdk/swift-codegen/WaitersTestSDK"
-        ),
+        testSDKPackage("AWSJSON"),
+        testSDKPackage("JSONName"),
+        testSDKPackage("MaxRecursion"),
+        testSDKPackage("NullTolerance"),
+        testSDKPackage("StringSerializer"),
+        testSDKPackage("Waiters"),
     ],
     targets: [
         .testTarget(
             name: "SmithySerializationTests",
             dependencies: [
                 .product(name: "SmithySerialization", package: "smithy-swift"),
-                .product(name: "StringSerTestSDK", package: "StringSerTestSDK"),
+                testSDKProduct("StringSerializer"),
             ]
         ),
         .testTarget(
@@ -59,7 +41,7 @@ let package = Package(
                 .product(name: "SmithyCBOR", package: "smithy-swift"),
                 .product(name: "Smithy", package: "smithy-swift"),
                 .product(name: "AwsCommonRuntimeKit", package: "aws-crt-swift"),
-                .product(name: "MaxRecursionTestSDK", package: "MaxRecursionTestSDK"),
+                testSDKProduct("MaxRecursion"),
             ]
         ),
         .testTarget(
@@ -70,9 +52,9 @@ let package = Package(
                 .product(name: "ClientRuntime", package: "smithy-swift"),
                 .product(name: "SmithyTimestamps", package: "smithy-swift"),
                 .product(name: "SmithyTestUtil", package: "smithy-swift"),
-                .product(name: "AWSJSONTestSDK", package: "AWSJSONTestSDK"),
-                .product(name: "JSONNameTestSDK", package: "JSONNameTestSDK"),
-                .product(name: "NullToleranceTestSDK", package: "NullToleranceTestSDK"),
+                testSDKProduct("AWSJSON"),
+                testSDKProduct("JSONName"),
+                testSDKProduct("NullTolerance"),
             ]
         ),
         .testTarget(
@@ -80,7 +62,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Smithy", package: "smithy-swift"),
                 .product(name: "SmithyWaitersAPI", package: "smithy-swift"),
-                .product(name: "WaitersTestSDK", package: "WaitersTestSDK"),
+                testSDKProduct("Waiters"),
             ]
         ),
         .testTarget(
@@ -212,3 +194,14 @@ let package = Package(
         ),
     ]
 )
+
+private func testSDKPackage(_ name: String) -> Package.Dependency {
+    .package(
+        name: "\(name)TestSDK",
+        path: "build/smithyprojections/test-sdks/\(name)/swift-codegen/\(name)TestSDK"
+    )
+}
+
+private func testSDKProduct(_ name: String) -> Target.Dependency {
+    .product(name: "\(name)TestSDK", package: "\(name)TestSDK")
+}

--- a/test-sdks/Package.swift
+++ b/test-sdks/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "SmithySwiftTests",
+    name: "SmithySwiftCodegenTests",
     platforms: [
         .macOS(.v12),
         .iOS(.v13),

--- a/test-sdks/Tests/ClientRuntimeTests/LoggingTests/SwiftLoggerTests.swift
+++ b/test-sdks/Tests/ClientRuntimeTests/LoggingTests/SwiftLoggerTests.swift
@@ -99,6 +99,18 @@ private class TestLogHandler: LogHandler, @unchecked Sendable {
 
     var logLevel: Logging.Logger.Level = .trace
 
+    func log(event: LogEvent) {
+        log(
+            level: event.level,
+            message: event.message,
+            metadata: event.metadata,
+            source: event.source,
+            file: event.file,
+            function: event.function,
+            line: event.line
+        )
+    }
+
     func log(
         level: Logger.Level,
         message: Logger.Message,

--- a/test-sdks/Tests/ClientRuntimeTests/LoggingTests/SwiftLoggerTests.swift
+++ b/test-sdks/Tests/ClientRuntimeTests/LoggingTests/SwiftLoggerTests.swift
@@ -99,18 +99,6 @@ private class TestLogHandler: LogHandler, @unchecked Sendable {
 
     var logLevel: Logging.Logger.Level = .trace
 
-    func log(event: LogEvent) {
-        log(
-            level: event.level,
-            message: event.message,
-            metadata: event.metadata,
-            source: event.source,
-            file: event.file,
-            function: event.function,
-            line: event.line
-        )
-    }
-
     func log(
         level: Logger.Level,
         message: Logger.Message,

--- a/test-sdks/Tests/SmithyCBORTests/RecursionTests.swift
+++ b/test-sdks/Tests/SmithyCBORTests/RecursionTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @_spi(SchemaBasedSerde) import Smithy
 @_spi(SchemaBasedSerde) import SmithyCBOR
 import AwsCommonRuntimeKit
-@_spi(SchemaBasedSerde) import RPCv2CBORTestSDK
+@_spi(SchemaBasedSerde) import MaxRecursionTestSDK
 
 final class RecursionTests: XCTestCase {
 

--- a/test-sdks/Tests/SmithyJSONTests/CollectionTests.swift
+++ b/test-sdks/Tests/SmithyJSONTests/CollectionTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 @_spi(SchemaBasedSerde) import SmithyJSON
-@_spi(SchemaBasedSerde) import AWSJSONTestSDK
+@_spi(SchemaBasedSerde) import NullToleranceTestSDK
 
 final class CollectionTests: XCTestCase {
 

--- a/test-sdks/Tests/SmithyJSONTests/CollectionTests.swift
+++ b/test-sdks/Tests/SmithyJSONTests/CollectionTests.swift
@@ -18,7 +18,7 @@ final class CollectionTests: XCTestCase {
         let subject = try Deserializer(usesJSONNameTrait: false, data: data)
 
         // Deserialize to a structure
-        let output = try NullToleranceOutput.deserialize(subject)
+        let output = try NullToleranceTestOutput.deserialize(subject)
 
         // Verify that list is just the numbers, omitting the nulls
         XCTAssertEqual(output.list, [123, 456, 789])
@@ -31,7 +31,7 @@ final class CollectionTests: XCTestCase {
         let subject = try Deserializer(usesJSONNameTrait: false, data: data)
 
         // Deserialize to a structure
-        let output = try NullToleranceOutput.deserialize(subject)
+        let output = try NullToleranceTestOutput.deserialize(subject)
 
         // Verify that map is just the keys & values for nonnull values
         XCTAssertEqual(output.map, ["a": 123, "c": 456, "e": 789])
@@ -44,7 +44,7 @@ final class CollectionTests: XCTestCase {
         let subject = try Deserializer(usesJSONNameTrait: false, data: data)
 
         // Deserialize to a structure
-        let output = try NullToleranceOutput.deserialize(subject)
+        let output = try NullToleranceTestOutput.deserialize(subject)
 
         // Verify that list contains numbers and nulls
         XCTAssertEqual(output.sparseList, [123, nil, 456, nil, 789, nil])
@@ -57,7 +57,7 @@ final class CollectionTests: XCTestCase {
         let subject = try Deserializer(usesJSONNameTrait: false, data: data)
 
         // Deserialize to a structure
-        let output = try NullToleranceOutput.deserialize(subject)
+        let output = try NullToleranceTestOutput.deserialize(subject)
 
         // Verify that map contains keys & values for null & nonnull values
         XCTAssertEqual(output.sparseMap, ["a": 123, "b": nil, "c": 456, "d": nil, "e": 789, "f": nil])

--- a/test-sdks/Tests/SmithyJSONTests/JSONNameTests.swift
+++ b/test-sdks/Tests/SmithyJSONTests/JSONNameTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 @_spi(SchemaBasedSerde) import SmithyJSON
-@_spi(SchemaBasedSerde) import AWSJSONTestSDK
+@_spi(SchemaBasedSerde) import JSONNameTestSDK
 
 final class JSONNameTests: XCTestCase {
 

--- a/test-sdks/Tests/SmithyJSONTests/JSONNameTests.swift
+++ b/test-sdks/Tests/SmithyJSONTests/JSONNameTests.swift
@@ -13,7 +13,7 @@ final class JSONNameTests: XCTestCase {
 
     func test_jsonNameSerialize_serializesMemberNameWhenDisabled() throws {
         let subject = Serializer(usesJSONNameTrait: false)
-        let input = JSONNameInput(original: "abc")
+        let input = JSONNameMembersInput(original: "abc")
         try input.serialize(subject)
         let data = try subject.data
         XCTAssertEqual(data, Data(#"{"original":"abc"}"#.utf8))
@@ -21,7 +21,7 @@ final class JSONNameTests: XCTestCase {
 
     func test_jsonNameSerialize_serializesJSONNameWhenEnabled() throws {
         let subject = Serializer(usesJSONNameTrait: true)
-        let input = JSONNameInput(original: "abc")
+        let input = JSONNameMembersInput(original: "abc")
         try input.serialize(subject)
         let data = try subject.data
         XCTAssertEqual(data, Data(#"{"modified":"abc"}"#.utf8))
@@ -30,14 +30,14 @@ final class JSONNameTests: XCTestCase {
     func test_jsonNameDeserialize_deserializesMemberNameWhenDisabled() throws {
         let data = Data(#"{"original":"abc"}"#.utf8)
         let subject = try Deserializer(usesJSONNameTrait: false, data: data)
-        let output = try JSONNameOutput.deserialize(subject)
+        let output = try JSONNameMembersOutput.deserialize(subject)
         XCTAssertEqual(output.original, "abc")
     }
 
     func test_jsonNameDeserialize_deserializesJSONNameWhenEnabled() throws {
         let data = Data(#"{"modified":"abc"}"#.utf8)
         let subject = try Deserializer(usesJSONNameTrait: true, data: data)
-        let output = try JSONNameOutput.deserialize(subject)
+        let output = try JSONNameMembersOutput.deserialize(subject)
         XCTAssertEqual(output.original, "abc")
     }
 }

--- a/test-sdks/Tests/SmithyRetriesTests/DefaultRetryStrategy/DefaultRetryStrategyTests.swift
+++ b/test-sdks/Tests/SmithyRetriesTests/DefaultRetryStrategy/DefaultRetryStrategyTests.swift
@@ -24,9 +24,18 @@ final class DefaultRetryStrategyTests: XCTestCase {
 
     private var options: RetryStrategyOptions!
     private var subject: DefaultRetryStrategy!
-    private var mockSleeper: ((TimeInterval) async throws -> Void)!
+    private var mockSleeper: @Sendable (TimeInterval) async throws -> Void = { _ in }
     private var backoffStrategy: ExponentialBackoffStrategy!
-    private var actualDelay: TimeInterval = 0.0
+
+    actor Delay {
+        var actual: TimeInterval = 0.0
+
+        func setActual(_ timeInterval: TimeInterval) {
+            self.actual = timeInterval
+        }
+    }
+
+    private let delay = Delay()
 
     override func setUp() {
         backoffStrategy = .init()
@@ -35,7 +44,7 @@ final class DefaultRetryStrategyTests: XCTestCase {
             backoffStrategy: backoffStrategy, maxRetriesBase: 2, useNewRetries2026: true
         )
         subject = DefaultRetryStrategy(options: options)
-        mockSleeper = { self.actualDelay = $0 }
+        mockSleeper = { @Sendable in await self.delay.setActual($0) }
         subject.sleeper = mockSleeper
     }
 
@@ -82,18 +91,22 @@ final class DefaultRetryStrategyTests: XCTestCase {
     func test_refresh_sleepsForExpectedPeriodOnNonThrottlingRetry() async throws {
         let token1 = try await subject.acquireInitialRetryToken(tokenScope: scope1)
         try await subject.refreshRetryTokenForRetry(tokenToRenew: token1, errorInfo: retryableInfo)
-        XCTAssertEqual(actualDelay, 0.05)
+        let actual1 = await delay.actual
+        XCTAssertEqual(actual1, 0.05)
         try await subject.refreshRetryTokenForRetry(tokenToRenew: token1, errorInfo: retryableInfo)
-        XCTAssertEqual(actualDelay, 0.1)
+        let actual2 = await delay.actual
+        XCTAssertEqual(actual2, 0.1)
     }
 
 
     func test_refresh_sleepsForExpectedPeriodOnThrottlingRetry() async throws {
         let token1 = try await subject.acquireInitialRetryToken(tokenScope: scope1)
         try await subject.refreshRetryTokenForRetry(tokenToRenew: token1, errorInfo: retryableThrottlingInfo)
-        XCTAssertEqual(actualDelay, 1.0)
+        let actual1 = await delay.actual
+        XCTAssertEqual(actual1, 1.0)
         try await subject.refreshRetryTokenForRetry(tokenToRenew: token1, errorInfo: retryableThrottlingInfo)
-        XCTAssertEqual(actualDelay, 2.0)
+        let actual2 = await delay.actual
+        XCTAssertEqual(actual2, 2.0)
     }
 
 
@@ -101,7 +114,8 @@ final class DefaultRetryStrategyTests: XCTestCase {
         let token1 = try await subject.acquireInitialRetryToken(tokenScope: scope1)
         try await subject.refreshRetryTokenForRetry(tokenToRenew: token1, errorInfo: retryableInfoWithHint)
         // retryAfterHint=0.44, t_i=0.05, so delay = max(0.44, 0.05) = 0.44
-        XCTAssertEqual(actualDelay, retryableInfoWithHint.retryAfterHint!)
+        let actual = await delay.actual
+        XCTAssertEqual(actual, retryableInfoWithHint.retryAfterHint!)
     }
 
     func test_refresh_throwsMaxAttemptsReachedWhenMaxAttemptsReached() async throws {
@@ -175,7 +189,8 @@ final class DefaultRetryStrategyTests: XCTestCase {
         let info = RetryErrorInfo(errorType: .serverError, retryAfterHint: 0.01, isTimeout: false)
         let token1 = try await subject.acquireInitialRetryToken(tokenScope: scope1)
         try await subject.refreshRetryTokenForRetry(tokenToRenew: token1, errorInfo: info)
-        XCTAssertEqual(actualDelay, 0.05)
+        let actual = await delay.actual
+        XCTAssertEqual(actual, 0.05)
     }
 
     func test_retryAfterHint_bounded_byMaximum() async throws {
@@ -183,7 +198,8 @@ final class DefaultRetryStrategyTests: XCTestCase {
         let info = RetryErrorInfo(errorType: .serverError, retryAfterHint: 10.0, isTimeout: false)
         let token1 = try await subject.acquireInitialRetryToken(tokenScope: scope1)
         try await subject.refreshRetryTokenForRetry(tokenToRenew: token1, errorInfo: info)
-        XCTAssertEqual(actualDelay, 5.05)
+        let actual = await delay.actual
+        XCTAssertEqual(actual, 5.05)
     }
 
     func test_retryAfterHint_withinBounds_usedAsIs() async throws {
@@ -191,6 +207,7 @@ final class DefaultRetryStrategyTests: XCTestCase {
         let info = RetryErrorInfo(errorType: .serverError, retryAfterHint: 1.5, isTimeout: false)
         let token1 = try await subject.acquireInitialRetryToken(tokenScope: scope1)
         try await subject.refreshRetryTokenForRetry(tokenToRenew: token1, errorInfo: info)
-        XCTAssertEqual(actualDelay, 1.5)
+        let actual = await delay.actual
+        XCTAssertEqual(actual, 1.5)
     }
 }

--- a/test-sdks/Tests/SmithySerializationTests/StringSerializerTests.swift
+++ b/test-sdks/Tests/SmithySerializationTests/StringSerializerTests.swift
@@ -14,11 +14,11 @@ import enum Smithy.Prelude
 import class Smithy.Schema
 @_spi(SchemaBasedSerde)
 import class Smithy.SensitiveTrait
-import struct RPCv2CBORTestSDK.GetWidgetOutput
-import enum RPCv2CBORTestSDK.RPCv2CBORServiceClientTypes
+import struct StringSerTestSDK.GetWidgetOutput
+import enum StringSerTestSDK.StringSerServiceClientTypes
 
 final class StringSerializerTests: XCTestCase {
-    typealias TestStruct = RPCv2CBORServiceClientTypes.SensitiveType
+    typealias TestStruct = StringSerServiceClientTypes.SensitiveType
 
     func test_writesASimpleString() throws {
         let string = "xyz"

--- a/test-sdks/Tests/SmithySerializationTests/StringSerializerTests.swift
+++ b/test-sdks/Tests/SmithySerializationTests/StringSerializerTests.swift
@@ -14,11 +14,11 @@ import enum Smithy.Prelude
 import class Smithy.Schema
 @_spi(SchemaBasedSerde)
 import class Smithy.SensitiveTrait
-import struct StringSerTestSDK.GetWidgetOutput
-import enum StringSerTestSDK.StringSerServiceClientTypes
+import struct StringSerializerTestSDK.GetWidgetOutput
+import enum StringSerializerTestSDK.StringSerializerClientTypes
 
 final class StringSerializerTests: XCTestCase {
-    typealias TestStruct = StringSerServiceClientTypes.SensitiveType
+    typealias TestStruct = StringSerializerClientTypes.SensitiveType
 
     func test_writesASimpleString() throws {
         let string = "xyz"

--- a/test-sdks/Tests/SmithyWaitersAPITests/WaiterTestUtils.swift
+++ b/test-sdks/Tests/SmithyWaitersAPITests/WaiterTestUtils.swift
@@ -13,7 +13,7 @@ import XCTest
 // to makes tests as simple as possible.
 // These Equatable conformances make the tests easier to read (and write).
 
-extension WaiterConfiguration.Acceptor.Match: Equatable where Output: Equatable {
+extension WaiterConfiguration.Acceptor.Match: Swift.Equatable where Output: Equatable {
 
     public static func ==(lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
@@ -29,7 +29,7 @@ extension WaiterConfiguration.Acceptor.Match: Equatable where Output: Equatable 
     }
 }
 
-extension WaiterOutcome: Equatable where Output: Equatable {
+extension WaiterOutcome: Swift.Equatable where Output: Equatable {
 
     public static func ==(lhs: WaiterOutcome, rhs: WaiterOutcome) -> Bool {
         lhs.attempts == rhs.attempts && lhs.result == rhs.result
@@ -50,7 +50,7 @@ extension Result where Success: Equatable, Failure == Error {
     }
 }
 
-extension WaiterFailureError: Equatable where Output == String {
+extension WaiterFailureError: Swift.Equatable where Output == String {
 
     public static func ==(lhs: WaiterFailureError, rhs: WaiterFailureError) -> Bool {
         lhs.attempts == rhs.attempts && lhs.failedOnMatch == rhs.failedOnMatch && lhs.result == rhs.result

--- a/test-sdks/build.gradle.kts
+++ b/test-sdks/build.gradle.kts
@@ -15,26 +15,26 @@ dependencies {
     implementation(project(":smithy-swift-codegen"))
 }
 
-data class TestSDK(val projection: String, val service: String, val module: String)
+data class TestSDK(val name: String)
 
 val testSDKs = listOf(
-    TestSDK("awsjson-test-sdk", "smithy.swift.tests#AWSJSONService", "AWSJSONTestSDK"),
-    TestSDK("jsonname-test-sdk", "smithy.swift.tests.jsonName#JSONNameService", "JSONNameTestSDK"),
-    TestSDK("maxrecursion-test-sdk", "smithy.swift.tests.maxRecursion#MaxRecursionService", "MaxRecursionTestSDK"),
-    TestSDK("nulltolerance-test-sdk", "smithy.swift.tests.nullTolerance#NullToleranceService", "NullToleranceTestSDK"),
-    TestSDK("stringser-test-sdk", "smithy.swift.tests.stringSer#StringSerService", "StringSerTestSDK"),
-    TestSDK("waiters-test-sdk", "aws.protocoltests.waiters#Waiters", "WaitersTestSDK"),
+    TestSDK("AWSJSON"),
+    TestSDK("JSONName"),
+    TestSDK("MaxRecursion"),
+    TestSDK("NullTolerance"),
+    TestSDK("StringSerializer"),
+    TestSDK("Waiters"),
 )
 
 fun generateProjection(sdk: TestSDK): String {
     return """
-    "${sdk.projection}": {
+    "${sdk.name}": {
       "transforms": [
         {
           "name": "includeServices",
           "args": {
             "services": [
-              "${sdk.service}"
+              "smithy.swift.tests.${sdk.name}#${sdk.name}"
             ]
           }
         },
@@ -47,8 +47,8 @@ fun generateProjection(sdk: TestSDK): String {
       ],
       "plugins": {
         "swift-codegen": {
-          "service": "${sdk.service}",
-          "module": "${sdk.module}",
+          "service": "smithy.swift.tests.${sdk.name}#${sdk.name}",
+          "module": "${sdk.name}TestSDK",
           "moduleVersion": "0.0.1",
           "gitRepo": "https://github.com/smithy-lang/smithy-swift.git",
           "author": "Amazon Web Services",

--- a/test-sdks/build.gradle.kts
+++ b/test-sdks/build.gradle.kts
@@ -18,8 +18,11 @@ dependencies {
 data class TestSDK(val projection: String, val service: String, val module: String)
 
 val testSDKs = listOf(
-    TestSDK("rpcv2cbor-test-sdk", "smithy.swift.tests#RPCv2CBORService", "RPCv2CBORTestSDK"),
     TestSDK("awsjson-test-sdk", "smithy.swift.tests#AWSJSONService", "AWSJSONTestSDK"),
+    TestSDK("jsonname-test-sdk", "smithy.swift.tests.jsonName#JSONNameService", "JSONNameTestSDK"),
+    TestSDK("maxrecursion-test-sdk", "smithy.swift.tests.maxRecursion#MaxRecursionService", "MaxRecursionTestSDK"),
+    TestSDK("nulltolerance-test-sdk", "smithy.swift.tests.nullTolerance#NullToleranceService", "NullToleranceTestSDK"),
+    TestSDK("stringser-test-sdk", "smithy.swift.tests.stringSer#StringSerService", "StringSerTestSDK"),
     TestSDK("waiters-test-sdk", "aws.protocoltests.waiters#Waiters", "WaitersTestSDK"),
 )
 

--- a/test-sdks/model/awsjson.smithy
+++ b/test-sdks/model/awsjson.smithy
@@ -8,48 +8,8 @@ use aws.protocols#awsJson1_0
 service AWSJSONService {
     version: "2022-11-30"
     operations: [
-        JSONName
-        NullTolerance
         SerdeOperation
     ]
-}
-
-operation JSONName {
-    input: JSONNameInput
-    output: JSONNameOutput
-}
-
-structure JSONNameInput {
-    @jsonName("modified")
-    original: String
-}
-
-structure JSONNameOutput {
-    @jsonName("modified")
-    original: String
-}
-
-operation NullTolerance {
-    input: NullToleranceInput
-    output: NullToleranceOutput
-}
-
-structure NullToleranceInput {}
-
-structure NullToleranceOutput {
-    list: NullToleranceList
-    map: NullToleranceMap
-    sparseList: SparseNullToleranceList
-    sparseMap: SparseNullToleranceMap
-}
-
-list NullToleranceList {
-    member: Integer
-}
-
-map NullToleranceMap {
-    key: String
-    value: Integer
 }
 
 @sparse

--- a/test-sdks/model/awsjson.smithy
+++ b/test-sdks/model/awsjson.smithy
@@ -1,11 +1,11 @@
 $version: "2.0"
 
-namespace smithy.swift.tests
+namespace smithy.swift.tests.AWSJSON
 
 use aws.protocols#awsJson1_0
 
 @awsJson1_0
-service AWSJSONService {
+service AWSJSON {
     version: "2022-11-30"
     operations: [
         SerdeOperation

--- a/test-sdks/model/jsonname.smithy
+++ b/test-sdks/model/jsonname.smithy
@@ -1,0 +1,28 @@
+$version: "2.0"
+
+namespace smithy.swift.tests.jsonName
+
+use aws.protocols#awsJson1_0
+
+@awsJson1_0
+service JSONNameService {
+    version: "2022-11-30"
+    operations: [
+        JSONName
+    ]
+}
+
+operation JSONName {
+    input: JSONNameInput
+    output: JSONNameOutput
+}
+
+structure JSONNameInput {
+    @jsonName("modified")
+    original: String
+}
+
+structure JSONNameOutput {
+    @jsonName("modified")
+    original: String
+}

--- a/test-sdks/model/jsonname.smithy
+++ b/test-sdks/model/jsonname.smithy
@@ -1,28 +1,28 @@
 $version: "2.0"
 
-namespace smithy.swift.tests.jsonName
+namespace smithy.swift.tests.JSONName
 
 use aws.protocols#awsJson1_0
 
 @awsJson1_0
-service JSONNameService {
+service JSONName {
     version: "2022-11-30"
     operations: [
-        JSONName
+        JSONNameMembers
     ]
 }
 
-operation JSONName {
-    input: JSONNameInput
-    output: JSONNameOutput
+operation JSONNameMembers {
+    input: JSONNameMembersInput
+    output: JSONNameMembersOutput
 }
 
-structure JSONNameInput {
+structure JSONNameMembersInput {
     @jsonName("modified")
     original: String
 }
 
-structure JSONNameOutput {
+structure JSONNameMembersOutput {
     @jsonName("modified")
     original: String
 }

--- a/test-sdks/model/maxrecursion.smithy
+++ b/test-sdks/model/maxrecursion.smithy
@@ -1,11 +1,11 @@
 $version: "2.0"
 
-namespace smithy.swift.tests.maxRecursion
+namespace smithy.swift.tests.MaxRecursion
 
 use smithy.protocols#rpcv2Cbor
 
 @rpcv2Cbor
-service MaxRecursionService {
+service MaxRecursion {
     version: "2022-11-30"
     operations: [
         Recursive

--- a/test-sdks/model/maxrecursion.smithy
+++ b/test-sdks/model/maxrecursion.smithy
@@ -1,0 +1,33 @@
+$version: "2.0"
+
+namespace smithy.swift.tests.maxRecursion
+
+use smithy.protocols#rpcv2Cbor
+
+@rpcv2Cbor
+service MaxRecursionService {
+    version: "2022-11-30"
+    operations: [
+        Recursive
+    ]
+}
+
+operation Recursive {
+    input: RecursiveInputOutput
+    output: RecursiveInputOutput
+}
+
+structure RecursiveInputOutput {
+    nested: RecursiveInputOutput
+    nestedList: NestedList
+    nestedMap: NestedMap
+}
+
+list NestedList {
+    member: RecursiveInputOutput
+}
+
+map NestedMap {
+    key: String
+    value: RecursiveInputOutput
+}

--- a/test-sdks/model/nulltolerance.smithy
+++ b/test-sdks/model/nulltolerance.smithy
@@ -1,0 +1,47 @@
+$version: "2.0"
+
+namespace smithy.swift.tests.nullTolerance
+
+use aws.protocols#awsJson1_0
+
+@awsJson1_0
+service NullToleranceService {
+    version: "2022-11-30"
+    operations: [
+        NullTolerance
+    ]
+}
+
+operation NullTolerance {
+    input: NullToleranceInput
+    output: NullToleranceOutput
+}
+
+structure NullToleranceInput {}
+
+structure NullToleranceOutput {
+    list: NullToleranceList
+    map: NullToleranceMap
+    sparseList: SparseNullToleranceList
+    sparseMap: SparseNullToleranceMap
+}
+
+list NullToleranceList {
+    member: Integer
+}
+
+map NullToleranceMap {
+    key: String
+    value: Integer
+}
+
+@sparse
+list SparseNullToleranceList {
+    member: Integer
+}
+
+@sparse
+map SparseNullToleranceMap {
+    key: String
+    value: Integer
+}

--- a/test-sdks/model/nulltolerance.smithy
+++ b/test-sdks/model/nulltolerance.smithy
@@ -1,25 +1,25 @@
 $version: "2.0"
 
-namespace smithy.swift.tests.nullTolerance
+namespace smithy.swift.tests.NullTolerance
 
 use aws.protocols#awsJson1_0
 
 @awsJson1_0
-service NullToleranceService {
+service NullTolerance {
     version: "2022-11-30"
     operations: [
-        NullTolerance
+        NullToleranceTest
     ]
 }
 
-operation NullTolerance {
-    input: NullToleranceInput
-    output: NullToleranceOutput
+operation NullToleranceTest {
+    input: NullToleranceTestInput
+    output: NullToleranceTestOutput
 }
 
-structure NullToleranceInput {}
+structure NullToleranceTestInput {}
 
-structure NullToleranceOutput {
+structure NullToleranceTestOutput {
     list: NullToleranceList
     map: NullToleranceMap
     sparseList: SparseNullToleranceList

--- a/test-sdks/model/stringser.smithy
+++ b/test-sdks/model/stringser.smithy
@@ -1,11 +1,11 @@
 $version: "2.0"
 
-namespace smithy.swift.tests.stringSer
+namespace smithy.swift.tests.StringSerializer
 
 use smithy.protocols#rpcv2Cbor
 
 @rpcv2Cbor
-service StringSerService {
+service StringSerializer {
     version: "2022-11-30"
     operations: [
         GetWidget

--- a/test-sdks/model/stringser.smithy
+++ b/test-sdks/model/stringser.smithy
@@ -1,15 +1,14 @@
 $version: "2.0"
 
-namespace smithy.swift.tests
+namespace smithy.swift.tests.stringSer
 
 use smithy.protocols#rpcv2Cbor
 
 @rpcv2Cbor
-service RPCv2CBORService {
+service StringSerService {
     version: "2022-11-30"
     operations: [
         GetWidget
-        Recursive
     ]
 }
 
@@ -56,24 +55,4 @@ list PrivateList {
 map PrivateMap {
     key: String
     value: PrivateString
-}
-
-operation Recursive {
-    input: RecursiveInputOutput
-    output: RecursiveInputOutput
-}
-
-structure RecursiveInputOutput {
-    nested: RecursiveInputOutput
-    nestedList: NestedList
-    nestedMap: NestedMap
-}
-
-list NestedList {
-    member: RecursiveInputOutput
-}
-
-map NestedMap {
-    key: String
-    value: RecursiveInputOutput
 }

--- a/test-sdks/model/waiters.smithy
+++ b/test-sdks/model/waiters.smithy
@@ -1,8 +1,7 @@
 $version: "2.0"
 
-namespace aws.protocoltests.waiters
+namespace smithy.swift.tests.Waiters
 
-use aws.api#service
 use aws.protocols#restJson1
 use smithy.waiters#waitable
 
@@ -10,7 +9,6 @@ use smithy.waiters#waitable
 // The acceptor in each waiter serves as subject for unit testing,
 // to ensure that the logic in code-generated acceptors works as
 // expected.
-@service(sdkId: "Waiters")
 @restJson1
 service Waiters {
     version: "2022-11-30"


### PR DESCRIPTION
## Description of changes
- Splits test SDKs into single-purpose units
- Simplifies test SDK configuration down to a single name in Smithy, Gradle and Swift

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.