### PR TITLE
perf: Serialize JSON to UInt8 array instead of Data

### DIFF
--- a/Sources/SmithyJSON/Serializer.swift
+++ b/Sources/SmithyJSON/Serializer.swift
@@ -57,13 +57,14 @@ public final class Serializer: ShapeSerializer {
     private static let negativeInfinity = "\"-Infinity\"".utf8
 
     let usesJSONNameTrait: Bool
-    private var _data: Data
+    private var _data: [UInt8]
     private var _needsComma = false
 
     public init(usesJSONNameTrait: Bool) {
         self.usesJSONNameTrait = usesJSONNameTrait
         // 64KB is reserved to allow for additions to data without requiring copy to a new buffer
-        self._data = Data(capacity: 65536)
+        self._data = [UInt8]()
+        self._data.reserveCapacity(65536)
     }
 
     public func writeStruct<S>(_ schema: Schema, _ value: S) throws where S: SerializableStruct {
@@ -263,7 +264,7 @@ public final class Serializer: ShapeSerializer {
         get throws {
             // Return the encoded data, substituting '{}' if empty
             guard !_data.isEmpty else { return Data("{}".utf8) }
-            return _data
+            return Data(_data)
         }
     }
 


### PR DESCRIPTION
## Description of changes
Changes internal storage on the JSON serializer from `Data` to `[UInt8]` (an array of bytes).

It turns out that this form of storage is mostly API-compatible with `Data` and has FAR less overhead when appending to it.  As a result, performance in serde benchmarks is 1.5-4X (!) as fast.

Type remains API compatible by converting to `Data` only when read.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.