### PR TITLE
perf: HTTP `Headers` performance improvements & tests

### DIFF
--- a/Sources/SmithyHTTPAPI/Headers.swift
+++ b/Sources/SmithyHTTPAPI/Headers.swift
@@ -5,28 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Foundation.NSRecursiveLock
+public struct Headers: Sendable {
 
-public struct Headers: @unchecked Sendable {
-    private let lock = NSRecursiveLock()
-
-    private var _headers: [Header] = []
-    public var headers: [Header] {
-        get { access { $0 } }
-        set { mutate { $0 = newValue } }
-    }
-
-    private mutating func mutate(_ block: (inout [Header]) -> Void) {
-        lock.lock()
-        defer { lock.unlock() }
-        block(&_headers)
-    }
-
-    private func access<T>(_ block: ([Header]) throws -> T) rethrows -> T {
-        lock.lock()
-        defer { lock.unlock() }
-        return try block(_headers)
-    }
+    public var headers: [Header] = []
 
     /// Creates an empty instance.
     public init() {}
@@ -73,13 +54,11 @@ public struct Headers: @unchecked Sendable {
     /// - Parameters:
     ///   - header:  The `Header` to be added or updated.
     public mutating func add(_ header: Header) {
-        mutate { headers in
-            guard let index = headers.index(of: header.name) else {
-                headers.append(header)
-                return
-            }
-            headers[index].value.append(contentsOf: header.value)
+        guard let index = headers.index(of: header.name) else {
+            headers.append(header)
+            return
         }
+        headers[index].value.append(contentsOf: header.value)
     }
 
     /// Case-insensitively updates the value of a `Header` by replacing the values of it or appends a `Header`
@@ -88,13 +67,11 @@ public struct Headers: @unchecked Sendable {
     /// - Parameters:
     ///   - header:  The `Header` to be added or updated.
     public mutating func update(_ header: Header) {
-        mutate { headers in
-            guard let index = headers.index(of: header.name) else {
-                headers.append(header)
-                return
-            }
-            headers.replaceSubrange(index...index, with: [header])
+        guard let index = headers.index(of: header.name) else {
+            headers.append(header)
+            return
         }
+        headers.replaceSubrange(index...index, with: [header])
     }
 
     /// Case-insensitively updates the value of a `Header` by replacing the values of it or appends a `Header`
@@ -122,19 +99,15 @@ public struct Headers: @unchecked Sendable {
     /// - Parameters:
     ///   - headers:  The `Headers` object.
     public mutating func addAll(headers otherHeaders: Headers) {
-        mutate { headers in
-            headers.append(contentsOf: otherHeaders.headers)
-        }
+        headers.append(contentsOf: otherHeaders.headers)
     }
 
     /// Case-insensitively removes a `Header`, if it exists, from the instance.
     ///
     /// - Parameter name: The name of the `HTTPHeader` to remove.
     public mutating func remove(name: String) {
-        mutate { headers in
-            guard let index = headers.index(of: name) else { return }
-            headers.remove(at: index)
-        }
+        guard let index = headers.index(of: name) else { return }
+        headers.remove(at: index)
     }
 
     /// Case-insensitively find a header's values by name.
@@ -143,14 +116,17 @@ public struct Headers: @unchecked Sendable {
     ///
     /// - Returns: The values of the header, if they exist.
     public func values(for name: String) -> [String]? {
-        access { headers in
-            guard let indices = headers.indices(of: name), !indices.isEmpty else { return nil }
-            var values = [String]()
-            for index in indices {
-                values.append(contentsOf: headers[index].value)
+        var values: [String]?
+        for header in headers where header.name.isCaseInsensitivelyEqual(to: name) {
+            if values == nil {
+                // A name almost always matches a single header, whose values are then returned
+                // as-is rather than copied into a fresh array.
+                values = header.value
+            } else {
+                values?.append(contentsOf: header.value)
             }
-            return values
         }
+        return values
     }
 
     /// Case-insensitively find a header's value by name.
@@ -164,23 +140,21 @@ public struct Headers: @unchecked Sendable {
     }
 
     public func exists(name: String) -> Bool {
-        access { $0.index(of: name) != nil }
+        headers.index(of: name) != nil
     }
 
     /// The dictionary representation of all headers.
     ///
     /// This representation does not preserve the current order of the instance.
     public var dictionary: [String: [String]] {
-        access { headers in
-            let namesAndValues = headers.map { ($0.name, $0.value) }
-            return Dictionary(namesAndValues) { (first, last) -> [String] in
-                first + last
-            }
+        let namesAndValues = headers.map { ($0.name, $0.value) }
+        return Dictionary(namesAndValues) { (first, last) -> [String] in
+            first + last
         }
     }
 
     public var isEmpty: Bool {
-        access { $0.isEmpty }
+        headers.isEmpty
     }
 }
 
@@ -191,8 +165,8 @@ extension Headers: Equatable {
     ///   - rhs: The second `Headers` to compare.
     /// - Returns: `true` if the two values are equal irrespective of order, otherwise `false`.
     public static func == (lhs: Headers, rhs: Headers) -> Bool {
-        let lhsHeaders = lhs.access { $0 }.sorted()
-        let rhsHeaders = rhs.access { $0 }.sorted()
+        let lhsHeaders = lhs.headers.sorted()
+        let rhsHeaders = rhs.headers.sorted()
         return lhsHeaders == rhsHeaders
     }
 }
@@ -200,21 +174,60 @@ extension Headers: Equatable {
 extension Headers: Hashable {
 
     public func hash(into hasher: inout Hasher) {
-        access { hasher.combine($0.sorted()) }
+        hasher.combine(headers.sorted())
     }
 }
 
 extension Array where Element == Header {
     /// Case-insensitively finds the index of an `Header` with the provided name, if it exists.
     func index(of name: String) -> Int? {
-        let lowercasedName = name.lowercased()
-        return firstIndex { $0.name.lowercased() == lowercasedName }
+        firstIndex { $0.name.isCaseInsensitivelyEqual(to: name) }
+    }
+}
+
+extension String {
+
+    /// Whether this string and `other` are equal, ignoring case.
+    ///
+    /// An HTTP field name is a token, and so is ASCII, by specification:
+    /// https://www.rfc-editor.org/rfc/rfc9110#section-5.1
+    /// Equality is therefore decided by comparing UTF-8 bytes with ASCII case folding, which unlike
+    /// `lowercased()` allocates nothing.  ASCII case folding also preserves length, so names of
+    /// different lengths are rejected without comparing them at all.
+    ///
+    /// Header names are compared once per stored header on every lookup, so this is on the hot path
+    /// for both request serialization and response deserialization.
+    func isCaseInsensitivelyEqual(to other: String) -> Bool {
+        let lhs = self.utf8
+        let rhs = other.utf8
+        guard lhs.count == rhs.count else { return false }
+        var lhsIterator = lhs.makeIterator()
+        var rhsIterator = rhs.makeIterator()
+        while let lhsByte = lhsIterator.next(), let rhsByte = rhsIterator.next() {
+            guard lhsByte.asciiLowercased == rhsByte.asciiLowercased else { return false }
+        }
+        return true
     }
 
-    /// Case-insensitively finds the indexes of an `Header` with the provided name, if it exists.
-    func indices(of name: String) -> [Int]? {
-        let lowercasedName = name.lowercased()
-        return enumerated().compactMap { $0.element.name.lowercased() == lowercasedName ? $0.offset : nil }
+    /// Whether this string begins with `prefix`, ignoring case.
+    ///
+    /// Folds ASCII case over UTF-8 bytes for the same reasons as ``isCaseInsensitivelyEqual(to:)``.
+    func hasCaseInsensitivePrefix(_ prefix: String) -> Bool {
+        var iterator = self.utf8.makeIterator()
+        for prefixByte in prefix.utf8 {
+            guard let byte = iterator.next() else { return false } // This string is the shorter one.
+            guard byte.asciiLowercased == prefixByte.asciiLowercased else { return false }
+        }
+        return true
+    }
+}
+
+extension UInt8 {
+
+    /// This byte, lowercased if it is an uppercase ASCII letter and unchanged otherwise.
+    @inline(__always)
+    var asciiLowercased: UInt8 {
+        (UInt8(ascii: "A")...UInt8(ascii: "Z")).contains(self) ? self | 0x20 : self
     }
 }
 

--- a/Sources/SmithyHTTPAPI/Headers.swift
+++ b/Sources/SmithyHTTPAPI/Headers.swift
@@ -208,18 +208,6 @@ extension String {
         }
         return true
     }
-
-    /// Whether this string begins with `prefix`, ignoring case.
-    ///
-    /// Folds ASCII case over UTF-8 bytes for the same reasons as ``isCaseInsensitivelyEqual(to:)``.
-    func hasCaseInsensitivePrefix(_ prefix: String) -> Bool {
-        var iterator = self.utf8.makeIterator()
-        for prefixByte in prefix.utf8 {
-            guard let byte = iterator.next() else { return false } // This string is the shorter one.
-            guard byte.asciiLowercased == prefixByte.asciiLowercased else { return false }
-        }
-        return true
-    }
 }
 
 extension UInt8 {

--- a/test-sdks/Tests/SmithyHTTPAPITests/HeadersMatchingTests.swift
+++ b/test-sdks/Tests/SmithyHTTPAPITests/HeadersMatchingTests.swift
@@ -1,0 +1,119 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import SmithyHTTPAPI
+import XCTest
+
+/// Covers case-insensitive matching of header names, and lookup of names that are
+/// stored more than once.
+class HeadersMatchingTests: XCTestCase {
+
+    // MARK: - values(for:) with repeated names
+    //
+    // `add` merges into an existing header, so duplicate case-insensitive names can only
+    // arise from `addAll` — which is exactly what CRTClientEngine does when it folds
+    // interim, main, and trailer headers into one response.
+
+    func test_values_aggregatesAcrossHeadersRepeatedInDifferentCase() {
+        var subject = Headers(["X-Foo": "1"])
+        subject.addAll(headers: Headers(["x-foo": "2"]))
+        subject.addAll(headers: Headers(["X-FOO": "3"]))
+
+        XCTAssertEqual(subject.headers.count, 3)  // addAll appends without merging
+        XCTAssertEqual(subject.values(for: "x-FoO"), ["1", "2", "3"])
+        XCTAssertEqual(subject.value(for: "x-FoO"), "1,2,3")
+    }
+
+    func test_values_preservesInsertionOrderAcrossRepeatedNames() {
+        var subject = Headers(["a": "z"])
+        var other = Headers()
+        other.add(name: "A", values: ["y", "x"])
+        subject.addAll(headers: other)
+
+        XCTAssertEqual(subject.values(for: "a"), ["z", "y", "x"])
+    }
+
+    func test_values_aggregatesWhenFirstMatchHasNoValues() {
+        var subject = Headers(["a": []])
+        var other = Headers()
+        other.add(name: "A", value: "x")
+        subject.addAll(headers: other)
+
+        XCTAssertEqual(subject.values(for: "a"), ["x"])
+    }
+
+    func test_values_nilWhenNoHeaderMatches() {
+        XCTAssertNil(Headers(["a": "x"]).values(for: "b"))
+        XCTAssertNil(Headers().values(for: "a"))
+    }
+
+    // MARK: - Case-insensitive name matching
+
+    func test_nameMatching_matchesRegardlessOfCase() {
+        let subject = Headers(["Content-Type": "application/json"])
+        for name in ["content-type", "CONTENT-TYPE", "Content-Type", "cOnTeNt-TyPe"] {
+            XCTAssertTrue(subject.exists(name: name), "expected \(name) to match")
+            XCTAssertEqual(subject.value(for: name), "application/json")
+        }
+    }
+
+    func test_nameMatching_rejectsNamesOfDifferentLength() {
+        let subject = Headers(["a": "x"])
+        XCTAssertFalse(subject.exists(name: ""))
+        XCTAssertFalse(subject.exists(name: "ab"))
+        XCTAssertFalse(subject.exists(name: "a "))
+    }
+
+    func test_nameMatching_doesNotFoldNonAlphabeticAsciiThatDiffersByTheCaseBit() {
+        // '_' (0x5F) and DEL (0x7F) differ only in bit 0x20, as do '[' (0x5B) and '{' (0x7B).
+        // A fold that blindly ORs 0x20 would conflate them.
+        let subject = Headers(["a_b": "x"])
+        XCTAssertTrue(subject.exists(name: "A_B"))
+        XCTAssertFalse(subject.exists(name: "a\u{7F}b"))
+
+        let bracket = Headers(["a[b": "x"])
+        XCTAssertFalse(bracket.exists(name: "a{b"))
+    }
+
+    func test_nameMatching_multiByteNameIsMatchedByteForByte() {
+        // Field names are ASCII tokens per RFC 9110, so a non-ASCII name matches only itself.
+        let subject = Headers(["x-café": "x"])
+        XCTAssertTrue(subject.exists(name: "X-café"))
+        XCTAssertFalse(subject.exists(name: "x-cafÉ"))
+    }
+
+    // MARK: - Mutations route through the same matching
+
+    func test_add_mergesIntoExistingHeaderFoundInDifferentCase() {
+        var subject = Headers(["X-Foo": "1"])
+        subject.add(name: "x-foo", value: "2")
+
+        XCTAssertEqual(subject.headers.count, 1)
+        XCTAssertEqual(subject.headers[0].name, "X-Foo")  // original casing is kept
+        XCTAssertEqual(subject.values(for: "X-Foo"), ["1", "2"])
+    }
+
+    func test_update_replacesHeaderFoundInDifferentCaseAndAdoptsTheNewName() {
+        var subject = Headers(["X-Foo": "1"])
+        subject.update(name: "x-foo", value: "2")
+
+        XCTAssertEqual(subject.headers.count, 1)
+        XCTAssertEqual(subject.headers[0].name, "x-foo")
+        XCTAssertEqual(subject.values(for: "X-FOO"), ["2"])
+    }
+
+    func test_remove_removesOnlyTheFirstMatchWhenNameIsRepeated() {
+        var subject = Headers(["X-Foo": "1"])
+        var other = Headers()
+        other.add(name: "x-foo", value: "2")
+        subject.addAll(headers: other)
+
+        subject.remove(name: "X-FOO")
+
+        XCTAssertEqual(subject.values(for: "x-foo"), ["2"])
+    }
+}


### PR DESCRIPTION
## Description of changes
Two performance improvements in the `Headers` type, plus tests.
- Removes internal locking from the `Headers` type.  Locking causes additional overhead when accessing headers, damaging performance.  The locking on `Headers` is unnecessary because:
  - `Headers` is a Swift value type, with value semantics, so it is copied across concurrency zones, not carried as a reference.
  - There is one place where `Headers` may be modified from multiple threads because it is a property of a reference-type `HTTPResponse` (in the CRT HTTP client), but that access is already made exclusive by a lock on `HTTPResponse`, rendering the lock on `Headers` superfluous.
- The case-insensitive compare code has been improved by comparing strings in-place, avoiding the extra allocations from calling `.downcased()` on each string before comparison.
- Tests have been added for existing behavior of `Headers`.

This change increases performance measurably on any protocol / request where many headers are used.  As much as 3x performance increase has been seen on REST-type requests with numerous headers.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.