### PR TITLE
chore: Upgrade Kotlin 1.9.24 to 2.4.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ smithyVersion=1.73.0
 smithyGradleVersion=1.4.0
 
 # kotlin
-kotlinVersion=1.9.24
-dokkaVersion=1.9.20
+kotlinVersion=2.4.10
+dokkaVersion=2.2.0
 kotlin.native.ignoreDisabledTargets=true
 
 # kotlin libraries

--- a/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareExecutionGenerator.kt
+++ b/smithy-swift-codegen/src/main/kotlin/software/amazon/smithy/swift/codegen/middleware/MiddlewareExecutionGenerator.kt
@@ -159,7 +159,7 @@ class MiddlewareExecutionGenerator(
             it(op)
         } ?: run {
             val httpTrait = httpBindingResolver.httpTrait(op)
-            httpTrait.method.toLowerCase()
+            httpTrait.method.lowercase()
         }
 
     private fun renderMiddlewares(


### PR DESCRIPTION
## Description of changes
Gradle was upgraded to 9.1.0 in #1093, but kotlinVersion was left at 1.9.24. KGP 1.9.x is only supported on Gradle 8.x and below; Gradle 9.1 requires KGP 2.3.20 or newer. The unsupported pairing caused intermittent CI failures when aws-sdk-swift builds smithy-swift as an included build:

    Could not determine the dependencies of task
    ':smithy-swift:smithy-swift-codegen:compileKotlin'.
    > Could not create task
      ':smithy-swift:smithy-swift-codegen:checkKotlinGradlePluginConfigurationErrors'.
       > DefaultTaskCollection#configureEach(Action) on task set cannot be
         executed in the current context.

KGP 1.9.24 registers that task via configureEach at a point Gradle 9 no longer allows the task container to be mutated. Standalone builds do not hit it; only the composite-build dependency substitution path does.

Moves to KGP 2.4.10 (supported window: Gradle 7.6.3 - 9.5.0) and Dokka 2.2.0, which is required for Kotlin 2.x. Gradle stays at 9.1.0.

String.toLowerCase() is raised from warning to error in Kotlin 2.x, so the one usage is replaced with lowercase(). Both are locale-independent for the ASCII HTTP method names involved.

Must land together with the matching aws-sdk-swift branch.

## Scope
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.